### PR TITLE
docs: add security warnings for unauthenticated API exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,19 @@ Nerve proxies WebSocket traffic to your gateway and adds its own REST layer for 
 **Frontend:** React 19 · Tailwind CSS 4 · shadcn/ui · Vite 7
 **Backend:** Hono 4 on Node.js
 
+## ⚠️ Security
+
+**Nerve has no built-in authentication.** All API endpoints are open by design — it's meant to run on localhost or behind a user-controlled access layer.
+
+**Do not expose Nerve directly to the public internet.** Anyone with network access can read/write your agent's memory, modify config files, inject API keys, and control sessions.
+
+Safe ways to access Nerve remotely:
+- **SSH tunnel** — `ssh -L 3080:localhost:3080 your-server` (recommended)
+- **Tailscale / WireGuard** — access over your private network
+- **Reverse proxy with auth** — nginx + basic auth, Cloudflare Access, OAuth proxy
+
+See **[Security](docs/SECURITY.md)** for the full threat model and details.
+
 ## Docs
 
 | | |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -77,7 +77,9 @@ The wizard backs up existing `.env` files (e.g. `.env.bak.1708100000000`) before
 |----------|---------|-------------|
 | `PORT` | `3080` | HTTP server port |
 | `SSL_PORT` | `3443` | HTTPS server port (requires certificates at `certs/cert.pem` and `certs/key.pem`) |
-| `HOST` | `127.0.0.1` | Bind address. Set to `0.0.0.0` for network access. **Warning:** exposes the API to the network |
+| `HOST` | `127.0.0.1` | Bind address. Set to `0.0.0.0` for network access — see warning below |
+
+> **⚠️ Security Warning:** Nerve has no built-in authentication. Setting `HOST=0.0.0.0` exposes **all API endpoints** to the network without any access control. Anyone with network access can read/write agent memory, modify config files, inject API keys, and control sessions. Only bind to `0.0.0.0` behind a VPN (Tailscale, WireGuard), reverse proxy with authentication, or a trusted private network. See [Security](SECURITY.md) for details.
 
 ```env
 PORT=3080


### PR DESCRIPTION
## Motivation

Nerve has no built-in authentication — all API endpoints are open by design. This is fine for localhost usage but the docs didn't make the risk obvious enough for users binding to `0.0.0.0` or exposing Nerve to a network.

## Changes

**README.md**
- Add prominent ⚠️ Security section between "How it works" and "Docs"
- Clearly states no auth, lists what's at risk (memory, config, API keys, sessions)
- Lists safe remote access methods: SSH tunnel, Tailscale/WireGuard, reverse proxy with auth

**docs/CONFIGURATION.md**
- Expand the `HOST` variable warning from a brief inline note to a blockquote detailing the specific risks of binding to `0.0.0.0`
- Links to SECURITY.md for the full threat model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Security section to README describing authentication considerations and recommended safe deployment practices
  * Updated configuration documentation with warnings about binding settings and API exposure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->