### PR TITLE
fix: UI polish - ConfirmDialog enter, highlight case, theme link

### DIFF
--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -42,11 +42,7 @@ export function ConfirmDialog({
 
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key === 'Escape') onCancel();
-    if (e.key === 'Enter' && dialogRef.current?.contains(document.activeElement)) {
-      e.preventDefault();
-      onConfirm();
-    }
-  }, [onConfirm, onCancel]);
+  }, [onCancel]);
 
   const handleTabKey = useCallback((e: KeyboardEvent) => {
     if (e.key !== 'Tab' || !dialogRef.current) return;

--- a/src/lib/highlight.ts
+++ b/src/lib/highlight.ts
@@ -91,6 +91,9 @@ EXT_LANG_MAP['h'] = 'c';
 EXT_LANG_MAP['m'] = 'objectivec';
 EXT_LANG_MAP['vue'] = 'xml';
 EXT_LANG_MAP['svelte'] = 'xml';
+// Extensionless filenames (lowercase for detectLanguage lookup)
+EXT_LANG_MAP['dockerfile'] = 'dockerfile';
+EXT_LANG_MAP['makefile'] = 'makefile';
 
 /** Get file extension for a code-fence language identifier */
 export function getExtension(lang: string): string {
@@ -102,7 +105,11 @@ export function getExtension(lang: string): string {
 /** Detect highlight.js language from a file path */
 export function detectLanguage(filePath?: string): string {
   if (!filePath) return '';
-  const ext = filePath.split('.').pop()?.toLowerCase() || '';
+  const filename = filePath.split('/').pop() || '';
+  // Check full filename first (Dockerfile, Makefile, etc.)
+  const byName = EXT_LANG_MAP[filename.toLowerCase()];
+  if (byName) return byName;
+  const ext = filename.split('.').pop()?.toLowerCase() || '';
   return EXT_LANG_MAP[ext] || '';
 }
 

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -770,7 +770,7 @@ export function applyTheme(themeName: ThemeName): void {
   const hljsHref = `/hljs/${hljsTheme}.min.css`;
   
   if (existingLink) {
-    if (existingLink.href !== hljsHref) {
+    if (existingLink.getAttribute('href') !== hljsHref) {
       existingLink.href = hljsHref;
     }
   } else {


### PR DESCRIPTION
## Problems

Three UI fixes from the pre-1.5 code review:

1. **ConfirmDialog Enter key** (`ConfirmDialog.tsx`): Global keydown handler fires `onConfirm` on Enter regardless of which button is focused. Tab to Cancel, press Enter, it confirms. Dangerous for destructive dialogs.

2. **Dockerfile/Makefile highlighting** (`highlight.ts`): `EXT_LANG_MAP` stores keys as `Dockerfile`/`Makefile` but `detectLanguage` lowercases the extension. These files get no syntax highlighting.

3. **Theme switch redundant CSS load** (`themes.ts`): Compares `existingLink.href` (absolute URL) against a relative path. Never matches, so the hljs stylesheet is needlessly reloaded on every theme switch.

## Fixes

1. Remove Enter handling from global keydown listener. Native button focus + Enter handles it correctly.
2. Check full lowercase filename against the map before falling back to extension lookup.
3. Use `getAttribute('href')` instead of `.href` for raw attribute comparison.

## Files Changed

- `src/components/ConfirmDialog.tsx`
- `src/lib/highlight.ts`
- `src/lib/themes.ts`
