### PR TITLE
fix: prevent stale WebSocket onclose from killing active connection

### DIFF
--- a/code-reviews/pre-1.5/fix-reports/fix-websocket-reconnect-race.md
+++ b/code-reviews/pre-1.5/fix-reports/fix-websocket-reconnect-race.md
@@ -1,0 +1,30 @@
+# Fix #5: WebSocket reconnect race kills active connection
+
+**Branch:** `fix/websocket-reconnect-race`
+**File:** `src/hooks/useWebSocket.ts`
+**Commit:** `fix: prevent stale WebSocket onclose from killing active connection`
+
+## Problem
+
+When `doConnect` is called while a socket is already open, it closes the old socket and creates a new one. The old socket's `onclose` fires asynchronously, sees `intentionalDisconnectRef = false`, and schedules a reconnect timer. That timer fires, calls `doConnect` again, killing the newly-active connection. This creates cascading disconnections.
+
+## Fix
+
+Added a connection generation counter (`connectionGenRef`) as a `useRef(0)`.
+
+1. **`connectionGenRef`** declared alongside other refs (line 76)
+2. **`doConnect`** increments the counter at entry and captures the value in a local `gen` variable (line 118)
+3. **`onclose`** checks if `gen !== connectionGenRef.current` before running any reconnect logic. If stale (a newer `doConnect` has already fired), it returns immediately (line 231)
+
+This ensures that when a new connection supersedes an old one, the old socket's `onclose` handler is a no-op for reconnection purposes.
+
+## Changes
+
+- +6 lines, -1 line (whitespace normalization)
+- No behavioral changes outside the race condition fix
+- No new dependencies
+
+## Verification
+
+- `npm run build` passes (no TS errors in `useWebSocket.ts`)
+- Change is purely additive: existing reconnect behavior is untouched for non-racing scenarios

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -73,6 +73,7 @@ export function useWebSocket(): UseWebSocketReturn {
   const hasConnectedRef = useRef(false);
   const doConnectRef = useRef<((url: string, token: string, isReconnect: boolean) => Promise<void>) | null>(null);
   const instanceIdRef = useRef(getOrCreateInstanceId());
+  const connectionGenRef = useRef(0);
 
   const rejectPending = useCallback((reason: Error) => {
     const pending = pendingRef.current;
@@ -114,6 +115,7 @@ export function useWebSocket(): UseWebSocketReturn {
 
   const doConnect = useCallback((url: string, token: string, isReconnect: boolean): Promise<void> => {
     return new Promise((resolve, reject) => {
+      const gen = ++connectionGenRef.current;
       if (!isReconnect) {
         setConnectError('');
       }
@@ -226,7 +228,10 @@ export function useWebSocket(): UseWebSocketReturn {
 
       ws.onclose = () => {
         rejectPending(new Error('WebSocket disconnected'));
-        
+
+        // Stale connection: a newer doConnect has already superseded this one
+        if (gen !== connectionGenRef.current) return;
+
         // Don't reconnect if intentionally disconnected, no credentials, or never connected
         if (intentionalDisconnectRef.current || !credentialsRef.current || !hasConnectedRef.current) {
           setConnectionState('disconnected');


### PR DESCRIPTION
## Problem

When `doConnect` is called while a socket is open, it closes the old socket and creates a new one. The old socket's `onclose` fires asynchronously, sees `intentionalDisconnectRef = false`, and schedules a reconnect timer. That timer calls `doConnect` again, killing the active connection. This cascades into repeated disconnections.

## Fix

Add a connection generation counter ref. Increment on each `doConnect` call, capture the current generation in a local variable. In `onclose`, compare the captured generation against the current ref value. If stale, skip reconnection entirely.

## Files Changed

- `src/hooks/useWebSocket.ts` (+6/-1)
