### PR TITLE
feat(auth): animated Nerve logo on login page

### DIFF
--- a/src/features/auth/LoginPage.tsx
+++ b/src/features/auth/LoginPage.tsx
@@ -6,6 +6,7 @@
  */
 
 import { useState, useRef, useEffect, useCallback } from 'react';
+import NerveLogo from '../../components/NerveLogo';
 
 interface LoginPageProps {
   onLogin: (password: string) => Promise<void>;
@@ -37,7 +38,10 @@ export function LoginPage({ onLogin, error }: LoginPageProps) {
       <div className="w-full max-w-sm mx-4">
         {/* Logo / Title */}
         <div className="text-center mb-8">
-          <div className="text-2xl font-bold text-primary mb-1">⚡ Nerve</div>
+          <div className="flex items-center justify-center mb-2">
+            <NerveLogo size={36} />
+          </div>
+          <div className="text-2xl font-bold text-primary mb-1">Nerve</div>
           <div className="text-xs text-muted-foreground font-mono tracking-wider uppercase">
             Authentication Required
           </div>


### PR DESCRIPTION
Replace the ⚡ emoji with the animated hexagonal NerveLogo canvas component on the password login screen. Renders at 36px with fire-pulse animation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the login page design with a new centered logo displayed above the title for improved visual branding on the authentication screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->