### PR TITLE
feat: auto-allow remote gateway hostname in WS proxy

### DIFF
--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -362,6 +362,21 @@ async function collectInteractive(
     }
   }
 
+  // Auto-add WS_ALLOWED_HOSTS for remote gateways
+  try {
+    const gwHostname = new URL(config.GATEWAY_URL!).hostname;
+    if (!isLoopback(gwHostname)) {
+      config.WS_ALLOWED_HOSTS = config.WS_ALLOWED_HOSTS
+        ? (config.WS_ALLOWED_HOSTS.includes(gwHostname) ? config.WS_ALLOWED_HOSTS : `${config.WS_ALLOWED_HOSTS},${gwHostname}`)
+        : gwHostname;
+      success(`Added ${gwHostname} to WS_ALLOWED_HOSTS`);
+      console.log('');
+      warn('Remote gateway detected. On the gateway host, ensure Nerve\'s origin is in');
+      dim('  gateway.controlUi.allowedOrigins in your OpenClaw config (~/.openclaw/openclaw.json).');
+      console.log('');
+    }
+  } catch { /* invalid URL — already validated above */ }
+
   // ── 2/5: Agent Identity ──────────────────────────────────────────
 
   section(2, TOTAL_SECTIONS, 'Agent Identity');
@@ -980,6 +995,18 @@ async function runDefaults(existing: EnvConfig): Promise<void> {
   if (!config.AGENT_NAME) config.AGENT_NAME = DEFAULTS.AGENT_NAME;
   if (!config.PORT) config.PORT = DEFAULTS.PORT;
   if (!config.HOST) config.HOST = DEFAULTS.HOST;
+
+  // Auto-add WS_ALLOWED_HOSTS for remote gateways
+  try {
+    const gwHostname = new URL(config.GATEWAY_URL).hostname;
+    if (!isLoopback(gwHostname)) {
+      config.WS_ALLOWED_HOSTS = config.WS_ALLOWED_HOSTS
+        ? (config.WS_ALLOWED_HOSTS.includes(gwHostname) ? config.WS_ALLOWED_HOSTS : `${config.WS_ALLOWED_HOSTS},${gwHostname}`)
+        : gwHostname;
+      success(`Added ${gwHostname} to WS_ALLOWED_HOSTS`);
+      warn('Remote gateway: ensure Nerve\'s origin is in gateway.controlUi.allowedOrigins on the gateway host.');
+    }
+  } catch { /* invalid URL — will fail later at connection test */ }
 
   // Auth: auto-enable when network-exposed with gateway token, generate session secret
   if (!config.NERVE_SESSION_SECRET) {

--- a/server/lib/config.ts
+++ b/server/lib/config.ts
@@ -80,9 +80,15 @@ export const config = {
 /** Session cookie name — suffixed with port to avoid collisions when running multiple instances. */
 export const SESSION_COOKIE_NAME = `nerve_session_${config.port}`;
 
+/** Hostname extracted from GATEWAY_URL so the WS proxy can connect to remote gateways. */
+const gatewayHostname = (() => {
+  try { return new URL(config.gatewayUrl).hostname; } catch { return null; }
+})();
+
 /** WebSocket proxy allowed hostnames (extend via WS_ALLOWED_HOSTS env var, comma-separated) */
 export const WS_ALLOWED_HOSTS = new Set([
   'localhost', '127.0.0.1', '::1',
+  ...(gatewayHostname ? [gatewayHostname] : []),
   ...(process.env.WS_ALLOWED_HOSTS?.split(',').map(h => h.trim()).filter(Boolean) ?? []),
 ]);
 
@@ -157,6 +163,14 @@ export function validateConfig(): void {
       '\n  \x1b[33m⚠ Server binds to 0.0.0.0 with authentication DISABLED.\x1b[0m\n' +
       '  All API endpoints are accessible from the network without a password.\n' +
       '  Run \x1b[36mnpm run setup\x1b[0m to enable authentication.\n',
+    );
+  }
+
+  // Remote gateway warning
+  if (gatewayHostname && gatewayHostname !== 'localhost' && gatewayHostname !== '127.0.0.1' && gatewayHostname !== '::1') {
+    console.warn(
+      '[config] \u26a0 Remote gateway detected \u2014 workspace/memory panels will show local files only.\n' +
+      '         Workspace files live on the gateway host. Use SSHFS or wait for remote workspace support.',
     );
   }
 


### PR DESCRIPTION
Fixes issue #19 

**Problem**

When Nerve runs on a different machine than the OpenClaw gateway (e.g. Nerve on Mac, gateway on Raspberry Pi), the WS proxy rejects the connection with "target not allowed" because WS_ALLOWED_HOSTS only includes localhost, 127.0.0.1, and ::1.

**Changes**

server/lib/config.ts

• Extract hostname from GATEWAY_URL and auto-add it to WS_ALLOWED_HOSTS
• No change for localhost setups (no regression)

scripts/setup.ts

• When user enters a non-localhost gateway URL, auto-write WS_ALLOWED_HOSTS to .env
• Print warning about gateway.controlUi.allowedOrigins config needed on the gateway host

**Testing**

• Tested with Nerve on macOS connecting to OpenClaw gateway on Raspberry Pi (LAN)
• WS proxy connects without manual WS_ALLOWED_HOSTS config
• Localhost gateway setups unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic configuration of WebSocket connections based on gateway hostname during setup
  * Added advisory messaging when remote gateways are configured, indicating workspace and memory panels remain locally accessible only
  * Improved error handling to gracefully manage invalid gateway URLs during configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->