### PR TITLE
fix(stt): sync server model and cancel stale downloads

### DIFF
--- a/server/services/whisper-local.ts
+++ b/server/services/whisper-local.ts
@@ -107,6 +107,7 @@ interface DownloadProgress {
 }
 
 let currentDownload: DownloadProgress | null = null;
+let currentDownloadAbort: AbortController | null = null;
 
 /** Get current download progress (null if no download active). */
 export function getDownloadProgress(): DownloadProgress | null {
@@ -130,17 +131,24 @@ async function downloadModel(model: string): Promise<{ ok: boolean; message: str
   const url = `${WHISPER_MODELS_BASE_URL}/${filename}`;
   console.log(`[whisper-local] Downloading model: ${model} from ${url}`);
 
-  currentDownload = { model, downloading: true, bytesDownloaded: 0, totalBytes: 0, percent: 0 };
+  const progress: DownloadProgress = { model, downloading: true, bytesDownloaded: 0, totalBytes: 0, percent: 0 };
+  currentDownload = progress;
+
+  const controller = new AbortController();
+  currentDownloadAbort = controller;
 
   try {
-    const response = await fetch(url, { redirect: 'follow' });
+    const response = await fetch(url, { redirect: 'follow', signal: controller.signal });
     if (!response.ok || !response.body) {
-      currentDownload = { ...currentDownload, downloading: false, error: `HTTP ${response.status}` };
+      if (currentDownload === progress) {
+        progress.downloading = false;
+        progress.error = `HTTP ${response.status}`;
+      }
       return { ok: false, message: `Download failed: HTTP ${response.status}` };
     }
 
     const totalBytes = Number(response.headers.get('content-length') || 0);
-    currentDownload.totalBytes = totalBytes;
+    progress.totalBytes = totalBytes;
 
     const writer = createWriteStream(tmpPath);
     let bytesDownloaded = 0;
@@ -151,8 +159,8 @@ async function downloadModel(model: string): Promise<{ ok: boolean; message: str
       if (done) break;
       writer.write(Buffer.from(value));
       bytesDownloaded += value.byteLength;
-      currentDownload.bytesDownloaded = bytesDownloaded;
-      currentDownload.percent = totalBytes > 0 ? Math.round((bytesDownloaded / totalBytes) * 100) : 0;
+      progress.bytesDownloaded = bytesDownloaded;
+      progress.percent = totalBytes > 0 ? Math.round((bytesDownloaded / totalBytes) * 100) : 0;
     }
     writer.end();
 
@@ -166,22 +174,43 @@ async function downloadModel(model: string): Promise<{ ok: boolean; message: str
     const { renameSync } = await import('node:fs');
     renameSync(tmpPath, destPath);
 
-    currentDownload = { ...currentDownload, downloading: false, percent: 100 };
+    if (currentDownload === progress) {
+      progress.downloading = false;
+      progress.percent = 100;
+    }
     console.log(`[whisper-local] Model downloaded: ${model} (${(bytesDownloaded / 1024 / 1024).toFixed(0)}MB)`);
 
     // Clear download state after a moment so UI can see completion
-    setTimeout(() => { currentDownload = null; }, 3000);
+    setTimeout(() => {
+      if (currentDownload === progress) currentDownload = null;
+    }, 3000);
 
     return { ok: true, message: `Downloaded ${model}` };
   } catch (err) {
-    const msg = (err as Error).message;
-    console.error(`[whisper-local] Download failed:`, msg);
-    currentDownload = { ...currentDownload, downloading: false, error: msg };
+    const isAbort = (err as { name?: string })?.name === 'AbortError';
+    const msg = isAbort ? 'Download cancelled' : (err as Error).message;
+    if (!isAbort) {
+      console.error('[whisper-local] Download failed:', msg);
+    }
+
+    if (currentDownload === progress) {
+      progress.downloading = false;
+      progress.error = msg;
+    }
+
     // Clean up partial file
     try { unlinkSync(tmpPath); } catch { /* ignore */ }
-    // Clear error state after a moment
-    setTimeout(() => { currentDownload = null; }, 5000);
-    return { ok: false, message: `Download failed: ${msg}` };
+
+    // Clear error/cancel state after a moment
+    setTimeout(() => {
+      if (currentDownload === progress) currentDownload = null;
+    }, isAbort ? 1200 : 5000);
+
+    return { ok: false, message: isAbort ? `${model} download cancelled` : `Download failed: ${msg}` };
+  } finally {
+    if (currentDownloadAbort === controller) {
+      currentDownloadAbort = null;
+    }
   }
 }
 
@@ -197,8 +226,14 @@ export async function setWhisperModel(model: string): Promise<{ ok: boolean; mes
   // If model not available, start downloading
   if (!isModelAvailable(model)) {
     if (currentDownload?.downloading) {
-      return { ok: true, message: `Already downloading ${currentDownload.model}`, downloading: true };
+      if (currentDownload.model === model) {
+        return { ok: true, message: `Already downloading ${currentDownload.model}`, downloading: true };
+      }
+      // User switched model while another download is running.
+      // Cancel stale download and start requested model instead.
+      currentDownloadAbort?.abort();
     }
+
     // Fire and forget — download runs in background
     downloadModel(model).then((result) => {
       if (result.ok) {
@@ -210,6 +245,12 @@ export async function setWhisperModel(model: string): Promise<{ ok: boolean; mes
       }
     });
     return { ok: true, message: `Downloading ${model}...`, downloading: true };
+  }
+
+  // If switching to an already-available model while another download is in progress,
+  // cancel the stale background download to avoid confusing progress UI.
+  if (currentDownload?.downloading && currentDownload.model !== model) {
+    currentDownloadAbort?.abort();
   }
 
   if (model === activeModel && whisperContext) {

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -105,15 +105,24 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     localStorage.setItem('oc-tts-model', model);
   }, []);
 
-  // Sync STT provider to server on mount (in case server restarted).
-  // GET first to avoid overwriting server state with a stale local value.
+  // Sync STT settings to server on mount (in case server restarted).
+  // GET first to avoid overwriting server state with stale local values.
   useEffect(() => {
     if (!sttProvider) return;
     fetch('/api/transcribe/config')
       .then(resp => resp.ok ? resp.json() : null)
       .then(data => {
         const serverProvider = data?.provider as STTProvider | undefined;
-        // Only PUT if local value differs from what the server already has
+        const serverModel = typeof data?.model === 'string' ? data.model : '';
+
+        // Model: trust server on startup to avoid stale localStorage mismatches
+        // (e.g. UI says tiny.en while server is actually tiny).
+        if (serverModel && serverModel !== sttModel) {
+          setSttModelState(serverModel);
+          localStorage.setItem('oc-stt-model', serverModel);
+        }
+
+        // Provider: preserve prior behavior (push local preference to server).
         if (serverProvider !== sttProvider) {
           return fetch('/api/transcribe/config', {
             method: 'PUT',


### PR DESCRIPTION
## Summary
Clean extraction of the two STT changes worth keeping from the previous branch:

1. Sync STT model from server on startup (avoid UI/localStorage drift)
2. Cancel stale Whisper model downloads when user switches models

No installer changes, no fallback package logic, no unrelated audio/TTS changes.

## Changes
- `server/services/whisper-local.ts`
  - Added `AbortController` tracking for active model download
  - Cancels stale in-flight download when user switches to another model
  - Keeps progress state coherent across success/error/cancel paths
- `src/contexts/SettingsContext.tsx`
  - On mount, fetches `/api/transcribe/config` and trusts server model
  - Updates local state/storage when server model differs
  - Keeps existing provider sync behavior

## Why
This removes a real UX bug class:
- UI says one model while server is actually using another
- Switching models can leave stale downloads running in background

## Validation
- `npm run build`
- `npm run build:server`
- `npm run test -- server/routes/transcribe.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to cancel model downloads when requesting a new model.
  * Enhanced download progress tracking with better state management.

* **Bug Fixes**
  * Fixed stale settings issue by syncing server-side model configuration on startup.
  * Improved error handling for download failures and interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->