### PR TITLE
fix(kanban): backfill missing config fields during migration

### DIFF
--- a/server/lib/kanban-store.ts
+++ b/server/lib/kanban-store.ts
@@ -310,9 +310,24 @@ export class KanbanStore {
     if (!Array.isArray(data.proposals)) {
       data.proposals = [];
     }
-    // Backfill proposalPolicy for existing configs
+    // Backfill missing config fields from defaults
+    if (!data.config.columns || data.config.columns.length === 0) {
+      data.config.columns = structuredClone(DEFAULT_CONFIG.columns);
+    }
+    if (!data.config.defaults || !data.config.defaults.status) {
+      data.config.defaults = structuredClone(DEFAULT_CONFIG.defaults);
+    }
     if (!data.config.proposalPolicy) {
       data.config.proposalPolicy = 'confirm';
+    }
+    if (data.config.reviewRequired === undefined) {
+      data.config.reviewRequired = DEFAULT_CONFIG.reviewRequired;
+    }
+    if (data.config.allowDoneDragBypass === undefined) {
+      data.config.allowDoneDragBypass = DEFAULT_CONFIG.allowDoneDragBypass;
+    }
+    if (data.config.quickViewLimit === undefined) {
+      data.config.quickViewLimit = DEFAULT_CONFIG.quickViewLimit;
     }
     data.meta.schemaVersion = CURRENT_SCHEMA_VERSION;
     return data;


### PR DESCRIPTION
## Summary

Fixes proposal approval 500 error caused by missing board config fields.

## Problem

`POST /api/kanban/proposals/:id/approve` returned `500 Internal Server Error` with:
```
Cannot read properties of undefined (reading 'status')
```

Root cause: the stored `tasks.json` config only had `{ "proposalPolicy": "confirm" }` — no `columns`, `defaults`, `reviewRequired`, etc. The migration only backfilled `proposalPolicy` but skipped everything else. When `_createTaskUnlocked` read `data.config.defaults.status`, it was `undefined`.

## Fix

Extended `migrate()` to backfill all missing config fields from `DEFAULT_CONFIG`:
- `columns` (if missing or empty)
- `defaults` (if missing or missing `.status`)
- `reviewRequired`
- `allowDoneDragBypass`
- `quickViewLimit`
- `proposalPolicy` (already existed)

## Validation

- Reproduced: create proposal → approve → 500
- After fix: create proposal → approve → 200 with task created
- `npm run build` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration migration now properly initializes additional missing fields with default values, ensuring data consistency and preventing potential configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->