### PR TITLE
Move workspace tab actions into pane content

### DIFF
--- a/src/features/dashboard/MemoryList.tsx
+++ b/src/features/dashboard/MemoryList.tsx
@@ -5,7 +5,7 @@
  * add new memories, edit sections inline, and delete via the OpenClaw gateway.
  */
 
-import { useState, useMemo, useCallback, useRef, useEffect, type ReactNode } from 'react';
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { Plus, RefreshCw, AlertCircle, CheckCircle } from 'lucide-react';
 import { MemoryItem, AddMemoryDialog, ConfirmDeleteDialog, MemoryEditor, useMemories } from '@/features/memory';
 import { MemorySkeletonGroup } from '@/components/skeletons';
@@ -16,12 +16,10 @@ interface MemoryListProps {
   onRefresh: (signal?: AbortSignal) => void | Promise<void>;
   isLoading?: boolean;
   hideHeader?: boolean;
-  /** When set, action buttons are passed to parent instead of rendered inline */
-  onActions?: (actions: ReactNode) => void;
 }
 
 /** Searchable, editable list of agent memories with add/delete support. */
-export function MemoryList({ memories: initialMemories, onRefresh, isLoading: initialLoading, hideHeader, onActions }: MemoryListProps) {
+export function MemoryList({ memories: initialMemories, onRefresh, isLoading: initialLoading, hideHeader }: MemoryListProps) {
   // useMemories provides optimistic state that reflects pending operations
   const { memories, addMemory, deleteMemory, error, clearError, isLoading } = useMemories(initialMemories);
   
@@ -161,12 +159,6 @@ export function MemoryList({ memories: initialMemories, onRefresh, isLoading: in
     setMemoryToDelete(null);
   }, [memoryToDelete, deleteMemory, showFeedback, onRefresh]);
 
-  // Handle refresh with loading state
-  const handleRefresh = useCallback(() => {
-    clearError();
-    onRefresh();
-  }, [clearError, onRefresh]);
-
   // Handle edit click - opens the editor
   const handleEditClick = useCallback((text: string, type: Memory['type'], date?: string) => {
     if (type === 'section' || type === 'daily') {
@@ -186,31 +178,7 @@ export function MemoryList({ memories: initialMemories, onRefresh, isLoading: in
     setEditingMemory(null);
   }, []);
 
-  // Register action buttons with parent (for tab bar rendering)
   const openAddDialog = useCallback(() => setAddDialogOpen(true), []);
-  useEffect(() => {
-    onActions?.(
-      <>
-        <button
-          onClick={openAddDialog}
-          className="bg-transparent border border-border/60 text-muted-foreground text-sm w-6 h-6 cursor-pointer flex items-center justify-center hover:text-purple hover:border-purple transition-colors focus-visible:ring-2 focus-visible:ring-purple/50 focus-visible:ring-offset-0"
-          title="Add memory"
-          aria-label="Add new memory"
-        >
-          <Plus size={12} aria-hidden="true" />
-        </button>
-        <button
-          onClick={handleRefresh}
-          disabled={isLoading}
-          className="bg-transparent border border-border/60 text-muted-foreground text-sm w-6 h-6 cursor-pointer flex items-center justify-center hover:text-foreground hover:border-muted-foreground disabled:opacity-50 transition-colors focus-visible:ring-2 focus-visible:ring-purple/50 focus-visible:ring-offset-0"
-          title="Refresh memories"
-          aria-label="Refresh memories"
-        >
-          <RefreshCw size={10} className={isLoading ? 'animate-spin' : ''} aria-hidden="true" />
-        </button>
-      </>
-    );
-  }, [isLoading, openAddDialog, handleRefresh, onActions]);
 
   // If editing, show the editor instead of the list
   if (editingMemory) {
@@ -226,34 +194,13 @@ export function MemoryList({ memories: initialMemories, onRefresh, isLoading: in
 
   return (
     <div className="h-full flex flex-col min-h-0">
-      {/* Header with actions — only when not lifted to tab bar */}
-      {!onActions && (
-        <div className={hideHeader ? "flex items-center gap-1 px-2 py-1 border-b border-border/40" : "panel-header border-l-[3px] border-l-purple"}>
-          {!hideHeader && (
-            <span className="panel-label text-purple">
-              <span className="panel-diamond">◆</span>
-              MEMORY
-            </span>
-          )}
-          <div className="flex items-center gap-1 ml-auto">
-            <button
-              onClick={openAddDialog}
-              className="bg-transparent border border-border/60 text-muted-foreground text-sm w-7 h-7 cursor-pointer flex items-center justify-center hover:text-purple hover:border-purple transition-colors focus-visible:ring-2 focus-visible:ring-purple/50 focus-visible:ring-offset-0"
-              title="Add memory"
-              aria-label="Add new memory"
-            >
-              <Plus size={14} aria-hidden="true" />
-            </button>
-            <button
-              onClick={handleRefresh}
-              disabled={isLoading}
-              className="bg-transparent border border-border/60 text-muted-foreground text-sm w-7 h-7 cursor-pointer flex items-center justify-center hover:text-foreground hover:border-muted-foreground disabled:opacity-50 transition-colors focus-visible:ring-2 focus-visible:ring-purple/50 focus-visible:ring-offset-0"
-              title="Refresh memories"
-              aria-label="Refresh memories"
-            >
-              <RefreshCw size={12} className={isLoading ? 'animate-spin' : ''} aria-hidden="true" />
-            </button>
-          </div>
+      {/* Header — only when used standalone (not in workspace tabs) */}
+      {!hideHeader && (
+        <div className="panel-header border-l-[3px] border-l-purple">
+          <span className="panel-label text-purple">
+            <span className="panel-diamond">◆</span>
+            MEMORY
+          </span>
         </div>
       )}
 
@@ -307,7 +254,31 @@ export function MemoryList({ memories: initialMemories, onRefresh, isLoading: in
             </button>
           </div>
         ) : (
-          visibleMemories.map((m, i) => (
+          <>
+          <div className="flex items-center border-b border-border/40">
+            <button
+              onClick={openAddDialog}
+              className="group flex items-center gap-2 px-3 py-1.5 text-[11px] hover:bg-foreground/[0.02] transition-colors cursor-pointer flex-1 bg-transparent border-0 text-left focus-visible:ring-2 focus-visible:ring-purple/50 focus-visible:ring-offset-0"
+              aria-label="Add new memory"
+            >
+              <span className="shrink-0 text-muted-foreground group-hover:text-purple transition-colors">
+                <Plus size={12} />
+              </span>
+              <span className="text-muted-foreground group-hover:text-purple transition-colors">
+                Add memory
+              </span>
+            </button>
+            <button
+              onClick={() => { clearError(); onRefresh(); }}
+              disabled={isLoading}
+              className="shrink-0 px-2 py-1.5 bg-transparent border-0 text-muted-foreground hover:text-foreground disabled:opacity-50 transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-purple/50 focus-visible:ring-offset-0"
+              title="Refresh memories"
+              aria-label="Refresh memories"
+            >
+              <RefreshCw size={10} className={isLoading ? 'animate-spin' : ''} />
+            </button>
+          </div>
+          {visibleMemories.map((m, i) => (
             <MemoryItem
               key={m.tempId || `${m.type}-${m.text.slice(0, 20)}-${i}`}
               memory={m}
@@ -319,7 +290,8 @@ export function MemoryList({ memories: initialMemories, onRefresh, isLoading: in
                 itemCount: sectionItemCounts[m.text] || 0,
               } : {})}
             />
-          ))
+          ))}
+          </>
         )}
       </div>
 

--- a/src/features/workspace/WorkspacePanel.tsx
+++ b/src/features/workspace/WorkspacePanel.tsx
@@ -5,7 +5,7 @@
  * Tab action buttons (add, refresh) render in the tab bar header.
  */
 
-import { useState, useCallback, type ReactNode } from 'react';
+import { useState, useCallback } from 'react';
 import { WorkspaceTabs, type TabId } from './WorkspaceTabs';
 import { MemoryTab, CronsTab, ConfigTab, SkillsTab } from './tabs';
 import { useCrons } from './hooks/useCrons';
@@ -35,18 +35,6 @@ export function WorkspacePanel({ memories, onRefreshMemories, memoriesLoading }:
 
   const [visitedTabs, setVisitedTabs] = useState<Set<TabId>>(() => new Set([activeTab]));
 
-  // Per-tab action buttons rendered in the tab bar
-  const [tabActions, setTabActions] = useState<Partial<Record<TabId, ReactNode>>>({});
-  const registerMemoryActions = useCallback((actions: ReactNode) => {
-    setTabActions(prev => ({ ...prev, memory: actions }));
-  }, []);
-  const registerCronsActions = useCallback((actions: ReactNode) => {
-    setTabActions(prev => ({ ...prev, crons: actions }));
-  }, []);
-  const registerSkillsActions = useCallback((actions: ReactNode) => {
-    setTabActions(prev => ({ ...prev, skills: actions }));
-  }, []);
-
   const handleTabChange = useCallback((tab: TabId) => {
     setActiveTab(tab);
     setVisitedTabs(prev => {
@@ -66,7 +54,6 @@ export function WorkspacePanel({ memories, onRefreshMemories, memoriesLoading }:
         activeTab={activeTab}
         onTabChange={handleTabChange}
         cronCount={activeCount || undefined}
-        actions={tabActions[activeTab]}
       />
       <div className="flex-1 min-h-0 overflow-hidden">
         <div className={activeTab === 'memory' ? 'h-full' : 'hidden'} hidden={activeTab !== 'memory'} role="tabpanel" id="workspace-tabpanel-memory" aria-labelledby="workspace-tab-memory">
@@ -75,18 +62,17 @@ export function WorkspacePanel({ memories, onRefreshMemories, memoriesLoading }:
               memories={memories}
               onRefresh={onRefreshMemories}
               isLoading={memoriesLoading}
-              onActions={registerMemoryActions}
             />
           )}
         </div>
         <div className={activeTab === 'crons' ? 'h-full' : 'hidden'} hidden={activeTab !== 'crons'} role="tabpanel" id="workspace-tabpanel-crons" aria-labelledby="workspace-tab-crons">
           {visitedTabs.has('crons') && (
-            <CronsTab onActions={registerCronsActions} />
+            <CronsTab />
           )}
         </div>
         <div className={activeTab === 'skills' ? 'h-full' : 'hidden'} hidden={activeTab !== 'skills'} role="tabpanel" id="workspace-tabpanel-skills" aria-labelledby="workspace-tab-skills">
           {visitedTabs.has('skills') && (
-            <SkillsTab onActions={registerSkillsActions} />
+            <SkillsTab />
           )}
         </div>
         <div className={activeTab === 'config' ? 'h-full' : 'hidden'} hidden={activeTab !== 'config'} role="tabpanel" id="workspace-tabpanel-config" aria-labelledby="workspace-tab-config">

--- a/src/features/workspace/WorkspaceTabs.tsx
+++ b/src/features/workspace/WorkspaceTabs.tsx
@@ -25,12 +25,10 @@ interface WorkspaceTabsProps {
   activeTab: TabId;
   onTabChange: (tab: TabId) => void;
   cronCount?: number;
-  /** Action buttons rendered right-aligned in the tab bar */
-  actions?: React.ReactNode;
 }
 
 /** Horizontal tab bar for workspace sections (Memory, Crons, Skills, Config). */
-export function WorkspaceTabs({ activeTab, onTabChange, cronCount, actions }: WorkspaceTabsProps) {
+export function WorkspaceTabs({ activeTab, onTabChange, cronCount }: WorkspaceTabsProps) {
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     const currentIndex = TABS.findIndex(t => t.id === activeTab);
     if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
@@ -83,11 +81,6 @@ export function WorkspaceTabs({ activeTab, onTabChange, cronCount, actions }: Wo
         );
       })}
       </div>
-      {actions && (
-        <div className="flex items-center gap-1 ml-auto flex-shrink-0">
-          {actions}
-        </div>
-      )}
     </div>
   );
 }

--- a/src/features/workspace/tabs/ConfigTab.tsx
+++ b/src/features/workspace/tabs/ConfigTab.tsx
@@ -88,8 +88,8 @@ export function ConfigTab() {
 
   return (
     <div className="h-full flex flex-col min-h-0">
-      <div className="flex items-center gap-1 px-2 py-1 border-b border-border/40">
-        <div className="flex items-center gap-1 ml-auto">
+      <div className="flex items-center border-b border-border/40">
+        <div className="flex-1 px-2 py-1">
           <InlineSelect
             value={selectedKey}
             onChange={(v) => {
@@ -103,16 +103,16 @@ export function ConfigTab() {
             options={FILE_OPTIONS.map(f => ({ value: f.key, label: f.label }))}
             ariaLabel="Select config file"
           />
-          <button
-            onClick={() => load(selectedKey)}
-            disabled={isLoading}
-            className="bg-transparent border border-border/60 text-muted-foreground text-sm w-7 h-7 cursor-pointer flex items-center justify-center hover:text-foreground hover:border-muted-foreground disabled:opacity-50 transition-colors focus-visible:ring-2 focus-visible:ring-purple/50 focus-visible:ring-offset-0"
-            title="Refresh"
-            aria-label="Refresh file"
-          >
-            <RefreshCw size={12} className={isLoading ? 'animate-spin' : ''} />
-          </button>
         </div>
+        <button
+          onClick={() => load(selectedKey)}
+          disabled={isLoading}
+          className="shrink-0 px-2 py-1.5 bg-transparent border-0 text-muted-foreground hover:text-foreground disabled:opacity-50 transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-purple/50 focus-visible:ring-offset-0"
+          title="Refresh"
+          aria-label="Refresh file"
+        >
+          <RefreshCw size={10} className={isLoading ? 'animate-spin' : ''} />
+        </button>
       </div>
 
       {/* Feedback toast */}

--- a/src/features/workspace/tabs/CronsTab.tsx
+++ b/src/features/workspace/tabs/CronsTab.tsx
@@ -2,7 +2,7 @@
  * CronsTab — Visual cron job management.
  */
 
-import { useEffect, useState, useCallback, useRef, type ReactNode } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { RefreshCw, Play, Plus, Trash2, Pencil, ChevronDown, ChevronRight, CheckCircle, XCircle, Circle, Loader2 } from 'lucide-react';
 import { useCrons, type CronJob, type CronRun } from '../hooks/useCrons';
 import { CronDialog } from './CronDialog';
@@ -219,12 +219,8 @@ function CronRow({ job, onToggle, onRun, onDelete, onEdit, onFetchRuns }: {
   );
 }
 
-interface CronsTabProps {
-  onActions?: (actions: ReactNode) => void;
-}
-
 /** Workspace tab listing cron jobs with create/edit/delete/toggle controls. */
-export function CronsTab({ onActions }: CronsTabProps) {
+export function CronsTab() {
   const { jobs, isLoading, error, fetchJobs, toggleJob, runJob, fetchRuns, addJob, updateJob, deleteJob } = useCrons();
   const [dialogOpen, setDialogOpen] = useState(false);
   const [dialogMode, setDialogMode] = useState<'create' | 'edit'>('create');
@@ -249,31 +245,6 @@ export function CronsTab({ onActions }: CronsTabProps) {
     return addJob(jobData);
   }, [dialogMode, editingJob, addJob, updateJob]);
 
-  // Register action buttons with parent tab bar
-  useEffect(() => {
-    onActions?.(
-      <>
-        <button
-          onClick={handleAdd}
-          className="bg-transparent border border-border/60 text-muted-foreground text-sm w-6 h-6 cursor-pointer flex items-center justify-center hover:text-purple hover:border-purple transition-colors focus-visible:ring-2 focus-visible:ring-purple/50 focus-visible:ring-offset-0"
-          title="Add cron job"
-          aria-label="Add cron job"
-        >
-          <Plus size={12} />
-        </button>
-        <button
-          onClick={fetchJobs}
-          disabled={isLoading}
-          className="bg-transparent border border-border/60 text-muted-foreground text-sm w-6 h-6 cursor-pointer flex items-center justify-center hover:text-foreground hover:border-muted-foreground disabled:opacity-50 transition-colors focus-visible:ring-2 focus-visible:ring-purple/50 focus-visible:ring-offset-0"
-          title="Refresh crons"
-          aria-label="Refresh crons"
-        >
-          <RefreshCw size={10} className={isLoading ? 'animate-spin' : ''} />
-        </button>
-      </>
-    );
-  }, [isLoading, handleAdd, fetchJobs, onActions]);
-
   return (
     <div className="h-full flex flex-col min-h-0">
       <div className="flex-1 overflow-y-auto">
@@ -293,16 +264,37 @@ export function CronsTab({ onActions }: CronsTabProps) {
           </div>
         )}
 
-        {/* Empty state */}
-        {!isLoading && !jobs.length && !error && (
-          <div className="text-muted-foreground px-3 py-8 text-center flex flex-col items-center gap-2">
-            <Plus size={20} className="text-muted-foreground/50" />
+        {/* Add + Refresh row */}
+        {!isLoading && (
+          <div className="flex items-center border-b border-border/40">
             <button
               onClick={handleAdd}
-              className="text-[11px] text-purple hover:underline bg-transparent border-0 cursor-pointer"
+              className="group flex items-center gap-2 px-3 py-1.5 text-[11px] hover:bg-foreground/[0.02] transition-colors cursor-pointer flex-1 bg-transparent border-0 text-left focus-visible:ring-2 focus-visible:ring-purple/50 focus-visible:ring-offset-0"
+              aria-label="Add cron job"
             >
-              Create your first scheduled task
+              <span className="shrink-0 text-muted-foreground group-hover:text-purple transition-colors">
+                <Plus size={12} />
+              </span>
+              <span className="text-muted-foreground group-hover:text-purple transition-colors">
+                Add cron
+              </span>
             </button>
+            <button
+              onClick={fetchJobs}
+              disabled={isLoading}
+              className="shrink-0 px-2 py-1.5 bg-transparent border-0 text-muted-foreground hover:text-foreground disabled:opacity-50 transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-purple/50 focus-visible:ring-offset-0"
+              title="Refresh crons"
+              aria-label="Refresh crons"
+            >
+              <RefreshCw size={10} className={isLoading ? 'animate-spin' : ''} />
+            </button>
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!isLoading && !jobs.length && !error && (
+          <div className="text-muted-foreground px-3 py-6 text-center text-[11px]">
+            No scheduled tasks yet
           </div>
         )}
         {jobs.map(job => (

--- a/src/features/workspace/tabs/MemoryTab.tsx
+++ b/src/features/workspace/tabs/MemoryTab.tsx
@@ -3,7 +3,7 @@
  * Zero changes to the underlying memory feature.
  */
 
-import { lazy, Suspense, type ReactNode } from 'react';
+import { lazy, Suspense } from 'react';
 import type { Memory } from '@/types';
 
 const MemoryList = lazy(() => import('@/features/dashboard/MemoryList').then(m => ({ default: m.MemoryList })));
@@ -12,14 +12,13 @@ interface MemoryTabProps {
   memories: Memory[];
   onRefresh: (signal?: AbortSignal) => void | Promise<void>;
   isLoading?: boolean;
-  onActions?: (actions: ReactNode) => void;
 }
 
 /** Workspace tab displaying agent memories with add/refresh actions. */
-export function MemoryTab({ memories, onRefresh, isLoading, onActions }: MemoryTabProps) {
+export function MemoryTab({ memories, onRefresh, isLoading }: MemoryTabProps) {
   return (
     <Suspense fallback={<div className="flex items-center justify-center text-muted-foreground text-xs p-4">Loading…</div>}>
-      <MemoryList memories={memories} onRefresh={onRefresh} isLoading={isLoading} hideHeader onActions={onActions} />
+      <MemoryList memories={memories} onRefresh={onRefresh} isLoading={isLoading} hideHeader />
     </Suspense>
   );
 }

--- a/src/features/workspace/tabs/SkillsTab.tsx
+++ b/src/features/workspace/tabs/SkillsTab.tsx
@@ -2,7 +2,7 @@
  * SkillsTab — Browse installed skills and their status.
  */
 
-import { useState, useCallback, useEffect, type ReactNode } from 'react';
+import { useState, useCallback } from 'react';
 import { RefreshCw, Circle, ExternalLink, ChevronDown, ChevronRight, Puzzle } from 'lucide-react';
 import { useSkills, type Skill, type SkillMissing } from '../hooks/useSkills';
 
@@ -111,12 +111,8 @@ function SkillRow({ skill }: { skill: Skill }) {
   );
 }
 
-interface SkillsTabProps {
-  onActions?: (actions: ReactNode) => void;
-}
-
 /** Workspace tab listing installed skills and flagging missing dependencies. */
-export function SkillsTab({ onActions }: SkillsTabProps) {
+export function SkillsTab() {
   const { skills, isLoading, error, refresh } = useSkills();
   const [showUnavailable, setShowUnavailable] = useState(false);
 
@@ -125,32 +121,36 @@ export function SkillsTab({ onActions }: SkillsTabProps) {
   const eligibleCount = eligibleSkills.length;
   const totalCount = skills.length;
 
-  // Register action buttons with parent tab bar
-  useEffect(() => {
-    onActions?.(
-      <>
-        {totalCount > 0 && (
-          <span className="text-[10px] text-muted-foreground tabular-nums mr-1">
-            {eligibleCount}/{totalCount}
-          </span>
-        )}
-        <button
-          onClick={refresh}
-          disabled={isLoading}
-          className="bg-transparent border border-border/60 text-muted-foreground text-sm w-6 h-6 cursor-pointer flex items-center justify-center hover:text-foreground hover:border-muted-foreground disabled:opacity-50 transition-colors focus-visible:ring-2 focus-visible:ring-purple/50 focus-visible:ring-offset-0"
-          title="Refresh skills"
-          aria-label="Refresh skills"
-        >
-          <RefreshCw size={10} className={isLoading ? 'animate-spin' : ''} />
-        </button>
-      </>
-    );
-  }, [isLoading, eligibleCount, totalCount, refresh, onActions]);
-
   return (
     <div className="h-full flex flex-col min-h-0">
       {/* Content */}
       <div className="flex-1 overflow-y-auto">
+        {/* Skills count + Refresh row */}
+        {!isLoading && skills.length > 0 && (
+          <div className="flex items-center border-b border-border/40">
+            <div className="flex items-center gap-2 px-3 py-1.5 text-[11px] flex-1">
+              <span className="shrink-0 text-muted-foreground">
+                <Puzzle size={12} />
+              </span>
+              <span className="text-muted-foreground">
+                {eligibleCount} active
+                {unavailableSkills.length > 0 && (
+                  <span className="text-muted-foreground/50"> / {totalCount} total</span>
+                )}
+              </span>
+            </div>
+            <button
+              onClick={refresh}
+              disabled={isLoading}
+              className="shrink-0 px-2 py-1.5 bg-transparent border-0 text-muted-foreground hover:text-foreground disabled:opacity-50 transition-colors cursor-pointer focus-visible:ring-2 focus-visible:ring-purple/50 focus-visible:ring-offset-0"
+              title="Refresh skills"
+              aria-label="Refresh skills"
+            >
+              <RefreshCw size={10} className={isLoading ? 'animate-spin' : ''} />
+            </button>
+          </div>
+        )}
+
         {/* Error */}
         <div aria-live="polite" aria-atomic="true">
           {error && (


### PR DESCRIPTION
Relocate action buttons (add, refresh) from the tab bar header into each pane's content area as inline first-row elements.

## Motivation

The tab bar was overloaded with action buttons that only applied to one tab at a time, creating visual clutter and inconsistent UX. Actions now live inside their respective panes where they contextually belong.

## Changes

**Memory tab**
- Add "+ Add memory" as first row in the list with refresh button on the right
- Remove `onActions` prop chain

**Crons tab**
- Add "+ Add cron" as first row with refresh on the right
- Simplify empty state to text-only (add button always visible above)
- Remove `onActions` prop chain

**Skills tab**
- Add info row showing active/total skill count with refresh on the right
- Remove `onActions` prop chain

**Config tab**
- Move file selector to left-aligned, refresh to the right
- Match refresh button styling with other tabs (borderless)

**WorkspaceTabs**
- Remove `actions` prop and rendering logic (dead code cleanup)

**WorkspacePanel**
- Remove all `onActions` registration callbacks and `tabActions` state

## Result

Tab bar is now pure navigation. All pane-specific actions live inside their respective content areas with a consistent layout: action/info on the left, refresh on the right.

## Breaking Changes

Removes `onActions` prop from `MemoryTab`, `CronsTab`, `SkillsTab` and `actions` prop from `WorkspaceTabs`. No external consumers known.

## Testing

- All four tabs verified: add and refresh actions functional
- Vite build passes with zero errors
- Net reduction: ~60 lines removed