### PR TITLE
fix(skills): fail loud on CLI errors and parse warning-prefixed JSON

### DIFF
--- a/server/routes/skills.test.ts
+++ b/server/routes/skills.test.ts
@@ -37,12 +37,13 @@ vi.mock('../lib/openclaw-bin.js', () => ({
   resolveOpenclawBin: () => '/usr/bin/openclaw',
 }));
 
-const GOOD_SKILLS_JSON = JSON.stringify({
-  skills: [
-    { name: 'weather', description: 'Get weather', emoji: '🌤️', eligible: true, disabled: false, blockedByAllowlist: false, source: 'bundled', bundled: true },
-    { name: 'github', description: 'GitHub ops', emoji: '🐙', eligible: true, disabled: false, blockedByAllowlist: false, source: 'bundled', bundled: true },
-  ],
-});
+const RAW_SKILLS = [
+  { name: 'weather', description: 'Get weather', emoji: '🌤️', eligible: true, disabled: false, blockedByAllowlist: false, source: 'bundled', bundled: true },
+  { name: 'github', description: 'GitHub ops', emoji: '🐙', eligible: true, disabled: false, blockedByAllowlist: false, source: 'bundled', bundled: true },
+];
+
+const GOOD_SKILLS_JSON = JSON.stringify({ skills: RAW_SKILLS });
+const GOOD_SKILLS_ARRAY_JSON = JSON.stringify(RAW_SKILLS);
 
 import skillsRoutes from './skills.js';
 
@@ -84,6 +85,35 @@ describe('GET /api/skills', () => {
     const json = (await res.json()) as { ok: boolean; skills: Array<{ name: string }> };
     expect(json.ok).toBe(true);
     expect(json.skills).toHaveLength(2);
+  });
+
+  it('parses skills when warning prelude contains bracket characters', async () => {
+    execFileImpl = (_bin, _args, _opts, cb) => {
+      cb(null, `[warn] duplicate plugin id\n${GOOD_SKILLS_JSON}`, '');
+    };
+
+    const app = buildApp();
+    const res = await app.request('/api/skills');
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean; skills: Array<{ name: string }> };
+    expect(json.ok).toBe(true);
+    expect(json.skills).toHaveLength(2);
+  });
+
+  it('parses top-level skills array when warnings are printed before JSON', async () => {
+    execFileImpl = (_bin, _args, _opts, cb) => {
+      cb(null, `Config warnings: noisy prelude\n${GOOD_SKILLS_ARRAY_JSON}`, '');
+    };
+
+    const app = buildApp();
+    const res = await app.request('/api/skills');
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean; skills: Array<{ name: string }> };
+    expect(json.ok).toBe(true);
+    expect(json.skills).toHaveLength(2);
+    expect(json.skills[1].name).toBe('github');
   });
 
   it('fails loud when openclaw binary is missing', async () => {

--- a/server/routes/skills.ts
+++ b/server/routes/skills.ts
@@ -65,14 +65,22 @@ function extractJsonPayload(stdout: string): unknown {
     // Fall through to prelude-tolerant parsing.
   }
 
-  // OpenClaw can print warnings before JSON. Parse from first object start.
-  const jsonStart = trimmed.indexOf('{');
-  if (jsonStart >= 0) {
-    const candidate = trimmed.slice(jsonStart).trim();
+  // OpenClaw can print warnings before JSON.
+  // Try parsing from each possible JSON structure start ({ or [).
+  const startIndices: number[] = [];
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i];
+    if (ch === '{' || ch === '[') {
+      startIndices.push(i);
+    }
+  }
+
+  for (const start of startIndices) {
+    const candidate = trimmed.slice(start).trim();
     try {
       return JSON.parse(candidate);
     } catch {
-      // Fall through to explicit error below.
+      // Keep scanning for the next JSON structure start.
     }
   }
 


### PR DESCRIPTION
Closes #23
Closes #25
Closes #34

## Summary
`GET /api/skills` no longer returns a silent empty list on backend failure.

## Behavior changes
- CLI failure (`ENOENT`, timeout, exec error) now returns `502` with `{ ok: false, error }`
- Invalid JSON now returns `502` with `{ ok: false, error }`
- Warning text before JSON is tolerated by parsing from the first JSON object start
- Missing `skills` array in parsed payload now returns explicit error instead of `[]`

## Files
- `server/routes/skills.ts`
  - Added resilient output parsing (`extractJsonPayload`, `parseSkillsOutput`)
  - Switched from silent fallback (`[]`) to explicit error propagation
- `server/routes/skills.test.ts`
  - Updated route tests for fail-loud behavior
  - Added warning-prelude regression test
  - Added missing-skills-array failure test

## Validation
- `npx tsc -b --noEmit`
- `npx vitest run` (734 passing)
- `npm run lint` (no errors; existing warnings only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for the skills API with clearer error messages for missing binaries, invalid output, and malformed data.
  * Enhanced robustness of JSON parsing for skills output to tolerate warning text preceding JSON responses.

* **Tests**
  * Expanded test coverage for error scenarios including missing binaries, invalid JSON output, and malformed payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->