### PR TITLE
fix(setup): allow cron + gateway tools for HTTP invoke policy

### DIFF
--- a/docs/INSTALLER-STEPS.md
+++ b/docs/INSTALLER-STEPS.md
@@ -201,7 +201,7 @@ After `.env` is written, the setup wizard detects and applies pending OpenClaw g
 #### Possible changes detected:
 1. **Device scopes** — bootstraps `~/.openclaw/devices/paired.json` with full operator scopes if missing or incomplete
 2. **Pre-pair Nerve device** — registers Nerve's Ed25519 identity in `paired.json` so it can connect without manual `openclaw devices approve`
-3. **Tools allow** — adds `"cron"` to `gateway.tools.allow` in `~/.openclaw/openclaw.json` (required for OpenClaw ≥2026.2.23 which denies cron on `/tools/invoke` by default)
+3. **Tools allow** — adds `"cron"` and `"gateway"` to `gateway.tools.allow` in `~/.openclaw/openclaw.json` (required for OpenClaw ≥2026.2.23 which denies these tools on `/tools/invoke` by default)
 4. **Allowed origins** — adds Nerve's HTTP/HTTPS origins to `gateway.controlUi.allowedOrigins` (network access modes only)
 
 #### Interactive mode:

--- a/scripts/lib/gateway-detect.ts
+++ b/scripts/lib/gateway-detect.ts
@@ -146,9 +146,11 @@ export function patchGatewayAllowedOrigins(origin: string): GatewayPatchResult {
   }
 }
 
+const REQUIRED_HTTP_TOOLS = ['cron', 'gateway'] as const;
+
 /**
- * Patch the OpenClaw gateway config to allow the cron tool.
- * Adds 'cron' to gateway.tools.allow (deduped).
+ * Patch the OpenClaw gateway config to allow required HTTP tools.
+ * Adds missing entries in `gateway.tools.allow` (deduped).
  * Returns a result indicating success/failure.
  */
 export function patchGatewayToolsAllow(): GatewayPatchResult {
@@ -166,19 +168,19 @@ export function patchGatewayToolsAllow(): GatewayPatchResult {
     config.gateway = config.gateway || {};
     config.gateway.tools = config.gateway.tools || {};
     const allow = Array.isArray(config.gateway.tools.allow) ? config.gateway.tools.allow : [];
+    const missing = REQUIRED_HTTP_TOOLS.filter(tool => !allow.includes(tool));
 
-    if (allow.includes('cron')) {
+    if (missing.length === 0) {
       result.ok = true;
-      result.message = 'cron already in gateway.tools.allow';
+      result.message = `${REQUIRED_HTTP_TOOLS.join(', ')} already in gateway.tools.allow`;
       return result;
     }
 
-    allow.push('cron');
-    config.gateway.tools.allow = allow;
+    config.gateway.tools.allow = [...allow, ...missing];
 
     writeFileSync(OPENCLAW_CONFIG, JSON.stringify(config, null, 2) + '\n');
     result.ok = true;
-    result.message = 'Added cron to gateway.tools.allow';
+    result.message = `Added ${missing.join(', ')} to gateway.tools.allow`;
     return result;
   } catch (err) {
     result.message = `Failed to patch config: ${err instanceof Error ? err.message : String(err)}`;
@@ -589,7 +591,7 @@ function needsPrePair(gatewayToken?: string): boolean {
 }
 
 /**
- * Detect whether gateway.tools.allow is missing the cron tool.
+ * Detect whether gateway.tools.allow is missing required HTTP tools.
  */
 function needsToolsAllow(): boolean {
   if (!existsSync(OPENCLAW_CONFIG)) return false;
@@ -597,8 +599,8 @@ function needsToolsAllow(): boolean {
   try {
     const raw = readFileSync(OPENCLAW_CONFIG, 'utf-8');
     const config = JSON.parse(raw) as OpenClawConfig;
-    const allow = config.gateway?.tools?.allow || [];
-    return !allow.includes('cron');
+    const allow = Array.isArray(config.gateway?.tools?.allow) ? config.gateway.tools.allow : [];
+    return REQUIRED_HTTP_TOOLS.some(tool => !allow.includes(tool));
   } catch {
     return false;
   }
@@ -654,7 +656,7 @@ export function detectNeededConfigChanges(opts: {
   if (needsToolsAllow()) {
     changes.push({
       id: 'tools-allow',
-      description: 'Allow cron tool on /tools/invoke (needed for cron management)',
+      description: 'Allow cron + gateway tools on /tools/invoke (needed for cron and gateway management)',
       apply: () => {
         const r = patchGatewayToolsAllow();
         return { ok: r.ok, message: r.message, needsRestart: r.ok };

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -601,7 +601,7 @@ async function collectInteractive(
         } else if (change.id === 'pre-pair') {
           dim('  • Pre-pair: run `openclaw devices approve` after starting Nerve');
         } else if (change.id === 'tools-allow') {
-          dim('  • Cron tools: add "cron" to gateway.tools.allow in ~/.openclaw/openclaw.json');
+          dim('  • HTTP tools: add "cron" and "gateway" to gateway.tools.allow in ~/.openclaw/openclaw.json');
         } else if (change.id === 'allowed-origins' && nerveOrigin) {
           dim(`  • Origins: add ${nerveOrigin} to gateway.controlUi.allowedOrigins in ~/.openclaw/openclaw.json`);
         } else if (change.id === 'allowed-origins-https' && nerveHttpsOrigin) {


### PR DESCRIPTION
Fixes #17

OpenClaw 2026.2.23+ applies a separate HTTP-layer tools policy on `/tools/invoke`. The setup wizard previously patched only `cron`, but Nerve also needs `gateway` for gateway-related actions.

### Changes
- `scripts/lib/gateway-detect.ts`
  - Added `REQUIRED_HTTP_TOOLS = ['cron', 'gateway']`
  - `patchGatewayToolsAllow()` now adds whichever required tools are missing
  - `needsToolsAllow()` now checks for any missing required tool and guards with `Array.isArray`
- `scripts/setup.ts`
  - Updated manual fallback hint to mention both `cron` and `gateway`
- `docs/INSTALLER-STEPS.md`
  - Updated setup patching docs to match actual behavior

### Validation
- `npx tsc -b --noEmit`
- `npm run lint` (no errors; existing warnings only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation & Bug Fixes**
  * Updated setup process to configure both "cron" and "gateway" tools as explicitly required for OpenClaw >=2026.2.23.
  * Updated installer documentation and user-facing messages to reflect the expanded tool allowance requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->