### PR TITLE
fix(chat): repair broken memory collapse toggle behavior

### DIFF
--- a/src/features/chat/ChatPanel.tsx
+++ b/src/features/chat/ChatPanel.tsx
@@ -303,6 +303,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
                 index={i}
                 isCollapsed={isCollapsed}
                 isMemoryCollapsed={isMemoryCollapsed}
+                memoryKey={memoryKey}
                 onToggleCollapse={toggleCollapse}
                 onToggleMemory={toggleMemory}
                 firstMessageTime={firstMessageTime}

--- a/src/features/chat/MessageBubble.tsx
+++ b/src/features/chat/MessageBubble.tsx
@@ -36,6 +36,7 @@ interface MessageBubbleProps {
   index: number;
   isCollapsed: boolean;
   isMemoryCollapsed: boolean;
+  memoryKey?: string;
   onToggleCollapse: (idx: number) => void;
   onToggleMemory: (key: string) => void;
   firstMessageTime?: Date | null;
@@ -70,7 +71,7 @@ function RoleBadge({ role, agentName = 'Agent' }: { role: string; agentName?: st
   return <span className="text-[9px] uppercase font-bold tracking-widest px-1.5 py-0.5 rounded-sm bg-muted-foreground/20 text-muted-foreground">SYSTEM</span>;
 }
 
-function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, onToggleCollapse, onToggleMemory, firstMessageTime, searchQuery, isCurrentMatch, agentName }: MessageBubbleProps) {
+function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memoryKey, onToggleCollapse, onToggleMemory, firstMessageTime, searchQuery, isCurrentMatch, agentName }: MessageBubbleProps) {
   const isUser = msg.role === 'user';
   const isAssistant = msg.role === 'assistant';
   const isSystem = msg.role === 'system' || msg.role === 'event';
@@ -105,7 +106,7 @@ function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, onTogg
     ? decodeHtmlEntities(systemPreview || msg.rawText.slice(0, 60).replace(/\n/g, ' ') + (msg.rawText.length > 60 ? '…' : ''))
     : '';
 
-  const memoryCollapsedKey = `mem-${msg.msgId || msg.tempId || index}`;
+  const memoryCollapsedKey = memoryKey ?? `mem-${msg.msgId || msg.tempId || index}`;
 
   const handleCopy = useCallback(async (e: React.MouseEvent) => {
     e.stopPropagation();


### PR DESCRIPTION
## fix(chat): repair broken memory collapse toggle behavior

Fixes the relevant memories collapse/expand toggle which was broken. The toggle now properly expands and collapses on each click, with memories starting in collapsed state by design.

**Note:** This issue only affects users whose agent output includes `<relevant-memories>` blocks, such as users of the mem0 OpenClaw plugin.

## Problem
Two issues combined to make relevant memories collapse toggles broken:
- The collapse state key used by the toggle was derived from message render `index`, while the collapse state reading logic expected stable message identifiers, causing a key mismatch.
- The toggle logic used `!prev[key]`, which treats `undefined` as `true`, matching the default-collapsed behavior and resulting in a first-click no-op.

## Changes
- Update relevant memory collapse key derivation to use a stable identifier (`msgId` / `tempId`) instead of only the render index to match the collapse state reading logic.
- Update the toggle logic to use nullish-coalescing semantics so `undefined` defaults are flipped correctly on first click.

## Testing
Ran locally:
```bash
npm run lint
npm test -- --run
```

## Notes
- This change is UI-state-only; no backend behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default memory panel state now opens (expanded) when no prior state exists.
  * Memory collapse state now tracks messages using stable identifiers so collapse/expand persists more consistently across message changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->