### PR TITLE
fix(claude-usage): resolve Claude CLI across install locations

### DIFF
--- a/server/services/claude-usage.ts
+++ b/server/services/claude-usage.ts
@@ -52,9 +52,19 @@ function stripAnsi(s: string): string {
 }
 
 function resolveClaudeBin(): string {
-  const local = join(homedir(), '.local', 'bin', 'claude');
-  if (existsSync(local)) return local;
-  return 'claude';
+  // Check common Claude CLI install locations in priority order.
+  // The server process (especially under systemd/launchd) often has a
+  // minimal PATH that doesn't include these directories.
+  const candidates = [
+    join(homedir(), '.local', 'bin', 'claude'),           // Linux native install
+    join(homedir(), '.claude', 'local', 'claude'),         // macOS native install
+    '/usr/local/bin/claude',                               // Homebrew / manual
+    '/opt/homebrew/bin/claude',                            // Homebrew ARM macOS
+  ];
+  for (const p of candidates) {
+    if (existsSync(p)) return p;
+  }
+  return 'claude'; // fall back to PATH lookup
 }
 
 function sleep(ms: number): Promise<void> {
@@ -103,12 +113,21 @@ export async function getClaudeUsage(): Promise<RawClaudeLimits> {
   let buffer = '';
 
   try {
+    // Ensure ~/.local/bin is in PATH — under systemd the default PATH is
+    // minimal and Claude CLI prints a "not in PATH" warning instead of
+    // starting the interactive REPL.
+    const spawnEnv = { ...process.env } as Record<string, string>;
+    const localBin = join(homedir(), '.local', 'bin');
+    if (spawnEnv.PATH && !spawnEnv.PATH.split(':').includes(localBin)) {
+      spawnEnv.PATH = `${localBin}:${spawnEnv.PATH}`;
+    }
+
     pty = nodePty.spawn(claudeBin, [], {
       name: 'xterm-256color',
       cols: 200,
       rows: 50,
       cwd: tmpdir(),
-      env: process.env as Record<string, string>,
+      env: spawnEnv,
     });
 
     pty.onData((data: string) => {


### PR DESCRIPTION
**Problem:** `posix_spawnp failed` on macOS — `node-pty` couldn't find the `claude` binary. The native macOS install lives at `~/.claude/local/claude`, but `resolveClaudeBin()` only checked `~/.local/bin/claude`.

**Also fixed:** Under systemd (Linux), `~/.local/bin` wasn't in PATH, so even when the binary was found by full path, Claude CLI printed a 'not in PATH' warning and never started the REPL.

**Changes:**
- Check all common Claude CLI paths: `~/.local/bin`, `~/.claude/local`, `/usr/local/bin`, `/opt/homebrew/bin`
- Inject `~/.local/bin` into the PTY spawn environment (systemd PATH fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Claude startup reliability in restricted system environments (systemd/launchd)
  * Enhanced binary discovery with expanded fallback path checks
  * Better PATH environment configuration for consistent startup behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->