### PR TITLE
feat(update): resolve latest published release for installer/updater

### DIFF
--- a/docs/INSTALLER-STEPS.md
+++ b/docs/INSTALLER-STEPS.md
@@ -21,10 +21,12 @@ This makes it fail fast on command errors, unset variables, and pipeline failure
 It initializes defaults such as:
 
 - `INSTALL_DIR` (default `~/nerve`, overridable via `NERVE_INSTALL_DIR`)
-- `BRANCH` (default `master`)
+- `BRANCH` (default `master`, used only for explicit/fallback branch installs)
 - `REPO`
 - `NODE_MIN=22`
 - flags: `SKIP_SETUP`, `DRY_RUN`
+- `VERSION` (optional pinned release version)
+- `BRANCH_EXPLICIT` (tracks whether `--branch` was set)
 - `GATEWAY_TOKEN` (optional CLI override)
 - `ENV_MISSING` (tracks partial installs)
 
@@ -46,12 +48,15 @@ Defines output helpers (`ok`, `warn`, `fail`, `info`, `dry`) and utility functio
 Supported flags:
 
 - `--dir <path>`
-- `--branch <name>`
+- `--version <vX.Y.Z>`
+- `--branch <name>` (dev override; bypasses release-first flow)
 - `--repo <url>`
 - `--skip-setup`
 - `--dry-run`
 - `--gateway-token <token>`
 - `--help`
+
+`--version` and `--branch` are mutually exclusive.
 
 Unknown or malformed args exit with error.
 
@@ -108,14 +113,24 @@ The script runs these checks in order:
 
 ## 2) Stage 2/5 — Download
 
-### 2.1 Dry-run behavior
-- Prints what would happen (clone vs update).
+### 2.1 Target ref resolution (release-first)
+The installer resolves a target ref before clone/update:
 
-### 2.2 Real behavior
+1. If `--version` is provided: use that release tag (`vX.Y.Z`)
+2. Else if `--branch` is provided: use that branch
+3. Else (default): query GitHub Releases API for latest published release tag
+4. If release API fails: fallback to branch (`master` by default)
+
+### 2.2 Dry-run behavior
+- Prints target ref and what clone/update would do.
+
+### 2.3 Real behavior
 - If `INSTALL_DIR/.git` exists:
-  - `git pull origin <branch>`
-- Else:
-  - `git clone --branch <branch> --depth 1 <repo> <dir>`
+  - Branch mode: `git fetch origin <branch>` + checkout + hard reset to `origin/<branch>`
+  - Release mode: `git fetch --tags origin` + checkout `<tag>`
+- Else (fresh clone):
+  - Branch mode: `git clone --branch <branch> --depth 1 <repo> <dir>`
+  - Release mode: clone repo, fetch tags, checkout `<tag>`
 - Then `cd` into `INSTALL_DIR`.
 
 ---

--- a/docs/UPDATING.md
+++ b/docs/UPDATING.md
@@ -1,6 +1,6 @@
 # Updating Nerve
 
-Nerve ships a built-in updater that pulls the latest release from GitHub, rebuilds, restarts the service, and verifies health — all in one command.
+Nerve ships a built-in updater that pulls the latest published release from GitHub, rebuilds, restarts the service, and verifies health — all in one command.
 
 ## Quick start
 
@@ -10,7 +10,7 @@ npm run update -- --yes
 
 This will:
 1. Check prerequisites (git, Node.js, npm)
-2. Resolve the latest version from remote tags
+2. Resolve the latest published GitHub release (fallback: latest semver tag)
 3. Snapshot the current state for rollback
 4. `git fetch --tags && git checkout <tag>`
 5. `npm install && npm run build && npm run build:server`
@@ -52,7 +52,7 @@ npm run update -- --yes --no-restart
 | 0 | Success |
 | 1 | Already up to date |
 | 10 | Preflight failure (missing git/node/npm) |
-| 20 | Version resolution failure (tag not found, no remote tags) |
+| 20 | Version resolution failure (release/tag not found) |
 | 40 | Build failure (npm install or build step) |
 | 50 | Service restart failure |
 | 60 | Health check failure (service unhealthy or version mismatch) |
@@ -121,14 +121,15 @@ If no service manager is found, the updater skips restart and prints manual star
 
 ## Troubleshooting
 
-### "No semver tags found on remote"
+### "Could not fetch release or semver tags"
 
-The updater reads tags via `git ls-remote --tags origin`. If no tags exist on the remote, it falls back to local tags. If both are empty, it fails with exit code 20.
+The updater resolves versions from GitHub Releases first. If release lookup fails (network/rate limits), it falls back to semver tags. If both sources fail, it exits with code 20.
 
-**Fix:** Ensure you cloned from the official repo and tags have been pushed:
+**Fix:** Verify remote/release access and tags:
 ```bash
-git remote -v              # Verify origin points to the right repo
-git fetch --tags origin    # Pull any missing tags
+git remote -v                               # Verify origin points to the right repo
+git fetch --tags origin                     # Pull any missing tags
+curl -sSf https://api.github.com/repos/<owner>/<repo>/releases/latest | jq .tag_name
 ```
 
 ### "Lock acquisition failure" (exit 80)

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@
 #   curl -fsSL https://raw.githubusercontent.com/daggerhashimoto/openclaw-nerve/master/install.sh | bash
 #
 # Or with options:
+#   curl -fsSL ... | bash -s -- --dir ~/nerve --version v1.4.4
 #   curl -fsSL ... | bash -s -- --dir ~/nerve --branch main
 # ──────────────────────────────────────────────────────────────────────
 set -euo pipefail
@@ -29,6 +30,8 @@ trap cleanup EXIT
 # ── Defaults ──────────────────────────────────────────────────────────
 INSTALL_DIR="${NERVE_INSTALL_DIR:-${HOME}/nerve}"
 BRANCH="master"
+BRANCH_EXPLICIT=false
+VERSION=""
 REPO="https://github.com/daggerhashimoto/openclaw-nerve.git"
 NODE_MIN=22
 SKIP_SETUP=false
@@ -139,6 +142,61 @@ detect_gateway_token() {
   echo ""
 }
 
+normalize_version_tag() {
+  local raw="$1"
+  local normalized="${raw#v}"
+  if [[ "$normalized" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "v${normalized}"
+    return 0
+  fi
+  return 1
+}
+
+github_repo_path_from_url() {
+  local url="$1"
+  local path=""
+
+  if [[ "$url" =~ ^https://github.com/([^/]+)/([^/]+)(\.git)?$ ]]; then
+    path="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+  elif [[ "$url" =~ ^git@github.com:([^/]+)/([^/]+)(\.git)?$ ]]; then
+    path="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+  elif [[ "$url" =~ ^ssh://git@github.com/([^/]+)/([^/]+)(\.git)?$ ]]; then
+    path="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+  else
+    return 1
+  fi
+
+  path="${path%.git}"
+  echo "$path"
+}
+
+fetch_latest_release_tag() {
+  local repo_path
+  repo_path=$(github_repo_path_from_url "$REPO") || return 1
+
+  local api_url="https://api.github.com/repos/${repo_path}/releases/latest"
+  local response
+  local token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+
+  if [[ -n "$token" ]]; then
+    response=$(curl -fsSL \
+      -H "Accept: application/vnd.github+json" \
+      -H "User-Agent: nerve-installer" \
+      -H "Authorization: Bearer ${token}" \
+      "$api_url" 2>/dev/null) || return 1
+  else
+    response=$(curl -fsSL \
+      -H "Accept: application/vnd.github+json" \
+      -H "User-Agent: nerve-installer" \
+      "$api_url" 2>/dev/null) || return 1
+  fi
+
+  local tag
+  tag=$(printf '%s' "$response" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const j=JSON.parse(d);if(typeof j.tag_name==="string")process.stdout.write(j.tag_name);}catch{}});') || return 1
+
+  normalize_version_tag "$tag" || return 1
+}
+
 STAGE_CURRENT=0
 STAGE_TOTAL=5
 stage() {
@@ -158,7 +216,8 @@ stage_done() {
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dir)       [[ $# -ge 2 ]] || { echo "Missing value for --dir"; exit 1; }; INSTALL_DIR="$2"; shift 2 ;;
-    --branch)    [[ $# -ge 2 ]] || { echo "Missing value for --branch"; exit 1; }; BRANCH="$2"; shift 2 ;;
+    --branch)    [[ $# -ge 2 ]] || { echo "Missing value for --branch"; exit 1; }; BRANCH="$2"; BRANCH_EXPLICIT=true; shift 2 ;;
+    --version)   [[ $# -ge 2 ]] || { echo "Missing value for --version"; exit 1; }; VERSION="$2"; shift 2 ;;
     --repo)      [[ $# -ge 2 ]] || { echo "Missing value for --repo"; exit 1; }; REPO="$2"; shift 2 ;;
     --skip-setup) SKIP_SETUP=true; shift ;;
     --dry-run)    DRY_RUN=true; shift ;;
@@ -167,9 +226,10 @@ while [[ $# -gt 0 ]]; do
       echo "Nerve Installer"
       echo ""
       echo "Options:"
-      echo "  --dir <path>     Install directory (default: ~/nerve)"
-      echo "  --branch <name>  Git branch (default: master)"
-      echo "  --repo <url>     Git repo URL"
+      echo "  --dir <path>       Install directory (default: ~/nerve)"
+      echo "  --version <vX.Y.Z> Install a specific release version"
+      echo "  --branch <name>    Install from a branch (dev override; bypasses release mode)"
+      echo "  --repo <url>       Git repo URL"
       echo "  --skip-setup       Skip the interactive setup wizard"
       echo "  --gateway-token <t> Gateway token (for non-interactive installs)"
       echo "  --dry-run          Simulate the install without changing anything"
@@ -179,6 +239,11 @@ while [[ $# -gt 0 ]]; do
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
 done
+
+if [[ -n "$VERSION" && "$BRANCH_EXPLICIT" == "true" ]]; then
+  fail "Use either --version or --branch, not both"
+  exit 1
+fi
 
 # ── Detect interactive mode ───────────────────────────────────────────
 # When piped via curl | bash, stdin is the pipe — but /dev/tty still
@@ -439,21 +504,66 @@ check_gateway
 # ── [2/5] Clone or update ────────────────────────────────────────────
 stage "Download"
 
+TARGET_REF=""
+TARGET_REF_KIND=""
+if [[ -n "$VERSION" ]]; then
+  if ! TARGET_REF=$(normalize_version_tag "$VERSION"); then
+    fail "Invalid --version: ${VERSION} (expected vX.Y.Z)"
+    exit 1
+  fi
+  TARGET_REF_KIND="version"
+elif [[ "$BRANCH_EXPLICIT" == "true" ]]; then
+  TARGET_REF="$BRANCH"
+  TARGET_REF_KIND="branch"
+else
+  TARGET_REF=$(fetch_latest_release_tag || true)
+  if [[ -n "$TARGET_REF" ]]; then
+    TARGET_REF_KIND="release"
+  else
+    TARGET_REF="$BRANCH"
+    TARGET_REF_KIND="branch-fallback"
+    warn "Could not resolve latest GitHub release — falling back to branch ${BRANCH}"
+  fi
+fi
+
+if [[ "$TARGET_REF_KIND" == "release" || "$TARGET_REF_KIND" == "version" ]]; then
+  info "Using ref ${TARGET_REF} (${TARGET_REF_KIND})"
+else
+  info "Using ref ${TARGET_REF} (${TARGET_REF_KIND})"
+fi
+
 if [[ "$DRY_RUN" == "true" ]]; then
   if [[ -d "$INSTALL_DIR/.git" ]]; then
     dry "Would update existing installation in ${INSTALL_DIR}"
-    dry "Would pull latest ${BRANCH}"
+    dry "Would checkout ${TARGET_REF}"
   else
     dry "Would clone ${REPO}"
+    dry "Would checkout ${TARGET_REF}"
     dry "Would install to ${INSTALL_DIR}"
   fi
 else
   if [[ -d "$INSTALL_DIR/.git" ]]; then
     cd "$INSTALL_DIR"
-    run_with_dots "Updating" git pull origin "$BRANCH" -q
-    ok "Updated to latest ${BRANCH}"
+
+    if [[ "$TARGET_REF_KIND" == "branch" || "$TARGET_REF_KIND" == "branch-fallback" ]]; then
+      run_with_dots "Fetching ${TARGET_REF}" git fetch origin "$TARGET_REF" -q
+      run_with_dots "Checking out ${TARGET_REF}" git checkout --force "$TARGET_REF" -q
+      run_with_dots "Resetting to origin/${TARGET_REF}" git reset --hard "origin/${TARGET_REF}" -q
+    else
+      run_with_dots "Fetching tags" git fetch --tags origin -q
+      run_with_dots "Checking out ${TARGET_REF}" git checkout --force "$TARGET_REF" -q
+    fi
+
+    ok "Updated to ${TARGET_REF}"
   else
-    run_with_dots "Cloning Nerve" git clone --branch "$BRANCH" --depth 1 -q "$REPO" "$INSTALL_DIR"
+    if [[ "$TARGET_REF_KIND" == "branch" || "$TARGET_REF_KIND" == "branch-fallback" ]]; then
+      run_with_dots "Cloning Nerve" git clone --branch "$TARGET_REF" --depth 1 -q "$REPO" "$INSTALL_DIR"
+    else
+      run_with_dots "Cloning Nerve" git clone --depth 1 -q "$REPO" "$INSTALL_DIR"
+      cd "$INSTALL_DIR"
+      run_with_dots "Fetching tags" git fetch --tags origin -q
+      run_with_dots "Checking out ${TARGET_REF}" git checkout --force "$TARGET_REF" -q
+    fi
     ok "Cloned to ${INSTALL_DIR}"
   fi
 

--- a/server/lib/release-source.ts
+++ b/server/lib/release-source.ts
@@ -1,0 +1,183 @@
+/**
+ * Shared release/version resolution helpers.
+ *
+ * Source priority:
+ *  1) Latest published GitHub release
+ *  2) Latest semver tag (fallback)
+ */
+
+import { execSync } from 'node:child_process';
+import https from 'node:https';
+
+export type LatestVersionSource = 'release' | 'tag';
+
+interface GitHubRepo {
+  owner: string;
+  repo: string;
+}
+
+const SEMVER_TAG_REGEX = /^v?(\d+\.\d+\.\d+)$/;
+const RELEASE_REQUEST_TIMEOUT_MS = 10_000;
+
+export function compareSemver(a: string, b: string): number {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+  return 0;
+}
+
+export function normalizeSemverTag(tag: string | null | undefined): string | null {
+  if (!tag) return null;
+  const match = SEMVER_TAG_REGEX.exec(tag.trim());
+  return match ? match[1] : null;
+}
+
+function parseSemverTags(output: string): string[] {
+  const versions: string[] = [];
+  for (const line of output.split('\n')) {
+    const match = /v?(\d+\.\d+\.\d+)$/.exec(line.trim());
+    if (match && !versions.includes(match[1])) {
+      versions.push(match[1]);
+    }
+  }
+  return versions.sort(compareSemver);
+}
+
+function getOriginRemoteUrl(cwd: string): string | null {
+  try {
+    return execSync('git remote get-url origin', { cwd, stdio: 'pipe' }).toString().trim();
+  } catch {
+    return null;
+  }
+}
+
+function parseGitHubRepo(remoteUrl: string): GitHubRepo | null {
+  const patterns = [
+    /^https:\/\/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/,
+    /^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/,
+    /^ssh:\/\/git@github\.com\/([^/]+)\/([^/]+?)(?:\.git)?\/?$/,
+  ];
+
+  for (const pattern of patterns) {
+    const match = pattern.exec(remoteUrl);
+    if (match) {
+      return { owner: match[1], repo: match[2] };
+    }
+  }
+
+  return null;
+}
+
+function fetchSemverTagsFromCommand(cwd: string, command: string): string[] {
+  try {
+    const output = execSync(command, { cwd, stdio: 'pipe' }).toString();
+    return parseSemverTags(output);
+  } catch {
+    return [];
+  }
+}
+
+export function listAvailableSemverVersions(cwd: string): string[] {
+  const remote = fetchSemverTagsFromCommand(cwd, 'git ls-remote --tags origin');
+  if (remote.length > 0) return remote;
+  return fetchSemverTagsFromCommand(cwd, 'git tag -l');
+}
+
+export function latestSemverTagVersion(cwd: string): string | null {
+  const versions = listAvailableSemverVersions(cwd);
+  return versions.length > 0 ? versions[versions.length - 1] : null;
+}
+
+function requestJson(url: string, headers: Record<string, string>, timeoutMs: number): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      url,
+      {
+        method: 'GET',
+        headers,
+        timeout: timeoutMs,
+      },
+      (res) => {
+        let body = '';
+        res.setEncoding('utf8');
+
+        res.on('data', (chunk: string) => {
+          body += chunk;
+        });
+
+        res.on('end', () => {
+          const status = res.statusCode ?? 0;
+          if (status < 200 || status >= 300) {
+            reject(new Error(`HTTP ${status}`));
+            return;
+          }
+
+          try {
+            resolve(JSON.parse(body));
+          } catch {
+            reject(new Error('Invalid JSON response'));
+          }
+        });
+      },
+    );
+
+    req.on('error', reject);
+    req.on('timeout', () => {
+      req.destroy(new Error('request timeout'));
+    });
+    req.end();
+  });
+}
+
+export async function latestReleaseVersion(cwd: string): Promise<string | null> {
+  const remoteUrl = getOriginRemoteUrl(cwd);
+  if (!remoteUrl) return null;
+
+  const repo = parseGitHubRepo(remoteUrl);
+  if (!repo) return null;
+
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'nerve-updater',
+  };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  try {
+    const payload = await requestJson(
+      `https://api.github.com/repos/${repo.owner}/${repo.repo}/releases/latest`,
+      headers,
+      RELEASE_REQUEST_TIMEOUT_MS,
+    );
+
+    const tagName =
+      payload && typeof payload === 'object' && 'tag_name' in payload && typeof payload.tag_name === 'string'
+        ? payload.tag_name
+        : null;
+
+    return normalizeSemverTag(tagName);
+  } catch {
+    return null;
+  }
+}
+
+export async function resolveLatestVersion(
+  cwd: string,
+): Promise<{ version: string; source: LatestVersionSource } | null> {
+  const release = await latestReleaseVersion(cwd);
+  if (release) {
+    return { version: release, source: 'release' };
+  }
+
+  const fallbackTag = latestSemverTagVersion(cwd);
+  if (fallbackTag) {
+    return { version: fallbackTag, source: 'tag' };
+  }
+
+  return null;
+}

--- a/server/lib/updater/orchestrator.ts
+++ b/server/lib/updater/orchestrator.ts
@@ -58,14 +58,20 @@ export async function orchestrate(options: UpdateOptions, reporter: Reporter): P
     // ── 3. Resolve version ─────────────────────────────────────────
     stageNum++;
     reporter.stage('Resolving version', stageNum, totalStages);
-    const resolved = resolveVersion(options.cwd, options.version);
+    const resolved = await resolveVersion(options.cwd, options.version);
 
     if (resolved.isUpToDate) {
       reporter.ok(`Already up to date (v${resolved.current})`);
       return EXIT_CODES.UP_TO_DATE;
     }
 
-    reporter.info(`v${resolved.current} → v${resolved.version}`);
+    const sourceLabel =
+      resolved.source === 'release'
+        ? 'latest release'
+        : resolved.source === 'tag'
+          ? 'latest tag fallback'
+          : 'pinned version';
+    reporter.info(`v${resolved.current} → v${resolved.version} (${sourceLabel})`);
 
     // ── Dry-run stops here ─────────────────────────────────────────
     if (options.dryRun) {

--- a/server/lib/updater/release-resolver.ts
+++ b/server/lib/updater/release-resolver.ts
@@ -1,21 +1,27 @@
 /**
  * Resolve the target version for an update.
- * Reads tags from the git remote and picks the latest semver tag,
- * or accepts an explicit --version flag.
+ *
+ * Priority when no explicit version is provided:
+ *   1) Latest published GitHub release
+ *   2) Latest semver tag (fallback)
  */
 
-import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import {
+  listAvailableSemverVersions,
+  normalizeSemverTag,
+  resolveLatestVersion,
+} from '../release-source.js';
 import { EXIT_CODES, UpdateError } from './types.js';
 import type { ResolvedVersion } from './types.js';
 
 /**
  * Resolve the target update version.
- * If `explicitVersion` is given, validates it exists as a remote tag.
- * Otherwise, finds the latest semver tag via `git ls-remote --tags`.
+ * If `explicitVersion` is given, validates that the corresponding semver tag exists.
+ * Otherwise, resolves latest published release and falls back to latest semver tag.
  */
-export function resolveVersion(cwd: string, explicitVersion?: string): ResolvedVersion {
+export async function resolveVersion(cwd: string, explicitVersion?: string): Promise<ResolvedVersion> {
   const pkgPath = join(cwd, 'package.json');
   let current: string;
   try {
@@ -31,30 +37,43 @@ export function resolveVersion(cwd: string, explicitVersion?: string): ResolvedV
 
   let tag: string;
   let version: string;
+  let source: ResolvedVersion['source'];
 
   if (explicitVersion) {
-    tag = explicitVersion.startsWith('v') ? explicitVersion : `v${explicitVersion}`;
-    version = tag.slice(1);
-    // Validate tag exists on remote/local
-    const available = fetchRemoteTags(cwd);
-    if (!available.includes(version)) {
+    const normalized = normalizeSemverTag(explicitVersion);
+    if (!normalized) {
       throw new UpdateError(
-        `Tag ${tag} not found (available: ${available.map(v => `v${v}`).join(', ') || 'none'})`,
+        `Invalid version ${explicitVersion} (expected vX.Y.Z)` ,
         'resolve',
         EXIT_CODES.VERSION_RESOLUTION,
       );
     }
-  } else {
-    const tags = fetchRemoteTags(cwd);
-    if (tags.length === 0) {
+
+    const available = listAvailableSemverVersions(cwd);
+    if (!available.includes(normalized)) {
       throw new UpdateError(
-        'No semver tags found on remote',
+        `Tag v${normalized} not found (available: ${available.map(v => `v${v}`).join(', ') || 'none'})`,
         'resolve',
         EXIT_CODES.VERSION_RESOLUTION,
       );
     }
-    version = tags[tags.length - 1];
+
+    version = normalized;
     tag = `v${version}`;
+    source = 'explicit';
+  } else {
+    const latest = await resolveLatestVersion(cwd);
+    if (!latest) {
+      throw new UpdateError(
+        'No published release or semver tags found',
+        'resolve',
+        EXIT_CODES.VERSION_RESOLUTION,
+      );
+    }
+
+    version = latest.version;
+    tag = `v${version}`;
+    source = latest.source;
   }
 
   return {
@@ -62,62 +81,6 @@ export function resolveVersion(cwd: string, explicitVersion?: string): ResolvedV
     version,
     current,
     isUpToDate: version === current,
+    source,
   };
-}
-
-/**
- * Fetch all semver tags from the remote, sorted ascending.
- * Falls back to local tags if remote returns nothing (e.g. tags not pushed).
- */
-function fetchRemoteTags(cwd: string): string[] {
-  // Try remote first, fall back to local tags on failure or empty result
-  let versions: string[] = [];
-  try {
-    versions = fetchTagsFromSource(cwd, 'git ls-remote --tags origin');
-  } catch {
-    // Remote unreachable — fall through to local
-  }
-
-  if (versions.length === 0) {
-    versions = fetchTagsFromSource(cwd, 'git tag -l');
-  }
-
-  return versions;
-}
-
-function fetchTagsFromSource(cwd: string, command: string): string[] {
-  let output: string;
-  try {
-    output = execSync(command, { cwd, stdio: 'pipe' }).toString();
-  } catch {
-    throw new UpdateError(
-      `Failed to fetch tags (${command})`,
-      'resolve',
-      EXIT_CODES.VERSION_RESOLUTION,
-    );
-  }
-
-  // Match only clean semver (no prerelease suffix like -beta.1)
-  const semverRegex = /v?(\d+\.\d+\.\d+)$/;
-  const versions: string[] = [];
-
-  for (const line of output.split('\n')) {
-    const match = semverRegex.exec(line.trim());
-    if (match) {
-      if (!versions.includes(match[1])) {
-        versions.push(match[1]);
-      }
-    }
-  }
-
-  return versions.sort(compareSemver);
-}
-
-function compareSemver(a: string, b: string): number {
-  const pa = a.split('.').map(Number);
-  const pb = b.split('.').map(Number);
-  for (let i = 0; i < 3; i++) {
-    if (pa[i] !== pb[i]) return pa[i] - pb[i];
-  }
-  return 0;
 }

--- a/server/lib/updater/types.ts
+++ b/server/lib/updater/types.ts
@@ -46,6 +46,7 @@ export interface ResolvedVersion {
   version: string;
   current: string;
   isUpToDate: boolean;
+  source: 'release' | 'tag' | 'explicit';
 }
 
 // ── Preflight ────────────────────────────────────────────────────────

--- a/server/routes/version-check.ts
+++ b/server/routes/version-check.ts
@@ -1,17 +1,15 @@
 /**
  * GET /api/version/check — Check if a newer version is available.
  *
- * Runs `git ls-remote --tags origin` (same logic as the updater's
- * release-resolver), caches the result for 1 hour, and returns:
- *   { current, latest, updateAvailable }
+ * Uses latest published GitHub release first, then latest semver tag fallback.
  */
 
 import { Hono } from 'hono';
-import { exec } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { rateLimitGeneral } from '../middleware/rate-limit.js';
+import { compareSemver, resolveLatestVersion } from '../lib/release-source.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(resolve(__dirname, '../../package.json'), 'utf-8')) as {
@@ -20,71 +18,12 @@ const pkg = JSON.parse(readFileSync(resolve(__dirname, '../../package.json'), 'u
 
 interface VersionCache {
   latest: string;
+  source: 'release' | 'tag';
   checkedAt: number;
 }
 
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 let cache: VersionCache | null = null;
-
-/** Compare two semver strings. Returns negative if a < b, positive if a > b, 0 if equal. */
-function compareSemver(a: string, b: string): number {
-  const pa = a.split('.').map(Number);
-  const pb = b.split('.').map(Number);
-  for (let i = 0; i < 3; i++) {
-    if (pa[i] !== pb[i]) return pa[i] - pb[i];
-  }
-  return 0;
-}
-
-/** Run a shell command asynchronously and return stdout. */
-function execAsync(command: string, cwd: string, timeoutMs: number): Promise<string> {
-  return new Promise((resolve, reject) => {
-    exec(command, { cwd, timeout: timeoutMs }, (err, stdout) => {
-      if (err) return reject(err);
-      resolve(stdout);
-    });
-  });
-}
-
-/** Parse semver tags from git output lines. */
-function parseTags(output: string): string[] {
-  const semverRegex = /v?(\d+\.\d+\.\d+)$/;
-  const versions: string[] = [];
-  for (const line of output.split('\n')) {
-    const match = semverRegex.exec(line.trim());
-    if (match && !versions.includes(match[1])) {
-      versions.push(match[1]);
-    }
-  }
-  return versions;
-}
-
-/** Fetch the latest semver tag from remote, falling back to local tags. */
-async function fetchLatestTag(cwd: string): Promise<string | null> {
-  let versions: string[] = [];
-
-  // Try remote first
-  try {
-    const output = await execAsync('git ls-remote --tags origin', cwd, 10_000);
-    versions = parseTags(output);
-  } catch {
-    // Remote unreachable — fall through to local
-  }
-
-  // Fallback to local tags
-  if (versions.length === 0) {
-    try {
-      const output = await execAsync('git tag -l', cwd, 5_000);
-      versions = parseTags(output);
-    } catch {
-      return null;
-    }
-  }
-
-  if (versions.length === 0) return null;
-  versions.sort(compareSemver);
-  return versions[versions.length - 1];
-}
 
 const app = new Hono();
 
@@ -92,32 +31,38 @@ app.get('/api/version/check', rateLimitGeneral, async (c) => {
   const now = Date.now();
   const cwd = resolve(__dirname, '../..');
 
-  // Serve from cache if fresh
+  // Serve from cache if fresh.
   if (cache && now - cache.checkedAt < CACHE_TTL_MS) {
     return c.json({
       current: pkg.version,
       latest: cache.latest,
+      source: cache.source,
       updateAvailable: compareSemver(cache.latest, pkg.version) > 0,
     });
   }
 
-  // Resolve latest tag (async — doesn't block the event loop)
-  const latest = await fetchLatestTag(cwd);
+  const latest = await resolveLatestVersion(cwd);
   if (!latest) {
     return c.json({
       current: pkg.version,
       latest: null,
+      source: null,
       updateAvailable: false,
-      error: 'Could not fetch remote tags',
+      error: 'Could not fetch release or semver tags',
     });
   }
 
-  cache = { latest, checkedAt: now };
+  cache = {
+    latest: latest.version,
+    source: latest.source,
+    checkedAt: now,
+  };
 
   return c.json({
     current: pkg.version,
-    latest,
-    updateAvailable: compareSemver(latest, pkg.version) > 0,
+    latest: latest.version,
+    source: latest.source,
+    updateAvailable: compareSemver(latest.version, pkg.version) > 0,
   });
 });
 


### PR DESCRIPTION
## Summary
- Installer resolves the latest **published GitHub release** by default.
- Added installer flag: `--version vX.Y.Z` for pinned release installs.
- Kept `--branch` as an explicit dev override (release mode bypass).
- Updater now resolves latest published release first, then falls back to latest semver tag.
- `/api/version/check` now uses the same shared release resolver.

## Why
Keep installer + updater behavior aligned so both target release artifacts by default.

## Validation
- `bash -n install.sh`
- `bash install.sh --dry-run` (resolves latest release ref)
- `npm run update -- --dry-run --yes` (resolves latest release source)
- `npm run build`
- `npm run build:server`
- `npm run lint` (warnings only, no errors)
