### PR TITLE
docs: sync all documentation with auth + device identity changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,11 +57,13 @@ Thanks for wanting to help! This guide covers everything you need to start contr
 nerve/
 ├── src/                        # Frontend (React + TypeScript)
 │   ├── features/               # Feature modules (co-located)
+│   │   ├── auth/               # Login page, auth gate, session hook
 │   │   ├── chat/               # Chat panel, messages, input, search
 │   │   ├── voice/              # Push-to-talk, wake word, audio feedback
 │   │   ├── tts/                # Text-to-speech playback
 │   │   ├── sessions/           # Session list, tree, spawn dialog
 │   │   ├── workspace/          # Tabbed panel: memory, crons, skills, config
+│   │   ├── file-browser/       # Workspace file browser with tabbed editor
 │   │   ├── settings/           # Settings drawer (appearance, audio, connection)
 │   │   ├── command-palette/    # ⌘K command palette
 │   │   ├── markdown/           # Markdown renderer, code block actions
@@ -82,7 +84,7 @@ nerve/
 │   ├── routes/                 # API route handlers
 │   ├── services/               # TTS engines, Whisper, usage tracking
 │   ├── lib/                    # Utilities (config, WS proxy, file watcher, etc.)
-│   ├── middleware/             # Rate limiting
+│   ├── middleware/             # Auth, rate limiting, security headers, caching
 │   └── app.ts                  # Hono app assembly
 ├── config/                     # TypeScript configs for server build
 ├── scripts/                    # Setup wizard and utilities

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,7 +53,7 @@ Built with **React 19**, **TypeScript**, **Vite**, and **Tailwind CSS v4**.
 
 | File | Purpose |
 |------|---------|
-| `src/main.tsx` | Mounts the React tree with the provider hierarchy: `ErrorBoundary → StrictMode → GatewayProvider → SettingsProvider → SessionProvider → ChatProvider → App` |
+| `src/main.tsx` | Mounts the React tree: `ErrorBoundary → StrictMode → AuthGate`. The auth gate checks session status before rendering the app |
 | `src/App.tsx` | Root layout — wires contexts to lazy-loaded panels, manages keyboard shortcuts and command palette |
 
 ### Context Providers (State Management)
@@ -72,6 +72,16 @@ All global state flows through four React contexts, nested in dependency order:
 ### Feature Modules
 
 Each feature lives in `src/features/<name>/` with its own components, hooks, types, and operations.
+
+#### `features/auth/`
+Authentication gate and login UI.
+
+| File | Purpose |
+|------|---------|
+| `AuthGate.tsx` | Top-level component — shows loading spinner, login page, or the full app depending on auth state |
+| `LoginPage.tsx` | Full-screen password form matching Nerve's dark theme. Auto-focus, Enter-to-submit, gateway token hint |
+| `useAuth.ts` | Auth state via `useSyncExternalStore`. Module-level fetch checks `/api/auth/status` once on load. Exposes `login`/`logout` callbacks |
+| `index.ts` | Barrel export |
 
 #### `features/chat/`
 The main chat interface.
@@ -147,7 +157,7 @@ Settings drawer with tabbed sections.
 
 | File | Purpose |
 |------|---------|
-| `SettingsDrawer.tsx` | Slide-out drawer container |
+| `SettingsDrawer.tsx` | Slide-out drawer container. Includes logout button when auth is enabled |
 | `ConnectionSettings.tsx` | Gateway URL/token, reconnect |
 | `AudioSettings.tsx` | TTS provider, model, voice, wake word |
 | `AppearanceSettings.tsx` | Theme, font selection |
@@ -296,6 +306,7 @@ Applied in order in `app.ts`:
 | CORS | Hono built-in + custom | Whitelist of localhost origins + `ALLOWED_ORIGINS` env var. Validates via `URL` constructor. Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS |
 | Security headers | `middleware/security-headers.ts` | Standard security headers (CSP, X-Frame-Options, etc.) |
 | Body limit | Hono built-in | Configurable max body size (from `config.limits.maxBodyBytes`) |
+| Auth | `middleware/auth.ts` | When `NERVE_AUTH=true`, requires a valid signed session cookie on `/api/*` routes (except auth endpoints and health). WebSocket upgrades checked separately in `ws-proxy.ts` |
 | Compression | Hono built-in | gzip/brotli on all routes **except** SSE (`/api/events`) |
 | Cache headers | `middleware/cache-headers.ts` | Hashed assets → immutable, API → no-cache, non-hashed static → must-revalidate |
 | Rate limiting | `middleware/rate-limit.ts` | Per-IP sliding window. Separate limits for general API vs TTS/transcribe. Client ID from socket or custom header |
@@ -305,6 +316,9 @@ Applied in order in `app.ts`:
 | Route | File | Methods | Purpose |
 |-------|------|---------|---------|
 | `/health` | `routes/health.ts` | GET | Health check with gateway connectivity probe |
+| `/api/auth/status` | `routes/auth.ts` | GET | Check whether auth is enabled and current session validity |
+| `/api/auth/login` | `routes/auth.ts` | POST | Authenticate with password, set signed session cookie |
+| `/api/auth/logout` | `routes/auth.ts` | POST | Clear session cookie |
 | `/api/connect-defaults` | `routes/connect-defaults.ts` | GET | Pre-fill gateway URL/token for browser. Token only returned for loopback clients |
 | `/api/events` | `routes/events.ts` | GET, POST | SSE stream for real-time push (memory.changed, tokens.updated, status.changed, ping). POST for test events |
 | `/api/tts` | `routes/tts.ts` | POST | Text-to-speech with provider auto-selection (OpenAI → Replicate → Edge). LRU cache with TTL |
@@ -337,9 +351,10 @@ Applied in order in `app.ts`:
 
 | File | Purpose |
 |------|---------|
-| `lib/config.ts` | Centralized configuration from env vars — ports, keys, paths, limits. Validated at startup |
-| `lib/ws-proxy.ts` | WebSocket proxy — client→gateway with device identity injection (Ed25519 challenge-response) |
-| `lib/device-identity.ts` | Ed25519 keypair generation/persistence for gateway auth. Stored in `~/.nerve/device-identity.json` |
+| `lib/config.ts` | Centralized configuration from env vars — ports, keys, paths, limits, auth settings. Validated at startup |
+| `lib/session.ts` | Session token creation/verification (HMAC-SHA256), password hashing (scrypt), cookie parsing for WS upgrade requests |
+| `lib/ws-proxy.ts` | WebSocket proxy — client→gateway with session cookie auth on upgrade and Ed25519 device identity injection |
+| `lib/device-identity.ts` | Ed25519 keypair generation/persistence (`~/.nerve/device-identity.json`). Builds signed connect blocks for gateway auth |
 | `lib/gateway-client.ts` | HTTP client for gateway tool invocation API (`/tools/invoke`) |
 | `lib/file-watcher.ts` | Watches MEMORY.md, `memory/`, and workspace directory (recursive). Broadcasts `file.changed` SSE events for real-time sync |
 | `lib/file-utils.ts` | File browser utilities — path validation, directory exclusions, binary file detection |
@@ -373,11 +388,13 @@ Browser WS → /ws?target=ws://gateway:18789/ws → ws-proxy.ts → OpenClaw Gat
 ```
 
 1. Client connects to `/ws` endpoint on Nerve server
-2. Proxy validates target URL against `WS_ALLOWED_HOSTS` allowlist
-3. Proxy opens upstream WebSocket to the gateway
-4. On `connect.challenge` event, proxy intercepts the client's `connect` request and injects Ed25519 device identity (`device` block with signed nonce)
-5. After handshake, all messages are transparently forwarded bidirectionally
-6. Pending messages are buffered (capped at 100 messages / 1 MB) while upstream connects
+2. When auth is enabled, the session cookie is verified on the HTTP upgrade request (rejects with 401 if invalid)
+3. Proxy validates target URL against `WS_ALLOWED_HOSTS` allowlist
+4. Proxy opens upstream WebSocket to the gateway
+5. On `connect.challenge` event, proxy intercepts the client's `connect` request and injects Ed25519 device identity (`device` block with signed nonce)
+6. If the gateway rejects the device (close code 1008), proxy retries without device identity (reduced scopes)
+7. After handshake, all messages are transparently forwarded bidirectionally
+8. Pending messages are buffered (capped at 100 messages / 1 MB) while upstream connects
 
 ### Server-Sent Events (SSE)
 

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -225,8 +225,11 @@ const fetchLimits = createCachedFetch(
 
 ### Security
 
+- **Authentication:** Session-cookie auth via `middleware/auth.ts`. When enabled, all `/api/*` routes (except auth/health) require a valid HMAC-SHA256 signed cookie. WebSocket upgrades checked in `ws-proxy.ts`
+- **Session tokens:** Stateless signed cookies (`HttpOnly`, `SameSite=Strict`). Password hashing via scrypt. Gateway token accepted as fallback password
 - **CORS:** Strict origin allowlist — only localhost variants and explicitly configured origins
 - **Token exposure:** Gateway token only returned to loopback clients (`/api/connect-defaults`)
+- **Device identity:** Ed25519 keypair for gateway WS auth (`~/.nerve/device-identity.json`). Required for operator scopes on OpenClaw 2026.2.19+
 - **File serving:** MIME-type allowlist + directory traversal prevention + allowed prefix check
 - **Body limits:** Configurable per-route (general API vs transcribe uploads)
 - **Rate limiting:** Per-IP sliding window with separate limits for expensive operations

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -26,7 +26,7 @@ Connects Nerve to your OpenClaw gateway. The wizard auto-detects the gateway tok
 2. Environment variable `OPENCLAW_GATEWAY_TOKEN`
 3. `~/.openclaw/openclaw.json` (auto-detected)
 
-Tests the connection before proceeding. If the gateway is unreachable, you can continue anyway.
+Tests the connection before proceeding. If the gateway is unreachable, you can continue anyway. On OpenClaw 2026.2.19+, the wizard also auto-fixes a known device scope bootstrap issue and approves pending device pairing requests.
 
 #### 2. Agent Identity
 
@@ -77,7 +77,9 @@ The wizard backs up existing `.env` files (e.g. `.env.bak.1708100000000`) before
 |----------|---------|-------------|
 | `PORT` | `3080` | HTTP server port |
 | `SSL_PORT` | `3443` | HTTPS server port (requires certificates at `certs/cert.pem` and `certs/key.pem`) |
-| `HOST` | `127.0.0.1` | Bind address. Set to `0.0.0.0` for network access. **Warning:** exposes the API to the network |
+| `HOST` | `127.0.0.1` | Bind address. Set to `0.0.0.0` for network access — see warning below |
+
+> **⚠️ Network exposure:** Setting `HOST=0.0.0.0` exposes all endpoints to the network. Enable authentication (`NERVE_AUTH=true`) and set a password via the setup wizard before binding to a non-loopback address. Without auth, anyone with network access can read/write agent memory, modify config files, and control sessions. See [Security](SECURITY.md) for the full threat model.
 
 ```env
 PORT=3080
@@ -130,7 +132,7 @@ TTS provider fallback chain (when no explicit provider is requested):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `STT_PROVIDER` | `openai` | STT provider: `openai` (requires `OPENAI_API_KEY`) or `local` (whisper.cpp, no API key needed) |
+| `STT_PROVIDER` | `local` | STT provider: `local` (whisper.cpp, no API key needed) or `openai` (requires `OPENAI_API_KEY`) |
 | `WHISPER_MODEL` | `tiny.en` | Local whisper model: `tiny.en` (75 MB), `base.en` (142 MB), or `small.en` (466 MB) |
 | `WHISPER_MODEL_DIR` | `~/.nerve/models/` | Directory for downloaded whisper model files |
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -4,6 +4,56 @@ Common issues and solutions for Nerve.
 
 ---
 
+## Authentication
+
+### Login page won't accept password
+
+**Symptom:** Entering the correct password returns "Invalid password".
+
+**Causes:**
+1. The password hash in `.env` doesn't match the password you're entering
+2. You're trying the gateway token but `GATEWAY_TOKEN` isn't set in `.env`
+
+**Fix:**
+- Re-run `npm run setup` to set a new password
+- Or set `NERVE_AUTH=true` with a valid `GATEWAY_TOKEN` — the gateway token works as a fallback password without needing a password hash
+
+### Session expired / redirected to login
+
+**Symptom:** You were logged in but got redirected to the login page.
+
+**Cause:** The session cookie expired (default TTL: 30 days) or the `NERVE_SESSION_SECRET` changed (e.g., server restart without a persisted secret).
+
+**Fix:**
+- Log in again with your password
+- If sessions don't survive restarts, ensure `NERVE_SESSION_SECRET` is set in `.env` (the setup wizard generates one). Without it, an ephemeral secret is created on each startup
+
+### API returns 401 but auth is disabled
+
+**Symptom:** API calls fail with "Authentication required" even though `NERVE_AUTH` isn't set.
+
+**Cause:** Check that `NERVE_AUTH` isn't set to `true` somewhere unexpected (e.g., exported in your shell profile).
+
+**Fix:**
+```bash
+# Check the env var
+grep NERVE_AUTH .env
+echo $NERVE_AUTH
+
+# Explicitly disable
+echo "NERVE_AUTH=false" >> .env
+```
+
+### WebSocket connects but immediately closes with 401
+
+**Symptom:** Browser console shows WebSocket upgrade failed with 401.
+
+**Cause:** When auth is enabled, WebSocket upgrade requests are also authenticated via the session cookie. If the cookie is missing or expired, the upgrade is rejected.
+
+**Fix:** Refresh the page and log in again. The session cookie is sent automatically with WebSocket upgrade requests.
+
+---
+
 ## Build Errors
 
 ### `tsc -b` fails with path alias errors
@@ -138,6 +188,25 @@ rm ~/.nerve/device-identity.json
 WS_ALLOWED_HOSTS=mygateway.local npm start
 ```
 
+### "Missing scope" errors after connecting
+
+**Symptom:** Chat sends but responses fail with "missing scope" or tool calls are rejected.
+
+**Cause:** The gateway didn't grant `operator.read`/`operator.write` scopes. This happens when:
+1. The device hasn't been approved yet (first connection)
+2. The device was rejected or the gateway was reset
+
+**Fix:**
+```bash
+# Check pending devices
+openclaw devices list
+
+# Approve the Nerve device
+openclaw devices approve <requestId>
+```
+
+After approval, reconnect from the browser (refresh the page or click reconnect).
+
 ### Messages buffered indefinitely
 
 **Symptom:** Messages sent immediately after connecting are lost.
@@ -213,12 +282,21 @@ WS_ALLOWED_HOSTS=mygateway.local npm start
 
 **Symptom:** Voice input records but transcription returns error.
 
-**Cause:** Transcription uses OpenAI Whisper API (requires `OPENAI_API_KEY`).
+**Causes:**
+- **Local STT** (default): The whisper model hasn't been downloaded yet, or `ffmpeg` is missing
+- **OpenAI STT**: `OPENAI_API_KEY` not set
 
-**Fix:**
-- Ensure `OPENAI_API_KEY` is set in `.env` or environment
-- Check file size: max 12 MB (configurable in `config.limits.transcribe`)
-- Check MIME type: must be one of: `audio/webm`, `audio/mp3`, `audio/mpeg`, `audio/mp4`, `audio/m4a`, `audio/wav`, `audio/ogg`, `audio/flac`
+**Fix (local STT):**
+- Models auto-download on first use. Check server logs for download progress or errors
+- Ensure `ffmpeg` is installed (the installer handles this): `ffmpeg -version`
+- Check model file exists: `ls ~/.nerve/models/ggml-tiny.en.bin`
+
+**Fix (OpenAI STT):**
+- Set `STT_PROVIDER=openai` and `OPENAI_API_KEY` in `.env`
+
+**Both providers:**
+- Max file size: 12 MB
+- Accepted formats: `audio/webm`, `audio/mp3`, `audio/mpeg`, `audio/mp4`, `audio/m4a`, `audio/wav`, `audio/ogg`, `audio/flac`
 
 ### Wake word doesn't trigger
 


### PR DESCRIPTION
Post-merge audit of all documentation against the auth system (PR #4) and device identity implementation. Every doc file in `docs/`, `CONTRIBUTING.md`, and `README.md` was reviewed.

## Changes

### ARCHITECTURE.md
- Fix `main.tsx` entry point description (`AuthGate` now wraps providers, not `main.tsx`)
- Add `features/auth/` section with AuthGate, LoginPage, useAuth
- Add auth middleware to middleware stack table
- Add auth routes (`/api/auth/*`) to API routes table
- Add `session.ts` and `device-identity.ts` to server libraries
- Document WS proxy session cookie check on upgrade + device rejection retry flow
- Note logout button in SettingsDrawer description

### CONFIGURATION.md
- Fix `STT_PROVIDER` default: `openai` → `local` (matches `config.ts` since local whisper was added)
- Document auto-fix of device scope bootstrap bug in setup wizard Gateway section

### TROUBLESHOOTING.md
- Add full Authentication section (4 scenarios: login failure, session expiry, 401 with auth disabled, WS upgrade 401)
- Add "missing scope" troubleshooting for device identity pairing
- Rewrite whisper transcription section: document local STT as default, split fix guidance by provider

### CODE_REVIEW.md
- Add auth middleware, session tokens, and device identity to security patterns list

### CONTRIBUTING.md
- Add `features/auth/` and `features/file-browser/` to project structure tree
- Fix middleware directory description (was only "Rate limiting", now lists all middleware types)

## Not changed (already accurate)
- `README.md` — auth section was added in PR #4, still accurate
- `SECURITY.md` — comprehensive auth + device identity docs were added in PR #4
- `API.md` — auth endpoints were documented in PR #4
- `AGENT-MARKERS.md` — no auth-related content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced user-facing authentication: login UI, auth gate, and logout in settings.

* **Documentation**
  * Expanded architecture docs to describe session-based auth and proxy device handling.
  * Added authentication and device-scope troubleshooting, and clarified security, input validation, and device identity guidance.
  * Updated gateway configuration notes and network-exposure warning.

* **Configuration**
  * Changed default STT provider preference ordering to favor local providers (e.g., whisper.cpp).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->