### PR TITLE
fix: enrich PATH in ws-proxy gatewayCall for nvm/systemd

### DIFF
--- a/server/lib/ws-proxy.ts
+++ b/server/lib/ws-proxy.ts
@@ -19,6 +19,7 @@ import { WebSocket, WebSocketServer } from 'ws';
 import type { IncomingMessage } from 'node:http';
 import type { Duplex } from 'node:stream';
 import { execFile } from 'node:child_process';
+import { dirname } from 'node:path';
 import { config, WS_ALLOWED_HOSTS, SESSION_COOKIE_NAME } from './config.js';
 import { verifySession, parseSessionCookie } from './session.js';
 import { createDeviceBlock, getDeviceIdentity } from './device-identity.js';
@@ -43,8 +44,9 @@ function gatewayCall(method: string, params: Record<string, unknown>): Promise<u
     const bin = resolveOpenclawBin();
     const args = ['gateway', 'call', method, '--params', JSON.stringify(params)];
     // Ensure nvm/fnm/volta node is in PATH for #!/usr/bin/env node shebangs
-    const nodeBinDir = process.execPath.replace(/\/node$/, '');
-    const env = { ...process.env, PATH: `${nodeBinDir}:${process.env.PATH || ''}` };
+    const nodeBinDir = dirname(process.execPath);
+    const existingPath = process.env.PATH;
+    const env = { ...process.env, PATH: existingPath ? `${nodeBinDir}:${existingPath}` : nodeBinDir };
     execFile(bin, args, { timeout: 10_000, maxBuffer: 1024 * 1024, env }, (err, stdout, stderr) => {
       if (err) {
         reject(new Error(stderr?.trim() || err.message));


### PR DESCRIPTION
## Problem

`sessions.patch` (rename), `sessions.delete`, `sessions.reset`, and `sessions.compact` all proxy through `gatewayCall()` in `ws-proxy.ts`, which shells out to the `openclaw` CLI via `execFile`.

Under systemd with nvm-managed Node, `PATH` doesn't include the nvm bin directory, so the `#!/usr/bin/env node` shebang in the `openclaw` binary fails:

```
/usr/bin/env: 'node': No such file or directory
```

This broke session renaming (and all other restricted WS RPC methods) when Nerve runs as a systemd service.

## Fix

Enrich `PATH` with `process.execPath` dirname before calling `execFile`, matching the pattern already used in `gateway.ts` and `skills.ts`.

## Testing

- Renamed a sub-agent session via Nerve UI — works ✅
- `systemctl restart nerve` — service healthy ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Node executable resolution so CLI invocations reliably use the correct Node binary when multiple versions are present.
  * PATH handling adjusted to ensure shebang-based CLI tools resolve to the active Node, preserving existing environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->