### PR TITLE
fix(ui): file browser pane vertical scroll overflow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -526,7 +526,7 @@ export default function App({ onLogout }: AppProps) {
       
       <div className="flex-1 flex overflow-hidden min-h-0">
         {/* File tree — far left, collapsible; hidden (not unmounted) in kanban to preserve state */}
-        <div className={viewMode === 'kanban' ? 'hidden' : undefined}>
+        <div className={viewMode === 'kanban' ? 'hidden' : 'h-full min-h-0'}>
           <PanelErrorBoundary name="File Explorer">
             <FileTreePanel
               onOpenFile={openFile}

--- a/src/features/file-browser/FileTreePanel.tsx
+++ b/src/features/file-browser/FileTreePanel.tsx
@@ -488,7 +488,7 @@ export function FileTreePanel({
   return (
     <div
       ref={panelRef}
-      className="shrink-0 border-r border-border bg-background flex flex-col min-h-0 relative"
+      className="shrink-0 border-r border-border bg-background flex flex-col h-full min-h-0 relative"
       style={{ width }}
       onContextMenu={(e) => {
         // Right-click on empty panel area closes any open context menu.


### PR DESCRIPTION
## Problem

The file browser sidebar (left pane) does not scroll vertically when the file tree exceeds the viewport height. Files below the fold are unreachable.

## Root cause

The wrapper `<div>` around `FileTreePanel` in `App.tsx` had no height constraint. It sits inside a `flex-1 flex overflow-hidden min-h-0` parent, but without `h-full min-h-0` on the wrapper itself, flexbox doesn't constrain its height. The `overflow-y: auto` on the inner tree content div never activates because its container grows unbounded.

## Fix

Added `h-full min-h-0` to the file browser wrapper div. One line, zero behavior change beyond enabling scroll.

## Validation

Built and deployed. File tree with 40+ entries now scrolls vertically as expected.