### PR TITLE
fix(chat): guard keydown handler during IME composition (#65)

### DIFF
--- a/src/features/chat/InputBar.tsx
+++ b/src/features/chat/InputBar.tsx
@@ -230,6 +230,11 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    // IME composition guard: during active CJK composition the browser may
+    // fire keydown for Enter/Escape/etc.  Let the IME handle them – acting
+    // on these events causes ghost messages (issue #65).
+    if (e.nativeEvent.isComposing || e.keyCode === 229) return;
+
     // Tab completion for session names (Tab cycles, Escape cancels)
     if (e.key === 'Tab' || e.key === 'Escape') {
       const consumed = handleTabKey(e as React.KeyboardEvent<HTMLTextAreaElement>);


### PR DESCRIPTION
Closes #65

## What

Adds an IME composition guard at the top of `handleKeyDown` in InputBar:

```ts
if (e.nativeEvent.isComposing || e.keyCode === 229) return;
```

## Why

CJK input methods (Korean, Japanese, Chinese, Vietnamese) compose characters through multiple keystrokes. During active composition, the browser fires `keydown` events that were being handled as normal input — pressing Enter to confirm a syllable would trigger `handleSend()`, then a second `keydown` after `compositionend` would send the final syllable as a ghost message.

## How

- `e.nativeEvent.isComposing` — W3C standard, `true` during active composition
- `e.keyCode === 229` — fallback for older browsers that don't set `isComposing`
- Guard placed before all key handlers (Enter, Escape, Tab, arrows) so the IME owns all keystrokes during composition

## Testing

Tested with Korean 2-Set (두벌식) IME on macOS. Typed gibberish rapidly and hit Enter mid-composition — no ghost syllables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where ghost messages could be sent and unintended keyboard actions could be triggered while composing text using IME-based input methods (such as CJK languages). This ensures smoother typing and prevents accidental message submissions during character composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->