### PR TITLE
fix(voice): disable english fallback merge for non-english phrase sets

### DIFF
--- a/server/lib/voice-phrases.ts
+++ b/server/lib/voice-phrases.ts
@@ -120,33 +120,19 @@ function writeStore(store: PhrasesStore): void {
 
 /**
  * Get voice phrases for a specific language.
- * Returns the user's custom phrases merged with English as fallback.
- * The matching logic should check both the language-specific set AND English.
+ * Returns only that language's phrase set (custom > defaults), without English merge.
+ * Falls back to English only if the requested language has no configured/default set.
  */
 export function getVoicePhrases(lang?: string): LanguageVoicePhrases {
   const store = readStore();
-  const effectiveLang = lang || 'en';
+  const effectiveLang = (lang || 'en').toLowerCase();
 
-  // Get language-specific phrases (custom > defaults)
   const langPhrases = store[effectiveLang] || DEFAULT_VOICE_PHRASES[effectiveLang];
-  const enPhrases = store['en'] || DEFAULT_VOICE_PHRASES.en;
-
-  if (!langPhrases || effectiveLang === 'en') {
-    return enPhrases;
+  if (langPhrases) {
+    return langPhrases;
   }
 
-  // Merge: language-specific + English fallback (deduplicated)
-  const merged: LanguageVoicePhrases = {
-    stopPhrases: [...new Set([...langPhrases.stopPhrases, ...enPhrases.stopPhrases])],
-    cancelPhrases: [...new Set([...langPhrases.cancelPhrases, ...enPhrases.cancelPhrases])],
-  };
-
-  // Wake phrases: language-specific only (no English merge — these replace, not augment)
-  if (langPhrases.wakePhrases?.length) {
-    merged.wakePhrases = langPhrases.wakePhrases;
-  }
-
-  return merged;
+  return store['en'] || DEFAULT_VOICE_PHRASES.en;
 }
 
 /**

--- a/server/routes/voice-phrases.ts
+++ b/server/routes/voice-phrases.ts
@@ -1,7 +1,7 @@
 /**
  * Voice phrases API — per-language stop/cancel phrase management.
  *
- * GET  /api/voice-phrases?lang=fr  → merged phrases (language + English fallback)
+ * GET  /api/voice-phrases?lang=fr  → effective phrases for that language (no English merge)
  * GET  /api/voice-phrases/:lang    → language-only phrases (no English merge)
  * PUT  /api/voice-phrases/:lang    → save custom phrases for a language
  * GET  /api/voice-phrases/status   → which languages have custom phrases configured
@@ -20,7 +20,7 @@ import {
 const app = new Hono();
 
 /**
- * GET /api/voice-phrases — merged phrases for current (or specified) language.
+ * GET /api/voice-phrases — effective phrases for current (or specified) language.
  * Client uses these for voice recognition matching.
  * Query param `lang` overrides the server config language.
  */

--- a/src/features/voice/useVoiceInput.ts
+++ b/src/features/voice/useVoiceInput.ts
@@ -18,7 +18,7 @@ const DEFAULT_PHRASES: VoicePhrases = {
 
 let phrasesCache: { lang: string; phrases: VoicePhrases } | null = null;
 
-/** Fetch voice phrases for the given language (merged with English fallback on server). */
+/** Fetch effective voice phrases for the given language (no English merge). */
 async function fetchVoicePhrases(lang?: string): Promise<VoicePhrases> {
   const effectiveLang = lang || 'en';
   if (phrasesCache && phrasesCache.lang === effectiveLang) return phrasesCache.phrases;


### PR DESCRIPTION
## Summary

Fixes language phrase-set behavior so non-English voice control no longer accepts English stop/cancel phrases by default.

## Problem

`GET /api/voice-phrases?lang=<x>` was returning the selected language merged with English fallback phrases.
This caused commands like English "done/cancel" to trigger while using Turkish (and other non-English languages).

## Changes

- `server/lib/voice-phrases.ts`
  - Updated `getVoicePhrases(lang)` to return **only** the selected language phrase set (`custom > defaults`), with no English merge.
  - Keep English fallback **only** when requested language has no configured/default set.
- `server/routes/voice-phrases.ts`
  - Updated endpoint docs/comments to match no-merge behavior.
- `src/features/voice/useVoiceInput.ts`
  - Updated client comment to reflect no English merge contract.

## Validation

- `npm run test -- src/features/voice/useVoiceInput.test.ts`
- `npm run build`

