### PR TITLE
fix: bundled config consent + gateway.tools.allow patch

### DIFF
--- a/docs/INSTALLER-STEPS.md
+++ b/docs/INSTALLER-STEPS.md
@@ -1,0 +1,332 @@
+# Nerve Installer Script: Step-by-Step Reference
+
+This document describes exactly what `install.sh` does, in the order it executes, including conditional branches.
+
+- Script: `install.sh`
+- Purpose: One-command install/update of **openclaw-nerve**
+- Primary entrypoint: `curl .../install.sh | bash`
+
+---
+
+## 0) Startup and Initialization
+
+### 0.1 Strict shell mode
+The script starts with:
+
+- `set -euo pipefail`
+
+This makes it fail fast on command errors, unset variables, and pipeline failures.
+
+### 0.2 Default variables
+It initializes defaults such as:
+
+- `INSTALL_DIR` (default `~/nerve`, overridable via `NERVE_INSTALL_DIR`)
+- `BRANCH` (default `master`)
+- `REPO`
+- `NODE_MIN=22`
+- flags: `SKIP_SETUP`, `DRY_RUN`
+- `GATEWAY_TOKEN` (optional CLI override)
+- `ENV_MISSING` (tracks partial installs)
+
+### 0.3 OS family detection
+It pre-detects platform family for package-manager logic:
+
+- macOS (`Darwin`)
+- Debian-like (`apt-get`)
+- Fedora/RHEL-like (`dnf`/`yum`)
+
+### 0.4 Utility helpers
+Defines output helpers (`ok`, `warn`, `fail`, `info`, `dry`) and utility functions:
+
+- `run_with_dots` for animated progress + exit capture (`RWD_EXIT`)
+- `detect_gateway_token` (systemd service token first, then `~/.openclaw/openclaw.json`)
+- stage renderer (`stage`) for `[1/5]`, `[2/5]`, etc.
+
+### 0.5 CLI argument parsing
+Supported flags:
+
+- `--dir <path>`
+- `--branch <name>`
+- `--repo <url>`
+- `--skip-setup`
+- `--dry-run`
+- `--gateway-token <token>`
+- `--help`
+
+Unknown or malformed args exit with error.
+
+### 0.6 Interactive mode detection
+Interactive mode is true if either:
+
+- stdin is a TTY (`-t 0`), or
+- `/dev/tty` is readable+writable
+
+This allows prompts even when invoked via `curl | bash`.
+
+### 0.7 Banner output
+Prints the Nerve ASCII banner and a dry-run warning banner when relevant.
+
+---
+
+## 1) Stage 1/5 — Prerequisites
+
+The script runs these checks in order:
+
+### 1.1 `check_node`
+- Verifies `node` exists.
+- Verifies major version is `>=22`.
+- On failure, prints targeted upgrade guidance (nvm/Homebrew/etc.) and exits.
+
+### 1.2 `check_npm`
+- Verifies `npm` exists.
+- If missing, explains reinstall path and exits.
+
+### 1.3 `check_git`
+- Verifies `git` exists.
+- If missing, prints OS-specific install command and exits.
+
+### 1.4 `check_build_tools`
+- Checks for `make` and `g++` (needed for native modules like `node-pty`).
+- If missing:
+  - Debian: auto-installs `build-essential` (unless dry-run)
+  - macOS: triggers Xcode CLI tools install and waits
+  - otherwise: prints manual install commands and exits
+
+### 1.5 `check_openclaw`
+- Verifies `openclaw` is in PATH.
+- If not, searches common install locations (nvm, Homebrew, Volta, fnm, etc.).
+- If found in fallback path, prepends that directory to `PATH`.
+- If still missing, exits with install instructions.
+
+### 1.6 `check_gateway`
+- Reads gateway port from `~/.openclaw/openclaw.json` (fallback 18789).
+- Probes gateway (`/health` then `/`) and warns if unreachable.
+- Verifies gateway token exists (CLI arg or auto-detected).
+- Warns (does not hard fail) if token is missing.
+
+---
+
+## 2) Stage 2/5 — Download
+
+### 2.1 Dry-run behavior
+- Prints what would happen (clone vs update).
+
+### 2.2 Real behavior
+- If `INSTALL_DIR/.git` exists:
+  - `git pull origin <branch>`
+- Else:
+  - `git clone --branch <branch> --depth 1 <repo> <dir>`
+- Then `cd` into `INSTALL_DIR`.
+
+---
+
+## 3) Stage 3/5 — Install & Build
+
+### 3.1 Dependency install (`npm ci`)
+- Runs `npm ci` with logs captured to temp file.
+- On failure, prints last 10 lines + full log path.
+- Detects common error patterns and prints targeted troubleshooting:
+  - permission errors
+  - node-gyp/build tool errors
+  - dependency resolve conflicts
+
+### 3.2 Client build
+- Runs `npm run build`.
+- On failure: prints last 10 log lines + full path + hints.
+
+### 3.3 Server build
+- Runs `npm run build:server`.
+- On failure: same structured diagnostics.
+
+### 3.4 Temp log cleanup
+- Deletes npm/build temp log files on success.
+
+### 3.5 Local speech model bootstrap
+- Ensures `~/.nerve/models/ggml-tiny.en.bin` exists.
+- If missing, downloads ~75MB from Hugging Face.
+- If download fails, continues with warning (voice input can still use OpenAI API).
+
+### 3.6 `ffmpeg` check/install
+- If `ffmpeg` missing:
+  - macOS: warning + brew install hint
+  - Debian: attempts apt install
+  - Fedora: attempts dnf install
+- Install failures are warnings, not hard failures.
+
+---
+
+## 4) Stage 4/5 — Configure
+
+This stage controls `.env` provisioning and setup wizard behavior.
+
+### 4.1 `generate_env_from_gateway` helper
+When called (and `.env` doesn’t already exist), it:
+
+1. Reads gateway token (`--gateway-token` first, then auto-detect)
+2. Reads gateway port from `openclaw.json` (fallback 18789)
+3. Writes minimal `.env`:
+   - `GATEWAY_URL=http://127.0.0.1:<port>`
+   - `GATEWAY_TOKEN=<token>`
+   - `PORT=3080`
+
+If token missing, it warns and sets `ENV_MISSING=true`.
+
+### 4.2 Configure decision matrix
+
+#### Dry-run
+- Shows simulated setup path only.
+
+#### `--skip-setup`
+- If `.env` exists: keep it.
+- If no `.env`: auto-generate from gateway config.
+
+#### Interactive mode (no `--skip-setup`)
+- If `.env` exists:
+  - ask: “Run setup wizard anyway?”
+  - if yes: run `NERVE_INSTALLER=1 npm run setup`
+  - if no: keep existing config
+- If no `.env`:
+  - run setup wizard
+  - if wizard fails, fallback to auto-generate `.env`
+
+#### Non-interactive mode (no `--skip-setup`)
+- If `.env` exists: keep it.
+- If no `.env`: auto-generate from gateway.
+
+### 4.3 Gateway config patching (inside setup wizard)
+
+After `.env` is written, the setup wizard detects and applies pending OpenClaw gateway config changes. This uses a detection layer (`detectNeededConfigChanges`) that checks what needs changing without applying, then presents all changes as a bundled consent prompt.
+
+#### Possible changes detected:
+1. **Device scopes** — bootstraps `~/.openclaw/devices/paired.json` with full operator scopes if missing or incomplete
+2. **Pre-pair Nerve device** — registers Nerve's Ed25519 identity in `paired.json` so it can connect without manual `openclaw devices approve`
+3. **Tools allow** — adds `"cron"` to `gateway.tools.allow` in `~/.openclaw/openclaw.json` (required for OpenClaw ≥2026.2.23 which denies cron on `/tools/invoke` by default)
+4. **Allowed origins** — adds Nerve's HTTP/HTTPS origins to `gateway.controlUi.allowedOrigins` (network access modes only)
+
+#### Interactive mode:
+- Shows a numbered list of all pending changes
+- One yes/no confirmation prompt
+- If declined, prints per-change manual fix instructions
+- If accepted, applies all changes, then a single gateway restart
+
+#### `--defaults` mode:
+- All changes applied silently (implicit consent)
+- Origins computed automatically from `HOST` and `PORT`
+- Treats any non-loopback HOST as network mode
+
+#### Post-apply:
+- Single gateway restart after all patches
+- `approveAllPendingDevices()` only runs when device-scopes or pre-pair changes were applied
+- Failures are logged with `warn()` in both interactive and defaults modes
+
+#### Dependency ordering:
+- Device-scopes always runs before pre-pair (pre-pair needs `paired.json` to exist)
+- If device-scopes fails, pre-pair is explicitly skipped
+
+---
+
+## 5) Stage 5/5 — Service Setup
+
+Service setup is OS-specific.
+
+## 5A) Linux/systemd path
+
+### 5A.1 Unit generation (`setup_systemd`)
+Creates a unit file at `/etc/systemd/system/nerve.service` with:
+
+- `ExecStart=<node> server-dist/index.js`
+- `WorkingDirectory=<INSTALL_DIR>`
+- `EnvironmentFile=<INSTALL_DIR>/.env`
+- `NODE_ENV=production`
+- explicit `HOME` and `PATH`
+- `Restart=on-failure`
+
+### 5A.2 Service user detection
+Determines service user/home by:
+
+1. `SUDO_USER`/`USER`
+2. `getent` home lookup (if via sudo)
+3. fallback heuristic: infer user from `openclaw` binary path under `/home/<user>/...`
+
+### 5A.3 Root vs non-root behavior
+- If root:
+  - installs service file directly
+  - `daemon-reload`, `enable`, and (if `.env` exists) `start`
+  - if `.env` missing: enables but does not start
+- If non-root:
+  - prints exact sudo commands to install/start manually
+  - leaves temp service file path in instructions
+
+### 5A.4 When service install is triggered
+- Existing service: stop + update
+- Interactive new install: asks user (default yes)
+- Non-interactive:
+  - if root: installs automatically
+  - if non-root: generates instructions/files
+
+## 5B) macOS/launchd path
+
+### 5B.1 Wrapper script creation
+Creates `<INSTALL_DIR>/start.sh` that:
+
+- sources `.env` at runtime
+- sets `NODE_ENV=production`
+- executes `node server-dist/index.js`
+
+This allows config updates by restarting service (no plist rewrite needed).
+
+### 5B.2 Plist creation
+Writes `~/Library/LaunchAgents/com.nerve.server.plist` with:
+
+- program args -> wrapper script
+- working directory
+- PATH env
+- keepalive + run-at-load
+- stdout/stderr logs to `<INSTALL_DIR>/nerve.log`
+
+### 5B.3 Service load behavior
+Attempts:
+
+1. `launchctl bootstrap gui/<uid> ...`
+2. fallback `launchctl load ...`
+
+If both fail, leaves plist and prints manual load command.
+
+### 5B.4 When launchd install is triggered
+- Existing plist: update/reload
+- Interactive new install: asks user (default yes)
+- Non-interactive: installs by default
+
+---
+
+## 6) Final Output and Exit Codes
+
+### 6.1 Completion UI
+Prints “Done” and a final success box with URL.
+
+URL logic:
+
+- Reads `PORT` from `.env` (default `3080`)
+- If `HOST=0.0.0.0`, tries to show a detected LAN IP URL
+- Otherwise shows `http://localhost:<port>`
+
+Also prints restart/log commands based on platform/service manager.
+
+### 6.2 Exit semantics
+- `exit 0`: fully configured install (`.env` present)
+- `exit 2`: partial success (installed, but `.env` missing or unusable)
+- `exit 1`: hard failure in prerequisite/build/etc.
+
+---
+
+## Quick Flow Summary
+
+1. Initialize + parse args + detect interactivity
+2. Check prerequisites
+3. Clone/update repo
+4. Install deps + build
+5. Fetch optional voice prerequisites (model + ffmpeg)
+6. Configure `.env` (wizard or auto-generation)
+7. Configure service (launchd/systemd)
+8. Print final URL and operational commands
+9. Exit with readiness-aware status code

--- a/scripts/lib/gateway-detect.ts
+++ b/scripts/lib/gateway-detect.ts
@@ -25,6 +25,9 @@ interface OpenClawConfig {
     controlUi?: {
       allowedOrigins?: string[];
     };
+    tools?: {
+      allow?: string[];
+    };
   };
   [key: string]: unknown;
 }
@@ -136,6 +139,46 @@ export function patchGatewayAllowedOrigins(origin: string): GatewayPatchResult {
     writeFileSync(OPENCLAW_CONFIG, JSON.stringify(config, null, 2) + '\n');
     result.ok = true;
     result.message = `Added ${origin} to gateway.controlUi.allowedOrigins`;
+    return result;
+  } catch (err) {
+    result.message = `Failed to patch config: ${err instanceof Error ? err.message : String(err)}`;
+    return result;
+  }
+}
+
+/**
+ * Patch the OpenClaw gateway config to allow the cron tool.
+ * Adds 'cron' to gateway.tools.allow (deduped).
+ * Returns a result indicating success/failure.
+ */
+export function patchGatewayToolsAllow(): GatewayPatchResult {
+  const result: GatewayPatchResult = { ok: false, message: '', configPath: OPENCLAW_CONFIG };
+
+  if (!existsSync(OPENCLAW_CONFIG)) {
+    result.message = `Config not found: ${OPENCLAW_CONFIG}`;
+    return result;
+  }
+
+  try {
+    const raw = readFileSync(OPENCLAW_CONFIG, 'utf-8');
+    const config = JSON.parse(raw) as OpenClawConfig;
+
+    config.gateway = config.gateway || {};
+    config.gateway.tools = config.gateway.tools || {};
+    const allow = Array.isArray(config.gateway.tools.allow) ? config.gateway.tools.allow : [];
+
+    if (allow.includes('cron')) {
+      result.ok = true;
+      result.message = 'cron already in gateway.tools.allow';
+      return result;
+    }
+
+    allow.push('cron');
+    config.gateway.tools.allow = allow;
+
+    writeFileSync(OPENCLAW_CONFIG, JSON.stringify(config, null, 2) + '\n');
+    result.ok = true;
+    result.message = 'Added cron to gateway.tools.allow';
     return result;
   } catch (err) {
     result.message = `Failed to patch config: ${err instanceof Error ? err.message : String(err)}`;
@@ -331,12 +374,23 @@ export function approveAllPendingDevices(): { ok: boolean; approved: number; mes
       stdio: ['pipe', 'pipe', 'pipe'],
     }).toString();
 
-    // Parse pending requests — the CLI may not have --json, fall back to regex
+    // Parse pending requests — try JSON first, fall back to box-drawing table regex
     const pendingIds: string[] = [];
-    const requestPattern = /│\s+([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\s+│/g;
-    let match;
-    while ((match = requestPattern.exec(listOutput)) !== null) {
-      pendingIds.push(match[1]);
+    try {
+      const parsed = JSON.parse(listOutput);
+      const items = Array.isArray(parsed?.pending) ? parsed.pending : [];
+      for (const item of items) {
+        if (item.requestId && typeof item.requestId === 'string') {
+          pendingIds.push(item.requestId);
+        }
+      }
+    } catch {
+      // Not valid JSON — fall back to table regex
+      const requestPattern = /│\s+([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\s+│/g;
+      let match;
+      while ((match = requestPattern.exec(listOutput)) !== null) {
+        pendingIds.push(match[1]);
+      }
     }
 
     if (pendingIds.length === 0) {
@@ -464,6 +518,173 @@ export function prePairNerveDevice(gatewayToken?: string): { ok: boolean; messag
       needsRestart: false,
     };
   }
+}
+
+// ── Detection layer ──────────────────────────────────────────────────
+
+export interface ConfigChange {
+  id: string;
+  description: string;
+  apply: () => { ok: boolean; message: string; needsRestart: boolean };
+}
+
+/**
+ * Detect whether gateway-side operator scopes need repair/bootstrap.
+ */
+function needsDeviceScopeFix(): boolean {
+  const pairedPath = join(HOME, '.openclaw', 'devices', 'paired.json');
+
+  if (!existsSync(pairedPath)) {
+    // Fresh install — needs bootstrap if the gateway identity exists
+    const deviceJsonPath = join(HOME, '.openclaw', 'identity', 'device.json');
+    return existsSync(deviceJsonPath);
+  }
+
+  try {
+    const raw = readFileSync(pairedPath, 'utf-8');
+    const paired = JSON.parse(raw) as Record<string, { scopes?: string[] }>;
+
+    for (const [, device] of Object.entries(paired)) {
+      const currentScopes = device.scopes || [];
+      const missing = FULL_OPERATOR_SCOPES.filter(s => !currentScopes.includes(s));
+      if (missing.length > 0) return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect whether Nerve device pre-pairing is needed.
+ * Returns false when paired.json is absent; device-scope bootstrap will create it first.
+ */
+function needsPrePair(gatewayToken?: string): boolean {
+  const nerveDir = process.env.NERVE_DATA_DIR || join(process.env.HOME || HOME, '.nerve');
+  const identityPath = join(nerveDir, 'device-identity.json');
+  const pairedPath = join(HOME, '.openclaw', 'devices', 'paired.json');
+
+  if (!existsSync(pairedPath)) return false;
+
+  try {
+    const paired = JSON.parse(readFileSync(pairedPath, 'utf-8')) as Record<string, unknown>;
+
+    if (!existsSync(identityPath)) return true; // No Nerve identity yet
+
+    const stored = JSON.parse(readFileSync(identityPath, 'utf-8'));
+    const deviceId = stored.deviceId;
+
+    if (!paired[deviceId]) return true; // Nerve not registered
+
+    // Check token match — if no token is available, assume mismatch (apply will generate one)
+    const token = gatewayToken || detectGatewayConfig().token;
+    if (!token) return true;
+    const existing = paired[deviceId] as { tokens?: Record<string, { token?: string }> };
+    if (existing.tokens?.operator?.token !== token) return true;
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect whether gateway.tools.allow is missing the cron tool.
+ */
+function needsToolsAllow(): boolean {
+  if (!existsSync(OPENCLAW_CONFIG)) return false;
+
+  try {
+    const raw = readFileSync(OPENCLAW_CONFIG, 'utf-8');
+    const config = JSON.parse(raw) as OpenClawConfig;
+    const allow = config.gateway?.tools?.allow || [];
+    return !allow.includes('cron');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect whether a specific origin is missing from gateway.controlUi.allowedOrigins.
+ */
+function needsOriginPatch(origin: string): boolean {
+  if (!existsSync(OPENCLAW_CONFIG)) return false;
+
+  try {
+    const raw = readFileSync(OPENCLAW_CONFIG, 'utf-8');
+    const config = JSON.parse(raw) as OpenClawConfig;
+    const origins = config.gateway?.controlUi?.allowedOrigins || [];
+    return !origins.includes(origin);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Detect which gateway config changes are needed without applying them.
+ * Returns an array of pending changes with descriptions and apply functions.
+ */
+export function detectNeededConfigChanges(opts: {
+  nerveOrigin?: string;
+  nerveHttpsOrigin?: string;
+  gatewayToken?: string;
+}): ConfigChange[] {
+  const changes: ConfigChange[] = [];
+
+  const deviceScopeFixNeeded = needsDeviceScopeFix();
+
+  if (deviceScopeFixNeeded) {
+    changes.push({
+      id: 'device-scopes',
+      description: 'Fix gateway device scopes (required for Nerve to connect)',
+      apply: () => fixGatewayDeviceScopes(),
+    });
+  }
+
+  // If device-scopes will bootstrap paired.json, always include pre-pair
+  // (paired.json won't exist yet for detection, but will after device-scopes runs)
+  if (deviceScopeFixNeeded || needsPrePair(opts.gatewayToken)) {
+    changes.push({
+      id: 'pre-pair',
+      description: 'Pre-pair Nerve device identity (skip manual approval step)',
+      apply: () => prePairNerveDevice(opts.gatewayToken),
+    });
+  }
+
+  if (needsToolsAllow()) {
+    changes.push({
+      id: 'tools-allow',
+      description: 'Allow cron tool on /tools/invoke (needed for cron management)',
+      apply: () => {
+        const r = patchGatewayToolsAllow();
+        return { ok: r.ok, message: r.message, needsRestart: r.ok };
+      },
+    });
+  }
+
+  if (opts.nerveOrigin && needsOriginPatch(opts.nerveOrigin)) {
+    changes.push({
+      id: 'allowed-origins',
+      description: `Add ${opts.nerveOrigin} to allowed origins (needed for WebSocket)`,
+      apply: () => {
+        const r = patchGatewayAllowedOrigins(opts.nerveOrigin!);
+        return { ok: r.ok, message: r.message, needsRestart: r.ok };
+      },
+    });
+  }
+
+  if (opts.nerveHttpsOrigin && needsOriginPatch(opts.nerveHttpsOrigin)) {
+    changes.push({
+      id: 'allowed-origins-https',
+      description: `Add ${opts.nerveHttpsOrigin} to allowed origins (needed for HTTPS WebSocket)`,
+      apply: () => {
+        const r = patchGatewayAllowedOrigins(opts.nerveHttpsOrigin!);
+        return { ok: r.ok, message: r.message, needsRestart: r.ok };
+      },
+    });
+  }
+
+  return changes;
 }
 
 /**

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -34,7 +34,7 @@ import {
   type EnvConfig,
 } from './lib/env-writer.js';
 import { generateSelfSignedCert } from './lib/cert-gen.js';
-import { detectGatewayConfig, getEnvGatewayToken, patchGatewayAllowedOrigins, restartGateway, fixGatewayDeviceScopes, approveAllPendingDevices, prePairNerveDevice } from './lib/gateway-detect.js';
+import { detectGatewayConfig, getEnvGatewayToken, restartGateway, approveAllPendingDevices, detectNeededConfigChanges, type ConfigChange } from './lib/gateway-detect.js';
 
 const PROJECT_ROOT = resolve(process.cwd());
 const ENV_PATH = resolve(PROJECT_ROOT, '.env');
@@ -44,6 +44,98 @@ const args = process.argv.slice(2);
 const isHelp = args.includes('--help') || args.includes('-h');
 const isCheck = args.includes('--check');
 const isDefaults = args.includes('--defaults');
+
+function detectPrimaryIpv4(): string | null {
+  const nets = networkInterfaces();
+  for (const addrs of Object.values(nets)) {
+    for (const addr of addrs ?? []) {
+      if (!addr.internal && addr.family === 'IPv4') return addr.address;
+    }
+  }
+  return null;
+}
+
+/** Check whether a host string is a loopback address (IPv4, IPv6, or localhost). */
+function isLoopback(host: string): boolean {
+  return !host || host === '127.0.0.1' || host === 'localhost' || host === '::1';
+}
+
+function computeGatewayOrigins(config: EnvConfig, accessMode: string): {
+  nerveOrigin?: string;
+  nerveHttpsOrigin?: string;
+} {
+  if (accessMode === 'local') return {};
+
+  const nervePort = config.PORT || DEFAULTS.PORT;
+  let accessIp = config.HOST === '0.0.0.0'
+    ? (config.ALLOWED_ORIGINS?.split(',')[0]?.trim()?.replace(/^https?:\/\//, '').replace(/:\d+$/, '') || '0.0.0.0')
+    : (config.HOST || 'localhost');
+
+  if (accessIp === '0.0.0.0') {
+    accessIp = detectPrimaryIpv4() || '';
+  }
+
+  // If we couldn't resolve a usable IP, skip origin generation
+  if (!accessIp || accessIp === '0.0.0.0') {
+    return {};
+  }
+
+  const nerveOrigin = `http://${accessIp}:${nervePort}`;
+  const sslPort = config.SSL_PORT;
+  const nerveHttpsOrigin = sslPort ? `https://${accessIp}:${sslPort}` : undefined;
+
+  return { nerveOrigin, nerveHttpsOrigin };
+}
+
+/**
+ * Apply a list of config changes, restart gateway if needed, and optionally approve pending devices.
+ * Shared between interactive and defaults flows to avoid duplication.
+ */
+async function applyConfigChanges(changes: ConfigChange[]): Promise<void> {
+  let needsRestart = false;
+  let deviceScopeFixFailed = false;
+  let shouldApprovePending = false;
+
+  for (const change of changes) {
+    if (change.id === 'pre-pair' && deviceScopeFixFailed) {
+      warn('Skipping pre-pair because device scope fix failed');
+      continue;
+    }
+
+    const result = change.apply();
+    if (result.ok) {
+      success(result.message);
+      if (result.needsRestart) needsRestart = true;
+      if (change.id === 'device-scopes' || change.id === 'pre-pair') {
+        shouldApprovePending = true;
+      }
+    } else {
+      warn(result.message);
+      if (change.id === 'device-scopes') {
+        deviceScopeFixFailed = true;
+      }
+    }
+  }
+
+  if (needsRestart) {
+    dim('Restarting gateway to apply changes...');
+    const restart = restartGateway();
+    if (restart.ok) {
+      await new Promise(r => setTimeout(r, 3000));
+      if (shouldApprovePending) {
+        const approved = approveAllPendingDevices();
+        if (approved.ok && approved.approved > 0) {
+          success(approved.message);
+        } else if (!approved.ok) {
+          warn(approved.message);
+        }
+      }
+      success('Gateway configuration updated');
+    } else {
+      warn(restart.message);
+    }
+  }
+}
 
 // ── Ctrl+C handler ───────────────────────────────────────────────────
 
@@ -65,12 +157,13 @@ async function main(): Promise<void> {
     --defaults   Non-interactive setup using auto-detected values
     --help, -h   Show this help message
 
-  The setup wizard guides you through 5 steps:
+  The setup wizard guides you through 6 steps:
     1. Gateway Connection — connect to your OpenClaw gateway
     2. Agent Identity     — set your agent's display name
     3. Access Mode        — local, Tailscale, LAN, or custom
-    4. TTS Configuration  — optional text-to-speech API keys
-    5. Advanced Settings  — custom file paths (most users skip this)
+    4. Authentication     — password protection (network mode)
+    5. TTS Configuration  — optional text-to-speech API keys
+    6. Advanced Settings  — custom file paths (most users skip this)
 
   Examples:
     npm run setup               # Interactive setup
@@ -254,31 +347,6 @@ async function collectInteractive(
   const gwTest = await testGatewayConnection(config.GATEWAY_URL!);
   if (gwTest.ok) {
     console.log(`\x1b[32m✓\x1b[0m ${gwTest.message}`);
-
-    // Fix OpenClaw 2026.2.19 bootstrap bug: gateway device has insufficient scopes
-    const scopeFix = fixGatewayDeviceScopes();
-    let needsGatewayRestart = scopeFix.ok && scopeFix.needsRestart;
-
-    // Pre-pair Nerve's device identity so it can connect without manual approval
-    const pairResult = prePairNerveDevice(config.GATEWAY_TOKEN);
-    if (pairResult.ok && pairResult.needsRestart) {
-      needsGatewayRestart = true;
-      dim(`  ${pairResult.message}`);
-    }
-
-    if (needsGatewayRestart) {
-      dim('  Restarting gateway to apply device changes...');
-      const restart = restartGateway();
-      if (restart.ok) {
-        // Wait for gateway to come back up
-        await new Promise(r => setTimeout(r, 3000));
-        const approved = approveAllPendingDevices();
-        if (approved.ok && approved.approved > 0) {
-          success(`${approved.message}`);
-        }
-        success('Gateway device configuration updated — Nerve will connect automatically');
-      }
-    }
   } else {
     console.log(`\x1b[31m✗\x1b[0m ${gwTest.message}`);
     dim('  Start it with: openclaw gateway start');
@@ -402,15 +470,7 @@ async function collectInteractive(
   } else if (accessMode === 'network') {
     config.HOST = '0.0.0.0';
     // Auto-detect LAN IP
-    const detectedIp = (() => {
-      const nets = networkInterfaces();
-      for (const addrs of Object.values(nets)) {
-        for (const addr of addrs ?? []) {
-          if (!addr.internal && addr.family === 'IPv4') return addr.address;
-        }
-      }
-      return null;
-    })();
+    const detectedIp = detectPrimaryIpv4();
     const lanIp = await input({
     theme: promptTheme,
       message: 'Your LAN IP address',
@@ -504,73 +564,52 @@ async function collectInteractive(
     }
   }
 
-  // ── Patch gateway for external access ─────────────────────────────
+  // ── Gateway config updates ─────────────────────────────────────────
 
-  if (accessMode !== 'local') {
-    const nervePort = config.PORT || DEFAULTS.PORT;
-    // Extract the real IP — 0.0.0.0 isn't a valid origin for browsers
-    let accessIp = config.HOST === '0.0.0.0'
-      ? (config.ALLOWED_ORIGINS?.split(',')[0]?.replace(/^https?:\/\//, '').replace(/:\d+$/, '') || '0.0.0.0')
-      : (config.HOST || 'localhost');
-    if (accessIp === '0.0.0.0') {
-      // Detect actual LAN IP as fallback
-      const nets = networkInterfaces();
-      for (const addrs of Object.values(nets)) {
-        for (const addr of addrs ?? []) {
-          if (!addr.internal && addr.family === 'IPv4') { accessIp = addr.address; break; }
-        }
-        if (accessIp !== '0.0.0.0') break;
-      }
-    }
-    const nerveOrigin = `http://${accessIp}:${nervePort}`;
-    const sslPort = config.SSL_PORT;
-    const nerveHttpsOrigin = sslPort ? `https://${accessIp}:${sslPort}` : null;
+  const { nerveOrigin, nerveHttpsOrigin } = computeGatewayOrigins(config, accessMode);
 
+  const neededChanges = detectNeededConfigChanges({
+    nerveOrigin,
+    nerveHttpsOrigin,
+    gatewayToken: config.GATEWAY_TOKEN,
+  });
+
+  if (neededChanges.length > 0) {
     console.log('');
-    warn('External access requires updating the OpenClaw gateway config.');
-    dim('Without this, the gateway will reject WebSocket connections from Nerve.');
+    warn('Nerve needs to update your OpenClaw gateway config.');
+    dim('OpenClaw config files will be updated.');
     console.log('');
-    dim('  This will:');
-    dim(`  1. Add ${nerveOrigin} to gateway.controlUi.allowedOrigins`);
-    if (nerveHttpsOrigin) {
-      dim(`  2. Add ${nerveHttpsOrigin} to gateway.controlUi.allowedOrigins`);
-    }
-    dim(`  Config file: ~/.openclaw/openclaw.json`);
-    dim('  Note: The gateway stays on loopback — Nerve proxies all connections.');
+    dim('The following changes are needed:');
+    neededChanges.forEach((change, i) => {
+      dim(`  ${i + 1}. ${change.description}`);
+    });
     console.log('');
 
-    const patchGateway = await confirm({
+    const applyChanges = await confirm({
       theme: promptTheme,
-      message: 'Update OpenClaw gateway config to allow Nerve connections?',
+      message: 'Apply these changes?',
       default: true,
     });
 
-    if (patchGateway) {
-      const httpResult = patchGatewayAllowedOrigins(nerveOrigin);
-      if (httpResult.ok) {
-        success(httpResult.message);
-      } else {
-        warn(httpResult.message);
-        dim('You can manually add the origin to gateway.controlUi.allowedOrigins in ~/.openclaw/openclaw.json');
-      }
-      if (nerveHttpsOrigin) {
-        const httpsResult = patchGatewayAllowedOrigins(nerveHttpsOrigin);
-        if (httpsResult.ok) {
-          success(httpsResult.message);
-        } else {
-          warn(httpsResult.message);
+    if (applyChanges) {
+      await applyConfigChanges(neededChanges);
+    } else {
+      warn('Skipped gateway config changes. Some features may not work:');
+      for (const change of neededChanges) {
+        if (change.id === 'device-scopes') {
+          dim('  • Device scopes: manually fix scopes in ~/.openclaw/devices/paired.json');
+        } else if (change.id === 'pre-pair') {
+          dim('  • Pre-pair: run `openclaw devices approve` after starting Nerve');
+        } else if (change.id === 'tools-allow') {
+          dim('  • Cron tools: add "cron" to gateway.tools.allow in ~/.openclaw/openclaw.json');
+        } else if (change.id === 'allowed-origins' && nerveOrigin) {
+          dim(`  • Origins: add ${nerveOrigin} to gateway.controlUi.allowedOrigins in ~/.openclaw/openclaw.json`);
+        } else if (change.id === 'allowed-origins-https' && nerveHttpsOrigin) {
+          dim(`  • Origins: add ${nerveHttpsOrigin} to gateway.controlUi.allowedOrigins in ~/.openclaw/openclaw.json`);
+        } else if (change.id.startsWith('allowed-origins')) {
+          dim('  • Origins: add the required origin(s) to gateway.controlUi.allowedOrigins in ~/.openclaw/openclaw.json');
         }
       }
-      // Auto-restart gateway to apply changes
-      const restartResult = restartGateway();
-      if (restartResult.ok) {
-        success(restartResult.message);
-      } else {
-        warn(restartResult.message);
-      }
-    } else {
-      warn('Skipped — you may see "origin not allowed" errors in Nerve.');
-      dim('To fix later, add the origin to gateway.controlUi.allowedOrigins in ~/.openclaw/openclaw.json');
     }
   }
 
@@ -964,6 +1003,21 @@ async function runDefaults(existing: EnvConfig): Promise<void> {
 
   success('Configuration written to .env');
   printSummary(config);
+
+  // Apply all gateway config patches silently (non-interactive = implicit consent)
+  const defaultsAccessMode = isLoopback(config.HOST || '') ? 'local' : 'network';
+  const { nerveOrigin, nerveHttpsOrigin } = computeGatewayOrigins(config, defaultsAccessMode);
+
+  const changes = detectNeededConfigChanges({
+    nerveOrigin,
+    nerveHttpsOrigin,
+    gatewayToken: config.GATEWAY_TOKEN,
+  });
+
+  if (changes.length > 0) {
+    await applyConfigChanges(changes);
+  }
+
   console.log('');
 }
 


### PR DESCRIPTION
## Summary

Addresses **#13** — OpenClaw v2026.2.23 denies `cron`/`gateway` tools on `/tools/invoke` by default, breaking Nerve's cron management UI.

## Changes

### New: `gateway.tools.allow` patch
- Adds `patchGatewayToolsAllow()` to ensure `"cron"` is in `gateway.tools.allow` in `~/.openclaw/openclaw.json`
- Idempotent — skips if already present

### Bundled config consent prompt
Previously, some OpenClaw config modifications ran silently (device scopes, pre-pairing) while others asked for permission (allowed origins). Now **all** config changes are bundled into one explicit consent prompt:

```
⚠ Nerve needs to update your OpenClaw gateway config.
  OpenClaw config files will be updated.

  The following changes are needed:
    1. Fix gateway device scopes (required for Nerve to connect)
    2. Pre-pair Nerve device identity (skip manual approval step)
    3. Allow cron tool on /tools/invoke (needed for cron management)
    4. Add http://192.168.1.5:3001 to allowed origins (needed for WebSocket)

  ? Apply these changes? (Y/n)
```

One yes/no decision. Declining shows per-change manual fix instructions.

### `--defaults` mode
Non-interactive mode applies all patches silently (implicit consent). Now correctly computes and patches origins for network-mode installs.

### Architecture
- **Detection layer**: `detectNeededConfigChanges()` checks what needs changing without applying — powers the dynamic bullet list
- **Shared apply helper**: `applyConfigChanges()` used by both interactive and defaults flows — no code duplication
- **`computeGatewayOrigins()`** + **`detectPrimaryIpv4()`**: extracted helpers for origin computation
- **Single gateway restart** after all patches applied
- **Scoped approval**: `approveAllPendingDevices()` only runs when device-related changes were applied
- **JSON-first parsing** in `approveAllPendingDevices()` with box-drawing table fallback

### Other fixes
- Help text updated from 5 to 6 steps (was missing Authentication)
- Detection handles fresh installs correctly (pre-pair always included when device-scopes needed)
- Custom bind IPs in defaults mode correctly treated as network mode

## Review history
This PR went through 4 review passes (Sonnet 4.5, Codex 5.3 ×2, Opus 4.6) with two rounds of fixes.

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gateway supports configurable tool permissions (adds cron).
  * Detection of needed gateway config changes with preview and apply workflow; defaults mode can auto-apply.

* **Bug Fixes**
  * More reliable pending-device approval parsing with JSON-first fallback.

* **Refactor**
  * Consolidated gateway configuration handling and unified apply flow in setup.

* **Documentation**
  * Added comprehensive installer steps and behavior reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->