### PR TITLE
fix: chat message integrity - scroll race, immutability, send race

### DIFF
--- a/code-reviews/pre-1.5/fix-reports/fix-chat-message-integrity.md
+++ b/code-reviews/pre-1.5/fix-reports/fix-chat-message-integrity.md
@@ -1,0 +1,56 @@
+# Fix Report: Chat Message Integrity
+
+**Branch:** `fix/chat-message-integrity`
+**Fixes:** #2, #4, #8, #18 from MASTER-REVIEW-v3.md
+**Files changed:** 4 (23 insertions, 17 deletions)
+
+## Fix #2: Infinite scroll race condition
+
+**File:** `src/features/chat/ChatPanel.tsx`
+
+**Problem:** IntersectionObserver useEffect depended on `messages.length`, causing teardown/recreate on every message change. After `loadMore()` prepends messages, the new observer fires immediately while `isLoadingMore.current` is still true from the previous cycle.
+
+**Fix:**
+- Added `loadMoreRef` and `hasMoreRef` refs, kept in sync via dedicated effects
+- Observer callback reads from refs instead of closure-captured values
+- Removed `messages.length` from the observer useEffect dependency array
+- Added `!loadMoreRef.current || !hasMoreRef.current` guard inside observer callback
+
+Observer is now stable across message changes. No teardown/recreate churn.
+
+## Fix #4: groupToolMessages mutates input array
+
+**File:** `src/features/chat/operations/loadHistory.ts`
+
+**Problem:** `msg.images = [...]` in `groupToolMessages()` directly mutates objects shared by React state, violating React's immutability contract.
+
+**Fix:** Instead of mutating `msg` and then pushing it, we now push a spread copy with the new images. Non-image messages still push the original reference (no unnecessary copies).
+
+## Fix #8: handleSend read-then-write race
+
+**File:** `src/contexts/ChatContext.tsx` + `src/hooks/useChatMessages.ts`
+
+**Problem:** `getAllMessages()` then `setAllMessages([...msgs, userMsg])` is non-atomic. A streaming event arriving between the read and write (especially after `await sendChatMessage`) overwrites intervening state updates.
+
+**Fix:**
+- Extended `setAllMessages` to accept a functional updater: `(prev: ChatMsg[]) => ChatMsg[]`
+- Converted all read-then-write patterns in `handleSend` to functional updaters:
+  - Optimistic insert: `setAllMessages(prev => [...prev, userMsg])`
+  - Confirm: `setAllMessages(prev => prev.map(confirmMsg))`
+  - Fail: `setAllMessages(prev => prev.map(failMsg))`
+  - Error bubble: `setAllMessages(prev => [...prev, errMsgBubble])`
+
+The ref-based `setAllMessages` now atomically reads and writes in one call.
+
+## Fix #18: mergeFinalMessages mutates incoming objects
+
+**File:** `src/hooks/useChatMessages.ts`
+
+**Problem:** `msg.msgId = generateMsgId()` in `mergeFinalMessages()` directly mutates objects from the incoming array, which may be shared by other React state references.
+
+**Fix:** Replaced mutation with conditional shallow copy. Objects that already have a `msgId` are pushed as-is (zero-cost). Only missing-ID objects get a copy.
+
+## Build Verification
+
+- `vite build`: Clean (0 errors)
+- `tsc --noEmit`: No type errors in changed files

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -552,8 +552,8 @@ export function ChatProvider({ children }: { children: ReactNode }) {
 
     recoveryHook.incrementGeneration();
 
-    // Optimistic insert
-    msgHook.setAllMessages([...msgHook.getAllMessages(), userMsg]);
+    // Optimistic insert (functional updater to avoid read-then-write race)
+    msgHook.setAllMessages(prev => [...prev, userMsg]);
     msgHook.setMessages((prev: ChatMsg[]) => [...prev, userMsg]);
     setIsGenerating(true);
     streamHook.setStream((prev: ChatStreamState) => ({ ...prev, html: '', runId: undefined }));
@@ -577,15 +577,15 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         streamHook.startThinking(ack.runId);
       }
 
-      // Confirm the message
+      // Confirm the message (functional updater to avoid race after await)
       const confirmMsg = (m: ChatMsg) => m.tempId === tempId ? { ...m, pending: false } : m;
-      msgHook.setAllMessages(msgHook.getAllMessages().map(confirmMsg));
+      msgHook.setAllMessages(prev => prev.map(confirmMsg));
       msgHook.setMessages((prev: ChatMsg[]) => prev.map(confirmMsg));
     } catch (e) {
       const errMsg = e instanceof Error ? e.message : String(e);
 
       const failMsg = (m: ChatMsg) => m.tempId === tempId ? { ...m, pending: false, failed: true } : m;
-      msgHook.setAllMessages(msgHook.getAllMessages().map(failMsg));
+      msgHook.setAllMessages(prev => prev.map(failMsg));
       msgHook.setMessages((prev: ChatMsg[]) => prev.map(failMsg));
 
       const errMsgBubble: ChatMsg = {
@@ -595,7 +595,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         rawText: '',
         timestamp: new Date(),
       };
-      msgHook.setAllMessages([...msgHook.getAllMessages(), errMsgBubble]);
+      msgHook.setAllMessages(prev => [...prev, errMsgBubble]);
       msgHook.setMessages((prev: ChatMsg[]) => [...prev, errMsgBubble]);
       setIsGenerating(false);
     }
@@ -636,7 +636,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         rawText: '',
         timestamp: new Date(),
       };
-      msgHook.setAllMessages([...msgHook.getAllMessages(), msg]);
+      msgHook.setAllMessages(prev => [...prev, msg]);
       msgHook.setMessages((prev: ChatMsg[]) => [...prev, msg]);
     }
   }, [msgHook, rpc]);

--- a/src/features/chat/ChatPanel.tsx
+++ b/src/features/chat/ChatPanel.tsx
@@ -59,24 +59,30 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
   const prevMessageCount = useRef(0);
   const sentinelRef = useRef<HTMLDivElement>(null);
   const isLoadingMore = useRef(false);
+  const loadMoreRef = useRef(loadMore);
+  const hasMoreRef = useRef(hasMore);
+
+  // Keep refs in sync so the observer callback always sees current values
+  useEffect(() => { loadMoreRef.current = loadMore; }, [loadMore]);
+  useEffect(() => { hasMoreRef.current = hasMore; }, [hasMore]);
 
   // Infinite scroll — load older messages when sentinel enters viewport
   useEffect(() => {
-    if (!loadMore || !hasMore) return;
+    if (!loadMoreRef.current || !hasMoreRef.current) return;
     const sentinel = sentinelRef.current;
     const container = scrollRef.current;
     if (!sentinel || !container) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
-        if (!entries[0].isIntersecting || isLoadingMore.current) return;
+        if (!entries[0].isIntersecting || isLoadingMore.current || !loadMoreRef.current || !hasMoreRef.current) return;
         isLoadingMore.current = true;
 
         // Preserve scroll position: record distance from bottom before prepend
         const prevScrollHeight = container.scrollHeight;
         const prevScrollTop = container.scrollTop;
 
-        loadMore();
+        loadMoreRef.current();
 
         // After React commits DOM updates, restore scroll position.
         // Double-rAF ensures we run after React's commit + browser layout.
@@ -94,7 +100,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [loadMore, hasMore, messages.length]);
+  }, [loadMore, hasMore]);
 
   // Expose focusInput to parent
   useImperativeHandle(ref, () => ({

--- a/src/features/chat/operations/loadHistory.ts
+++ b/src/features/chat/operations/loadHistory.ts
@@ -370,10 +370,11 @@ export function groupToolMessages(msgs: ChatMsg[]): ChatMsg[] {
       flushTools();
       // Attach any rescued images from preceding tool results
       if (pendingImages.length > 0 && msg.role === 'assistant') {
-        msg.images = [...(msg.images || []), ...pendingImages];
+        grouped.push({ ...msg, images: [...(msg.images || []), ...pendingImages] });
         pendingImages = [];
+      } else {
+        grouped.push(msg);
       }
-      grouped.push(msg);
     }
   }
   flushTools();

--- a/src/hooks/useChatMessages.ts
+++ b/src/hooks/useChatMessages.ts
@@ -66,8 +66,7 @@ export function mergeFinalMessages(existing: ChatMsg[], incoming: ChatMsg[]): Ch
       if (duplicateRecentUser) continue;
     }
 
-    if (!msg.msgId) msg.msgId = generateMsgId();
-    merged.push(msg);
+    merged.push(msg.msgId ? msg : { ...msg, msgId: generateMsgId() });
   }
 
   return merged;
@@ -162,9 +161,9 @@ export function useChatMessages({ rpc, currentSessionRef }: UseChatMessagesDeps)
   /** Get all messages (full buffer, not just visible window). */
   const getAllMessages = useCallback(() => allMessagesRef.current, []);
 
-  /** Set all messages buffer directly (for optimistic inserts). */
-  const setAllMessages = useCallback((all: ChatMsg[]) => {
-    allMessagesRef.current = all;
+  /** Set all messages buffer directly, or via functional updater for atomic read-then-write. */
+  const setAllMessages = useCallback((updater: ChatMsg[] | ((prev: ChatMsg[]) => ChatMsg[])) => {
+    allMessagesRef.current = typeof updater === 'function' ? updater(allMessagesRef.current) : updater;
   }, []);
 
   /** Reset message state (for session switch). */


### PR DESCRIPTION
## Problems

Four related chat integrity issues found in the pre-1.5 code review:

1. **Infinite scroll stall** (`ChatPanel.tsx`): IntersectionObserver recreated on every message change due to `messages.length` in deps. After `loadMore()` prepends messages, the new observer fires while `isLoadingMore` is still true, permanently stalling scroll loading.

2. **groupToolMessages mutation** (`loadHistory.ts`): `msg.images = [...]` mutates objects shared by React state, breaking memo comparisons and causing stale renders.

3. **handleSend race** (`ChatContext.tsx`): `getAllMessages()` then `setAllMessages([...msgs, userMsg])` is non-atomic. A streaming event arriving between the two calls gets silently overwritten.

4. **mergeFinalMessages mutation** (`useChatMessages.ts`): `msg.msgId = generateMsgId()` mutates incoming message objects, same immutability violation as #2.

## Fixes

1. Remove `messages.length` from observer deps; use refs for `loadMore` and `hasMore`.
2. Spread into new object instead of mutating: `{ ...msg, images: [...] }`.
3. Switch to functional updater: `setAllMessages(prev => [...prev, userMsg])`.
4. Shallow copy before mutation: `{ ...msg, msgId: generateMsgId() }`.

## Files Changed

- `src/features/chat/ChatPanel.tsx`
- `src/features/chat/operations/loadHistory.ts`
- `src/contexts/ChatContext.tsx`
- `src/hooks/useChatMessages.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved chat message loading stability to prevent unnecessary reloads during scrolling.
  * Fixed message sending race conditions that could cause state inconsistencies.
  * Resolved chat message mutation issues that affected message integrity when grouping and merging.
  * Enhanced atomic state updates to ensure messages are processed reliably in concurrent scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->