### PR TITLE
docs: add deployment guides and improve setup links

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ curl -fsSL https://raw.githubusercontent.com/daggerhashimoto/openclaw-nerve/mast
 
 The installer handles dependencies, cloning, building, and launching. It runs a setup wizard that auto-detects your gateway token and walks you through configuration.
 
+### Pick your setup
+
+- **[Run everything on one machine](docs/DEPLOYMENT-A.md)**
+- **[Use a cloud Gateway with Nerve on your laptop](docs/DEPLOYMENT-B.md)**
+- **[Run both Nerve and Gateway in the cloud](docs/DEPLOYMENT-C.md)**
+
 ### Manual install
 
 ```bash
@@ -138,6 +144,7 @@ See [Security](docs/SECURITY.md) for the full threat model.
 |---|---|
 | **[Architecture](docs/ARCHITECTURE.md)** | How the codebase is organized |
 | **[Configuration](docs/CONFIGURATION.md)** | Every `.env` variable explained |
+| **[Deployment Guides](docs/README.md#deployment-guides)** | Practical guides for local, remote Gateway, and cloud setups |
 | **[Agent Markers](docs/AGENT-MARKERS.md)** | TTS markers, inline charts, and how agents render rich UI |
 | **[Security](docs/SECURITY.md)** | What's locked down and how |
 | **[API](docs/API.md)** | REST and WebSocket endpoints |

--- a/docs/DEPLOYMENT-A.md
+++ b/docs/DEPLOYMENT-A.md
@@ -1,0 +1,117 @@
+# Deployment Guide A: Gateway local + Nerve local
+
+This guide covers the default setup where OpenClaw Gateway and Nerve run on the same machine.
+
+## Topology
+
+```
+Browser (localhost) -> Nerve (127.0.0.1:3080) -> Gateway (127.0.0.1:18789)
+```
+
+Both services stay local. This is the most stable and lowest friction deployment.
+
+## Prerequisites
+
+- Node.js 22+
+- OpenClaw installed
+- OpenClaw gateway installed and running
+- Local shell access to the machine
+
+## Step by step setup
+
+### 1) Install Nerve
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/daggerhashimoto/openclaw-nerve/master/install.sh | bash
+```
+
+### 2) Run setup if needed
+
+If `.env` is missing or wrong, run:
+
+```bash
+cd ~/nerve
+npm run setup
+```
+
+Recommended choices:
+
+- Access mode: `This machine only (localhost)`
+- Authentication: optional for localhost only usage
+
+### 3) Start or restart Nerve
+
+```bash
+# if running as systemd service
+sudo systemctl restart nerve.service
+
+# or run directly
+npm run prod
+```
+
+## Validation checklist
+
+Run these commands on the same machine:
+
+```bash
+openclaw gateway status
+curl -sS http://127.0.0.1:18789/health
+curl -sS http://127.0.0.1:3080/health
+```
+
+Expected result:
+
+- Gateway is running
+- Both health endpoints return success
+- Browser can connect without manual network setup
+
+## Known frictions and current gaps
+
+### 1) Token mismatch after OpenClaw updates
+
+Symptom:
+
+- Connect dialog suddenly fails with auth errors after update or re-onboard
+
+Current workaround:
+
+- Re-run `npm run setup`
+- Restart gateway and Nerve
+- Open a fresh browser tab
+
+### 2) Missing scopes after first connect
+
+Symptom:
+
+- Chat connects but actions fail with missing scope errors
+
+Current workaround:
+
+- Re-run `npm run setup`
+- Check pending devices and approve if required:
+
+```bash
+openclaw devices list
+openclaw devices approve <requestId>
+```
+
+### 3) Browser keeps old credentials
+
+Symptom:
+
+- Valid token fails until browser state is reset
+
+Current workaround:
+
+- Open a new tab or private window
+- Clear saved Nerve connection state in the browser
+
+## Security notes
+
+- Keep `HOST=127.0.0.1` for local-only deployments
+- Do not expose Nerve or Gateway to network unless you need remote access
+- If you expose Nerve (`HOST=0.0.0.0`), enable `NERVE_AUTH=true`
+
+## Operational recommendation
+
+If you are choosing a first deployment, choose this scenario first. It has the fewest moving parts and the best current support in setup and docs.

--- a/docs/DEPLOYMENT-B.md
+++ b/docs/DEPLOYMENT-B.md
@@ -1,0 +1,170 @@
+# Deployment Guide B: Gateway cloud + Nerve local (laptop)
+
+This guide covers a split setup where Nerve runs on your laptop and Gateway runs on a cloud host.
+
+## Who should use this
+
+Use this when:
+
+- You want local Nerve UI responsiveness
+- Your OpenClaw runtime lives in the cloud
+- You do not want to run Nerve on the cloud host
+
+## Topology
+
+```
+Browser (localhost) -> Nerve local (127.0.0.1:3080) -> Gateway cloud (<host>:18789)
+```
+
+## Important behavior to understand
+
+- Nerve setup can edit local OpenClaw config files
+- In this scenario, gateway config is remote, so local auto-patching cannot fix remote gateway settings
+- You must configure remote gateway allowlists manually
+
+## Prerequisites
+
+- Nerve installed on your laptop
+- Cloud Gateway reachable from your laptop
+- Gateway token from the cloud host
+- Access to cloud host config (`~/.openclaw/openclaw.json`)
+
+## Recommended network approach
+
+Use a private network path (Tailscale, WireGuard, SSH tunnel, or private VPC). Avoid exposing port `18789` publicly.
+
+## Step by step setup
+
+### 1) Prepare cloud gateway
+
+On the cloud host:
+
+```bash
+openclaw gateway status
+curl -sS http://127.0.0.1:18789/health
+```
+
+Confirm gateway is healthy.
+
+### 2) Configure Nerve locally
+
+On your laptop:
+
+```bash
+cd ~/nerve
+npm run setup
+```
+
+When prompted:
+
+- Set `Gateway URL` to your cloud gateway URL
+- Set `Gateway token` from cloud host
+- Keep Nerve access mode as `localhost` unless you need LAN access
+
+### 3) Allow gateway host in Nerve WS proxy
+
+If your gateway hostname is not localhost, add it:
+
+```env
+WS_ALLOWED_HOSTS=<gateway-hostname-or-ip>
+```
+
+Then restart Nerve.
+
+### 4) Patch remote gateway allowed origins
+
+On the cloud gateway host, add your local Nerve origin to gateway allowlist:
+
+- `http://localhost:3080`
+- `http://127.0.0.1:3080`
+- Any other local origin you actually use
+
+Then restart gateway.
+
+### 5) Optional: allow HTTP tools needed by Nerve
+
+On cloud gateway config, ensure:
+
+```json
+"gateway": {
+  "tools": {
+    "allow": ["cron", "gateway"]
+  }
+}
+```
+
+## Validation checklist
+
+### On laptop
+
+```bash
+curl -sS http://127.0.0.1:3080/health
+```
+
+### Connectivity from laptop to cloud gateway
+
+```bash
+curl -sS <your-gateway-url>/health
+```
+
+### In browser
+
+- Open Nerve on localhost
+- Connect succeeds
+- Session list loads
+- Sending a message works
+
+## Known frictions and current gaps
+
+### 1) Installer has no `--gateway-url` flag
+
+Impact:
+
+- Non-interactive installs are awkward for this scenario
+
+Current workaround:
+
+- Run `npm run setup` interactively after install
+
+### 2) Remote gateway config is not auto-patched by local setup
+
+Impact:
+
+- Origin or tools allowlist drift causes hard-to-debug failures
+
+Current workaround:
+
+- Patch remote `~/.openclaw/openclaw.json` manually
+- Restart remote gateway
+
+### 3) WS target host allowlist mismatch
+
+Impact:
+
+- WebSocket closes with `Target not allowed`
+
+Current workaround:
+
+- Add gateway host to `WS_ALLOWED_HOSTS`
+
+### 4) Device scope or pairing errors from remote gateway state
+
+Impact:
+
+- Connection works but actions fail with scope errors
+
+Current workaround:
+
+- Repair pairing/scopes on gateway host
+- Re-run setup flows where possible on gateway host itself
+
+## Security notes
+
+- Do not expose cloud gateway directly to the public internet if you can avoid it
+- Prefer private addressing and strict firewall rules
+- Rotate gateway token if it has been shared widely
+- If you expose local Nerve to LAN, enable `NERVE_AUTH=true`
+
+## Operational recommendation
+
+This scenario is workable today but has manual steps. If you want low maintenance and multi-user access, scenario C with Nerve in cloud is usually cleaner.

--- a/docs/DEPLOYMENT-C.md
+++ b/docs/DEPLOYMENT-C.md
@@ -1,0 +1,182 @@
+# Deployment Guide C: Nerve cloud + Gateway cloud
+
+This guide covers hosted deployments where users access Nerve remotely.
+
+## Who should use this
+
+Use this when:
+
+- You want to access Nerve from multiple devices
+- You want one always-on deployment
+
+## Topology options
+
+### C1) Same host (recommended)
+
+```
+Browser remote -> Nerve cloud -> Gateway cloud (same machine)
+```
+
+### C2) Split hosts
+
+```
+Browser remote -> Nerve cloud host A -> Gateway cloud host B
+```
+
+C1 is simpler and has fewer failure points.
+
+## Prerequisites
+
+- Cloud Linux host with Node.js 22+
+- OpenClaw gateway running
+- Domain or stable IP for Nerve
+- TLS termination plan (reverse proxy or direct certs)
+
+## C1 setup (same host)
+
+### 1) Install Nerve on cloud host
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/daggerhashimoto/openclaw-nerve/master/install.sh | bash
+```
+
+### 2) Run setup and choose network access
+
+```bash
+cd ~/nerve
+npm run setup
+```
+
+Recommended choices:
+
+- Access mode: network or custom
+- `HOST=0.0.0.0`
+- Enable authentication and set password
+- Enable HTTPS if serving directly
+
+### 3) Start service
+
+```bash
+sudo systemctl restart nerve.service
+sudo systemctl status nerve.service
+```
+
+### 4) Put Nerve behind TLS reverse proxy
+
+Use Nginx, Caddy, or Traefik. Forward HTTP and WebSocket traffic to Nerve.
+
+## C2 setup (split hosts)
+
+Follow C1 for Nerve host, then add these extra steps:
+
+### 1) Point Nerve to remote gateway
+
+In Nerve `.env`:
+
+```env
+GATEWAY_URL=<remote-gateway-url>
+WS_ALLOWED_HOSTS=<remote-gateway-hostname-or-ip>
+```
+
+### 2) Patch remote gateway allowed origins
+
+On gateway host, add Nerve public origin to `gateway.controlUi.allowedOrigins`.
+
+Example origin:
+
+- `https://nerve.example.com`
+
+### 3) Ensure remote gateway tools allowlist includes required entries
+
+```json
+"gateway": {
+  "tools": {
+    "allow": ["cron", "gateway"]
+  }
+}
+```
+
+### 4) Restart both services
+
+- Restart Gateway on host B
+- Restart Nerve on host A
+
+## Validation checklist
+
+### Nerve host
+
+```bash
+curl -sS http://127.0.0.1:3080/health
+```
+
+### Public endpoint
+
+```bash
+curl -sS https://<nerve-domain>/health
+```
+
+### Browser tests
+
+- Login screen appears when auth enabled
+- Connect to gateway succeeds
+- Session list loads
+- Send message and receive response
+- File browser and workspace actions succeed
+
+## Known frictions and current gaps
+
+### 1) Remote clients do not get auto token prefill
+
+Impact:
+
+- `/api/connect-defaults` does not return token to non-loopback clients
+- Users need gateway token in Connect dialog
+
+Current workaround:
+
+- Provide token to operators out of band
+- Keep user count limited to trusted operators
+
+### 2) Multi-user credential model is rough
+
+Impact:
+
+- Gateway token handling is user-facing in hosted mode
+- Hard to delegate access cleanly
+
+Current workaround:
+
+- Treat deployment as single-operator or small trusted group
+
+### 3) Reverse proxy and trusted proxy settings can drift
+
+Impact:
+
+- Wrong IP detection for rate limiting or logs
+
+Current workaround:
+
+- Set `TRUSTED_PROXIES` to your reverse proxy addresses
+- Re-test after infrastructure changes
+
+### 4) Split-host deployments inherit scenario B manual steps
+
+Impact:
+
+- More config points to keep in sync
+
+Current workaround:
+
+- Use same-host C1 if possible
+
+## Security notes
+
+- Always enable `NERVE_AUTH=true` for public or shared access
+- Use HTTPS end to end or at least at the edge
+- Restrict gateway network exposure to trusted paths only
+- Keep gateway on loopback when Nerve and Gateway share host
+- Rotate gateway token on ownership or access changes
+
+## Operational recommendation
+
+Choose C1 unless you have a hard requirement for split hosts. C1 is easier to secure and easier to support.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,12 @@ Use this folder as the docs hub for Nerve.
 - [Agent Markers](./AGENT-MARKERS.md)
 - [Code Review](./CODE_REVIEW.md)
 
+## Deployment Guides
+
+- [Run everything on one machine](./DEPLOYMENT-A.md)
+- [Use a cloud Gateway with Nerve on your laptop](./DEPLOYMENT-B.md)
+- [Run both Nerve and Gateway in the cloud](./DEPLOYMENT-C.md)
+
 ## Release Notes
 
 - [Changelog](../CHANGELOG.md)


### PR DESCRIPTION
## Summary
- Add 3 deployment guides for common setups:
  - Run everything on one machine
  - Use a cloud Gateway with Nerve on your laptop
  - Run both Nerve and Gateway in the cloud
- Add a **Pick your setup** section in `README.md` with direct links to those guides
- Add a **Deployment Guides** section in `docs/README.md`
- Add a deployment-guides pointer row in the main README docs table

## Why
- Make deployment paths easier to discover
- Reduce confusion for users outside the default local-local setup

## Scope
- Documentation only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added three comprehensive deployment guides covering local-only, hybrid cloud-local, and full cloud deployment scenarios with prerequisites, setup steps, validation checks, and operational guidance.
  * Updated documentation index with a new "Deployment Guides" section for improved navigation to deployment options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->