### PR TITLE
fix(voice): keep chat panel mounted during tab switch (#64)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -516,8 +516,8 @@ export default function App({ onLogout }: AppProps) {
       </PanelErrorBoundary>
       
       <div className="flex-1 flex overflow-hidden min-h-0">
-        {/* File tree — far left, collapsible (chat mode only) */}
-        {viewMode === 'chat' && (
+        {/* File tree — far left, collapsible; hidden (not unmounted) in kanban to preserve state */}
+        <div className={viewMode === 'kanban' ? 'hidden' : undefined}>
           <PanelErrorBoundary name="File Explorer">
             <FileTreePanel
               onOpenFile={openFile}
@@ -526,30 +526,38 @@ export default function App({ onLogout }: AppProps) {
               onCloseOpenPaths={closeOpenPathsByPrefix}
             />
           </PanelErrorBoundary>
-        )}
+        </div>
 
-        {/* Main area: kanban or chat */}
-        {viewMode === 'kanban' ? (
+        {/*
+         * Chat panel is always rendered but hidden when kanban is active.
+         * This keeps ChatPanel → InputBar → useVoiceInput mounted so that
+         * in-progress voice recording / STT transcription survives tab switches.
+         * See: https://github.com/.../issues/64
+         */}
+        {viewMode === 'kanban' && (
           <div className="flex-1 flex flex-col min-w-0 min-h-0 boot-panel">
             <Suspense fallback={<div className="flex-1 flex items-center justify-center text-muted-foreground text-xs bg-background">Loading…</div>}>
               <KanbanPanel initialTaskId={pendingTaskId} onInitialTaskConsumed={() => setPendingTaskId(null)} />
             </Suspense>
           </div>
-        ) : isCompactLayout ? (
-          <div className="flex-1 min-w-0 min-h-0 boot-panel">
+        )}
+        {isCompactLayout ? (
+          <div className={`flex-1 min-w-0 min-h-0 boot-panel${viewMode === 'kanban' ? ' hidden' : ''}`}>
             {chatContent}
           </div>
         ) : (
-          <ResizablePanels
-            leftPercent={panelRatio}
-            onResize={setPanelRatio}
-            minLeftPercent={30}
-            maxLeftPercent={75}
-            leftClassName="boot-panel"
-            rightClassName="boot-panel flex flex-col gap-px bg-border"
-            left={chatContent}
-            right={renderRightPanels(handleSessionChange)}
-          />
+          <div style={{ display: viewMode === 'kanban' ? 'none' : 'contents' }}>
+            <ResizablePanels
+              leftPercent={panelRatio}
+              onResize={setPanelRatio}
+              minLeftPercent={30}
+              maxLeftPercent={75}
+              leftClassName="boot-panel"
+              rightClassName="boot-panel flex flex-col gap-px bg-border"
+              left={chatContent}
+              right={renderRightPanels(handleSessionChange)}
+            />
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
## Problem

When a user is recording a voice message or waiting for STT transcription, switching from the chat view to the Tasks/Kanban board kills the recording. The chat panel (containing `ChatPanel` → `InputBar` → `useVoiceInput`) was conditionally rendered — switching to kanban unmounted it entirely, tearing down the MediaRecorder and aborting in-flight `/api/transcribe` requests.

## Fix

Instead of conditionally rendering chat content vs kanban (only one exists at a time), **both are always rendered**. The chat panel is hidden with CSS (`display: none` / Tailwind `hidden` class) when kanban is active. This keeps the entire component tree mounted so voice recording, transcription state, and all chat state survive tab switches.

Key changes in `src/App.tsx`:
- Chat content (both compact and resizable layouts) is always rendered
- `hidden` class / `display: none` applied when `viewMode === 'kanban'`
- KanbanPanel renders alongside (not instead of) chat content
- File tree panel also stays mounted (hidden) during kanban view
- Wrapper uses `display: contents` when visible so it's transparent to flex layout

`display: none` ensures hidden panels don't intercept keyboard events or participate in layout.

## Testing

- ✅ All 968 tests pass (`vitest run`)
- ✅ No ESLint errors
- ✅ Production build succeeds (`vite build`)

Closes #64