### PR TITLE
fix(kanban): enable vertical scroll in board columns

### DIFF
--- a/src/features/kanban/KanbanBoard.tsx
+++ b/src/features/kanban/KanbanBoard.tsx
@@ -21,7 +21,7 @@ interface KanbanBoardProps {
 /* ── Loading skeleton ── */
 function SkeletonColumn() {
   return (
-    <div className="flex flex-col min-w-[280px] w-[320px] max-w-[360px] shrink-0 bg-background/50 rounded-lg border border-border/40">
+    <div className="flex flex-col min-w-[280px] w-[320px] max-w-[360px] h-full shrink-0 bg-background/50 rounded-lg border border-border/40">
       <div className="h-10 px-3 flex items-center border-b border-border/40">
         <div className="h-3 w-16 bg-muted rounded animate-pulse" />
       </div>
@@ -140,7 +140,7 @@ export const KanbanBoard = memo(function KanbanBoard({
   /* ── Loading skeleton ── */
   if (loading) {
     return (
-      <div className="flex-1 overflow-x-auto">
+      <div className="h-full overflow-x-auto">
         <div className="flex gap-3 p-0 min-w-min h-full">
           {COLUMNS.map(s => <SkeletonColumn key={s} />)}
         </div>
@@ -179,7 +179,7 @@ export const KanbanBoard = memo(function KanbanBoard({
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
     >
-      <div className="flex-1 overflow-x-auto">
+      <div className="h-full overflow-x-auto">
         <div className="flex gap-3 p-0 min-w-min h-full">
           {COLUMNS.map(status => (
             <KanbanColumn

--- a/src/features/kanban/KanbanColumn.tsx
+++ b/src/features/kanban/KanbanColumn.tsx
@@ -39,7 +39,7 @@ export const KanbanColumn = memo(function KanbanColumn({ status, tasks, onCardCl
 
   return (
     <div
-      className={`flex flex-col min-w-[280px] w-[320px] max-w-[360px] shrink-0 bg-background/50 rounded-lg border transition-colors duration-150 ${
+      className={`flex flex-col min-w-[280px] w-[320px] max-w-[360px] h-full shrink-0 bg-background/50 rounded-lg border transition-colors duration-150 ${
         isOverColumn ? 'border-primary/50 bg-primary/5' : 'border-border/40'
       }`}
     >

--- a/src/features/kanban/KanbanPanel.tsx
+++ b/src/features/kanban/KanbanPanel.tsx
@@ -108,7 +108,7 @@ export function KanbanPanel({ initialTaskId, onInitialTaskConsumed }: KanbanPane
       />
 
       {/* Board body */}
-      <div className="flex-1 overflow-hidden px-4 pb-4">
+      <div className="flex-1 flex flex-col min-h-0 overflow-hidden px-4 pb-4">
         <KanbanBoard
           tasksByStatus={tasksByStatus}
           onCardClick={handleCardClick}


### PR DESCRIPTION
## Problem
Kanban board columns didn't scroll when tasks overflowed. Cards were cut off and unreachable.

## Root Cause
Three issues in the CSS height chain from panel to card list:

1. **Board body** (`KanbanPanel.tsx`) -- `flex-1` without `min-h-0` lets the flex item grow beyond its container (classic flexbox gotcha where `min-height: auto` prevents overflow)
2. **Board wrapper** (`KanbanBoard.tsx`) -- used `flex-1` but `DndContext` doesn't render a DOM element, breaking the flex parent relationship. Changed to `h-full`
3. **Columns** (`KanbanColumn.tsx`) -- missing `h-full` so they grew with content instead of constraining to parent height

## Fix
- Add `min-h-0 flex flex-col` to board body container
- Change board wrapper from `flex-1` to `h-full` (both main board and loading skeleton)
- Add `h-full` to column and skeleton column containers

Column headers stay pinned, cards scroll independently within each column.

## Testing
- Build: clean
- Kanban parser tests: 25/25 pass
- Manually verified: backlog column with 20+ tasks scrolls correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved Kanban board vertical layout to properly fill available screen space and ensure consistent scrolling behavior across all board sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->