### PR TITLE
fix(ws-proxy): connect as 'ui' mode instead of 'webchat'

### DIFF
--- a/server/lib/ws-proxy.ts
+++ b/server/lib/ws-proxy.ts
@@ -256,7 +256,10 @@ interface ConnectParams {
 function injectDeviceIdentity(msg: Record<string, unknown>, nonce: string): Record<string, unknown> {
   const params = (msg.params || {}) as ConnectParams;
   const clientId = params.client?.id || 'nerve-ui';
-  const clientMode = params.client?.mode || 'webchat';
+  // Force 'ui' mode — the gateway restricts webchat clients from
+  // sessions.patch / sessions.delete / sessions.reset. Nerve needs full
+  // control-UI-level access for session management.
+  const clientMode = 'ui';
   const role = params.role || 'operator';
   const scopes = params.scopes || ['operator.admin', 'operator.read', 'operator.write'];
   const token = params.auth?.token || '';


### PR DESCRIPTION
**Root cause:** The gateway restricts `webchat` clients from admin RPC methods (`sessions.patch`, `sessions.delete`, `sessions.reset`, etc.). Nerve's WS proxy was forwarding the browser's `mode: 'webchat'` to the gateway, so all session management operations silently failed.

**Symptoms:**
- Delete/rename buttons on sessions did nothing
- Thinking effort changes failed: *'webchat clients cannot patch sessions'*
- Spawn subagent hung indefinitely (chat.send works but polling uses restricted methods)

**Fix:** Force `clientMode` to `'ui'` in the WS proxy's device identity injection, matching the OpenClaw Control UI's access level. The browser still identifies as webchat internally, but the proxy overrides it before forwarding to the gateway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed device identity handling to enforce consistent UI-level access during websocket connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->