### PR TITLE
feat: add NERVE_LAN_EXPOSE_TOKEN to expose gateway token to LAN clients

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,11 @@ GATEWAY_TOKEN=
 # OPENCLAW_GATEWAY_TOKEN=  # Alternative name for GATEWAY_TOKEN (checked as fallback)
 GATEWAY_URL=http://127.0.0.1:18789
 
+# Expose GATEWAY_TOKEN to non-loopback LAN clients (remote browsers)
+# When enabled, remote clients will receive the token via /api/connect-defaults
+# Default: false (token only exposed to localhost/127.0.0.1)
+# NERVE_LAN_EXPOSE_TOKEN=false
+
 # ─── Authentication ──────────────────────────────────────────────────────────
 # Enable to require a password for all API/WebSocket access.
 # The setup wizard configures these automatically when network access is chosen.

--- a/server/lib/config.ts
+++ b/server/lib/config.ts
@@ -68,6 +68,8 @@ export const config = {
   // Gateway connection
   gatewayUrl: process.env.GATEWAY_URL || DEFAULT_GATEWAY_URL,
   gatewayToken: process.env.GATEWAY_TOKEN || process.env.OPENCLAW_GATEWAY_TOKEN || '',
+  // Expose gateway token to non-loopback LAN clients (security: disabled by default)
+  lanExposeToken: (process.env.NERVE_LAN_EXPOSE_TOKEN || 'false').toLowerCase() === 'true',
 
   // Agent identity (used in UI)
   agentName: process.env.AGENT_NAME || 'Agent',

--- a/server/routes/connect-defaults.ts
+++ b/server/routes/connect-defaults.ts
@@ -41,9 +41,14 @@ app.get('/api/connect-defaults', rateLimitGeneral, (c) => {
     wsUrl = gwUrl.replace(/^http/, 'ws');
   }
 
+  // Return token if:
+  // 1. Client is loopback, OR
+  // 2. NERVE_LAN_EXPOSE_TOKEN is enabled in .env
+  const shouldExposeToken = isLoopback || config.lanExposeToken;
+
   return c.json({
     wsUrl,
-    token: isLoopback ? (config.gatewayToken || null) : null,
+    token: shouldExposeToken ? (config.gatewayToken || null) : null,
     agentName: config.agentName,
   });
 });


### PR DESCRIPTION
When enabled, remote LAN clients will receive the gateway token via /api/connect-defaults instead of requiring manual entry.

Security: disabled by default, only loopback clients receive token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional configuration to control gateway token exposure to LAN clients. When enabled, network clients can receive tokens directly; when disabled (default), only loopback connections have access for enhanced security.

* **Chores**
  * Updated environment configuration with new token exposure settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->