### PR TITLE
docs: updater documentation and v1.4.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [1.4.0] — 2026-02-26
+
+### Added
+- **`nerve update` command** — git-based updater with automatic rollback. Supports `--dry-run`, `--version`, `--rollback`, `--no-restart`, and `--verbose` flags. See [docs/UPDATING.md](docs/UPDATING.md).
+- Memory filenames are no longer restricted to `YYYY-MM-DD.md` format — any safe filename is accepted (PR #29).
+
+### Fixed
+- `git checkout` during updates now uses `--force` to handle dirty working trees.
+- `/api/version` endpoint is now public (required for updater health checks with auth enabled).
+
+---
+
+## [1.3.0] — 2026-02-18
 
 ### Added
 - Multilingual voice control across 12 languages: `en`, `zh`, `hi`, `es`, `fr`, `ar`, `bn`, `pt`, `ru`, `ja`, `de`, `tr`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -386,6 +386,26 @@ Applied in order in `app.ts`:
 | `services/whisper-local.ts` | Local whisper.cpp STT via `@fugood/whisper.node`. Singleton model context, auto-download from HuggingFace, GPU detection |
 | `services/claude-usage.ts` | Claude Code CLI usage/limits parser via node-pty |
 
+### Updater (`server/lib/updater/`)
+
+Self-update system invoked via `npm run update` (entrypoint: `bin/nerve-update.ts` → `bin-dist/bin/nerve-update.js`).
+
+| File | Purpose |
+|------|---------|
+| `orchestrator.ts` | State machine: lock → preflight → resolve → snapshot → update → build → restart → health → rollback |
+| `preflight.ts` | Validates git, Node.js, npm versions and git repo state |
+| `release-resolver.ts` | Finds latest semver tag via `git ls-remote --tags`, falls back to local tags |
+| `snapshot.ts` | Saves current git ref, version, and `.env` backup to `~/.nerve/updater/` |
+| `installer.ts` | `git fetch + checkout --force`, `npm install`, `npm run build + build:server` |
+| `service-manager.ts` | Auto-detects systemd or launchd, provides restart/status/logs |
+| `health.ts` | Polls `/health` and `/api/version` with exponential backoff (60s deadline) |
+| `rollback.ts` | Restores snapshot ref, clean rebuilds, restarts service |
+| `lock.ts` | PID-based exclusive lock file (`wx` flag) with stale detection |
+| `reporter.ts` | Formatted terminal output with stage progress, colors, and dry-run markers |
+| `types.ts` | Shared types, exit codes, `UpdateError` class |
+
+Compiled separately via `config/tsconfig.bin.json` to avoid changing the server's `rootDir`.
+
 ---
 
 ## Data Flow
@@ -490,6 +510,7 @@ Project references with four configs:
 - `config/tsconfig.node.json` — Vite/build tooling
 - `config/tsconfig.server.json` — Backend (server/) → compiled to `server-dist/`
 - `config/tsconfig.scripts.json` — Setup scripts
+- `config/tsconfig.bin.json` — CLI tools (bin/) → compiled to `bin-dist/`
 
 ---
 
@@ -504,22 +525,18 @@ npm run test:coverage # With V8 coverage
 
 ### Test Files
 
-| Test | Coverage |
-|------|----------|
-| `src/hooks/useWebSocket.test.ts` | WebSocket connection, RPC, reconnection |
-| `src/hooks/useServerEvents.test.ts` | SSE client |
-| `src/features/tts/useTTS.test.ts` | TTS hook behavior |
-| `src/features/voice/useVoiceInput.test.ts` | Voice input |
-| `src/features/voice/audio-feedback.test.ts` | Audio feedback |
-| `src/features/sessions/unreadSessions.test.ts` | Unread tracking |
-| `src/lib/formatting.test.ts` | Message formatting |
-| `src/lib/constants.test.ts` | Constants validation |
-| `src/lib/sanitize.test.ts` | HTML sanitization |
-| `src/lib/voice-prefix.test.ts` | Voice prefix parsing |
-| `server/routes/health.test.ts` | Health endpoint |
-| `server/services/tts-cache.test.ts` | TTS cache LRU/TTL |
-| `server/middleware/rate-limit.test.ts` | Rate limiting |
-| `server/lib/mutex.test.ts` | Async mutex |
+48 test files, 692 tests. Key areas:
+
+| Area | Files | Coverage |
+|------|-------|----------|
+| Server lib | `config`, `device-identity`, `env-file`, `gateway-client`, `mutex`, `voice-language-coverage`, `ws-proxy` | Auth, config resolution, WS proxy relay, device identity signing |
+| Server routes | `auth`, `events`, `files`, `gateway`, `health`, `sessions`, `skills` | API endpoints, error handling, gateway proxy |
+| Server middleware | `auth`, `error-handler`, `rate-limit`, `security-headers` | Request pipeline |
+| Chat operations | `sendMessage`, `streamEventHandler`, `loadHistory`, `mergeRecoveredTail` | Message lifecycle, streaming, history recovery |
+| Client features | `extractCharts`, `extractImages`, `edit-blocks`, `MarkdownRenderer`, `ContextMeter`, `ErrorBoundary`, `sessionTree` | Rendering, parsing, UI components |
+| Hooks | `useAuth`, `useInputHistory`, `useKeyboardShortcuts`, `useServerEvents`, `useTTS` | Client-side state and interaction |
+| Voice/audio | `audio-feedback`, `useVoiceInput`, `voice-prefix` | Voice input, TTS, wake/stop phrase parsing |
+| Utilities | `constants`, `formatting`, `sanitize`, `unreadSessions` | Shared logic |
 
 ### Configuration
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -241,6 +241,17 @@ TTS_CACHE_TTL_MS=7200000
 TTS_CACHE_MAX=500
 ```
 
+### Updater State
+
+The updater stores state in `~/.nerve/updater/`. These are not configurable via env vars — they're managed automatically by `npm run update`.
+
+| Path | Purpose |
+|------|---------|
+| `~/.nerve/updater/last-good.json` | Snapshot of the last successful state (git ref, version, env hash) |
+| `~/.nerve/updater/last-run.json` | Result metadata from the most recent update attempt |
+| `~/.nerve/updater/snapshots/<ts>/.env` | Timestamped `.env` backups (mode 0600) |
+| `~/.nerve/updater/nerve-update.lock` | PID lock file (prevents concurrent updates) |
+
 ### Development
 
 | Variable | Description |

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Use this folder as the docs hub for Nerve.
 - [API](./API.md)
 - [Security](./SECURITY.md)
 - [Troubleshooting](./TROUBLESHOOTING.md)
+- [Updating](./UPDATING.md)
 - [Installer Steps](./INSTALLER-STEPS.md)
 - [Agent Markers](./AGENT-MARKERS.md)
 - [Code Review](./CODE_REVIEW.md)

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -548,8 +548,62 @@ test: {
 
 ---
 
+## Update & Rollback
+
+See [docs/UPDATING.md](UPDATING.md) for the full updater reference.
+
+### "No semver tags found on remote"
+
+**Symptom:** `npm run update` fails at version resolution (exit 20).
+
+**Cause:** No tags on the remote, or git can't reach origin.
+
+**Fix:**
+```bash
+git remote -v              # Verify origin
+git fetch --tags origin    # Pull tags
+git tag -l                 # Confirm tags exist locally
+```
+
+### Update stuck or "Lock acquisition failure" (exit 80)
+
+**Symptom:** Update refuses to start, says another update is running.
+
+**Cause:** A previous update crashed without releasing the lock.
+
+**Fix:**
+```bash
+cat ~/.nerve/updater/nerve-update.lock   # Shows the PID
+ps -p <pid>                               # Check if alive
+rm ~/.nerve/updater/nerve-update.lock     # Remove if stale
+```
+
+### Health check version mismatch (exit 60)
+
+**Symptom:** Update completes build and restart, but health check says wrong version.
+
+**Cause:** The old server process didn't release the port, or systemd hasn't fully restarted.
+
+**Fix:**
+```bash
+systemctl restart nerve
+curl http://127.0.0.1:3080/api/version   # Verify version
+```
+
+### Rollback failed (exit 70)
+
+**Symptom:** Both update and automatic rollback failed. Critical state.
+
+**Fix:** Manual recovery:
+```bash
+cat ~/.nerve/updater/last-good.json       # Get snapshot ref
+git checkout --force <ref>
+npm install && npm run build && npm run build:server
+systemctl restart nerve
+```
+
+---
+
 ## Known Limitations
 
-### Desktop browsers only
-
-Nerve is designed for desktop browsers. There is no mobile-responsive layout yet. On phones and tablets the UI will be unusable or heavily clipped. This is a known gap, tracked in [#107](https://github.com/daggerhashimoto/openclaw-nerve/issues/107).
+None currently tracked.

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -1,0 +1,173 @@
+# Updating Nerve
+
+Nerve ships a built-in updater that pulls the latest release from GitHub, rebuilds, restarts the service, and verifies health — all in one command.
+
+## Quick start
+
+```bash
+npm run update -- --yes
+```
+
+This will:
+1. Check prerequisites (git, Node.js, npm)
+2. Resolve the latest version from remote tags
+3. Snapshot the current state for rollback
+4. `git fetch --tags && git checkout <tag>`
+5. `npm install && npm run build && npm run build:server`
+6. Restart the systemd/launchd service
+7. Verify `/health` and `/api/version` match the target
+
+## CLI flags
+
+| Flag | Description |
+|------|-------------|
+| `--version <vX.Y.Z>` | Pin to a specific version instead of latest |
+| `--yes`, `-y` | Skip the confirmation prompt |
+| `--dry-run` | Show what would happen without making changes |
+| `--verbose`, `-v` | Extra logging (git commands, service detection) |
+| `--rollback` | Restore the last-known-good snapshot |
+| `--no-restart` | Skip service restart and health checks |
+| `--help`, `-h` | Show help |
+
+## Examples
+
+```bash
+# Preview what an update would do
+npm run update -- --dry-run
+
+# Update to a specific version
+npm run update -- --version v1.4.0 --yes
+
+# Rollback to the previous version
+npm run update -- --rollback
+
+# Update without restarting (e.g. to restart manually)
+npm run update -- --yes --no-restart
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Already up to date |
+| 10 | Preflight failure (missing git/node/npm) |
+| 20 | Version resolution failure (tag not found, no remote tags) |
+| 40 | Build failure (npm install or build step) |
+| 50 | Service restart failure |
+| 60 | Health check failure (service unhealthy or version mismatch) |
+| 70 | Rollback failure (critical — manual intervention needed) |
+| 80 | Lock acquisition failure (another update is running) |
+
+## How it works
+
+### Update flow
+
+```
+lock → preflight → resolve → confirm → snapshot → git checkout
+  → npm install + build → restart → health check → done
+```
+
+Each stage has a dedicated exit code. If any stage after snapshot fails, the updater attempts an automatic rollback.
+
+### Snapshots
+
+Before making changes, the updater saves:
+- The current git ref (commit hash)
+- The current version from `package.json`
+- A SHA-256 hash of `.env`
+- A timestamped backup of `.env`
+
+Snapshots are stored in `~/.nerve/updater/`. The `.env` file is **never overwritten** during an update — only backed up.
+
+### Rollback
+
+Rollback restores the snapshot ref, cleans `node_modules`, rebuilds, and restarts the service. It runs automatically on build/restart/health failures, or manually via `--rollback`.
+
+The rollback flow:
+1. `git checkout --force <snapshot-ref>`
+2. Remove `node_modules` (clean slate)
+3. `npm install && npm run build && npm run build:server`
+4. Restart and verify the service
+
+### Health checks
+
+After restart, the updater polls:
+- `GET /health` — must return 2xx
+- `GET /api/version` — must report the target version
+
+Retries with exponential backoff (2s, 4s, 8s) up to a 60-second deadline. If the version doesn't match, the updater assumes the old process is still serving and triggers rollback.
+
+### Locking
+
+A PID-based lock file prevents concurrent updates. The lock is acquired with `wx` (exclusive create) and released on exit. If a lock is stale (the PID no longer exists), it's automatically cleaned up.
+
+### Service detection
+
+The updater auto-detects the service manager:
+- **systemd** — `systemctl restart nerve`
+- **launchd** — `launchctl kickstart -k`
+
+If no service manager is found, the updater skips restart and prints manual start instructions.
+
+## State files
+
+| Path | Purpose |
+|------|---------|
+| `~/.nerve/updater/last-good.json` | Last-known-good snapshot |
+| `~/.nerve/updater/last-run.json` | Result of the most recent update attempt |
+| `~/.nerve/updater/snapshots/<timestamp>/.env` | Backed-up `.env` files |
+| `~/.nerve/updater/nerve-update.lock` | PID lock file |
+
+## Troubleshooting
+
+### "No semver tags found on remote"
+
+The updater reads tags via `git ls-remote --tags origin`. If no tags exist on the remote, it falls back to local tags. If both are empty, it fails with exit code 20.
+
+**Fix:** Ensure you cloned from the official repo and tags have been pushed:
+```bash
+git remote -v              # Verify origin points to the right repo
+git fetch --tags origin    # Pull any missing tags
+```
+
+### "Lock acquisition failure" (exit 80)
+
+Another update process is running, or a stale lock file exists.
+
+**Fix:** Check if an update is actually running:
+```bash
+cat ~/.nerve/updater/nerve-update.lock   # Shows the PID
+ps -p <pid>                               # Check if it's alive
+```
+
+If the process is gone, the lock is stale — delete it:
+```bash
+rm ~/.nerve/updater/nerve-update.lock
+```
+
+### Health check fails with version mismatch
+
+The service restarted but `/api/version` reports the old version.
+
+**Causes:**
+- The old process didn't shut down cleanly (port still bound)
+- systemd started the service before the build finished
+
+**Fix:** Restart manually and check:
+```bash
+systemctl restart nerve
+curl http://127.0.0.1:3080/api/version
+```
+
+### Build failure after checkout
+
+`npm install` or `npm run build` failed on the new version.
+
+**Fix:** The updater will attempt automatic rollback. If rollback also fails (exit 70), restore manually:
+```bash
+cat ~/.nerve/updater/last-good.json           # Get the snapshot ref
+git checkout --force <ref>
+npm install && npm run build && npm run build:server
+systemctl restart nerve
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-nerve",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-nerve",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Changes

### New
- **`docs/UPDATING.md`** — Full updater reference: CLI flags, exit codes, update flow, snapshots, rollback, health checks, locking, service detection, state files, and troubleshooting.

### Updated
- **`CHANGELOG.md`** — Cut v1.4.0 release section (updater command + memory filename fix). Moved existing entries under v1.3.0.
- **`docs/ARCHITECTURE.md`** — Added updater module table (12 source files), `tsconfig.bin.json` in TypeScript config list, refreshed test file inventory (14 → 48 files, grouped by area).
- **`docs/CONFIGURATION.md`** — Added "Updater State" section documenting `~/.nerve/updater/` paths.
- **`docs/TROUBLESHOOTING.md`** — Added "Update & Rollback" section (4 failure scenarios with fixes). Removed stale "desktop browsers only" limitation.
- **`docs/README.md`** — Added UPDATING.md link to docs index.

### Context
Follows the merge and successful testing of the git-based updater (Phase 1). All documentation written against the tested v1.3.0 → v1.4.0 upgrade flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added update command with rollback, dry-run, version pinning, and verbose modes.
  * Extended memory filename support beyond date format.
  * Exposed /api/version endpoint for health checks.

* **Bug Fixes**
  * Improved git checkout reliability during updates for dirty working trees.

* **Documentation**
  * Added comprehensive update workflow guide with examples and troubleshooting steps.
  * Enhanced troubleshooting with update and rollback recovery procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->