### PR TITLE
fix(file-browser): evict invalid paths from tree cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Create recurring jobs and one-shot reminders. Every scheduled run shows up as it
 |---|---|
 | **Voice I/O** | Push-to-talk + wake word, live transcription preview, language-aware stop/cancel phrases, local Whisper model picker, TTS providers (Edge/OpenAI/Replicate) |
 | **Streaming chat** | Markdown, syntax highlighting, diff views, image paste, file previews. All rendering as it streams |
-| **File browser** | Browse your workspace, rename, move, trash, and restore files. Open files in tabs |
+| **File browser** | Browse your workspace, rename, move, trash, and restore files. Open files in tabs. Support for custom workspace roots via `FILE_BROWSER_ROOT` |
 | **Built-in editor** | CodeMirror editor with syntax highlighting, conflict-safe saves, and automatic lock protection during concurrent agent edits |
 | **Multi-session** | Session tree with sub-agents, per-session model overrides, unread indicators |
 | **Kanban board** | Drag-and-drop task management with agent execution, review workflow, and proposal inbox |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -243,7 +243,8 @@ REPLICATE_BASE_URL=https://api.replicate.com/v1
 ### File Paths
 
 | Variable | Default | Description |
-|----------|---------|-------------|
+|---------|---------|-------------|
+| `FILE_BROWSER_ROOT` | `""` (disabled) | If set, overrides OpenClaw workspace as the root directory for the workspace directory tree. In this mode, default exclusion rules are disabled and delete operations are permanent (no `.trash` recovery). |
 | `MEMORY_PATH` | `~/.openclaw/workspace/MEMORY.md` | Path to the agent's long-term memory file |
 | `MEMORY_DIR` | `~/.openclaw/workspace/memory/` | Directory for daily memory files (`YYYY-MM-DD.md`) |
 | `SESSIONS_DIR` | `~/.openclaw/agents/main/sessions/` | Session transcript directory (scanned for token usage) |
@@ -252,6 +253,7 @@ REPLICATE_BASE_URL=https://api.replicate.com/v1
 | `WORKSPACE_ROOT` | *(auto-detected)* | Allowed base directory for git workdir registration. Auto-derived from `git worktree list` or parent of `process.cwd()` |
 
 ```env
+FILE_BROWSER_ROOT=/home/user
 MEMORY_PATH=/custom/path/MEMORY.md
 MEMORY_DIR=/custom/path/memory/
 SESSIONS_DIR=/custom/path/sessions/

--- a/scripts/lib/env-writer.ts
+++ b/scripts/lib/env-writer.ts
@@ -21,6 +21,7 @@ export interface EnvConfig {
   MEMORY_DIR?: string;
   SESSIONS_DIR?: string;
   USAGE_FILE?: string;
+  FILE_BROWSER_ROOT?: string;
   TTS_CACHE_TTL_MS?: string;
   TTS_CACHE_MAX?: string;
   VITE_PORT?: string;
@@ -114,6 +115,7 @@ export function generateEnvContent(config: EnvConfig): string {
   if (config.MEMORY_DIR) advLines.push(`MEMORY_DIR=${config.MEMORY_DIR}`);
   if (config.SESSIONS_DIR) advLines.push(`SESSIONS_DIR=${config.SESSIONS_DIR}`);
   if (config.USAGE_FILE) advLines.push(`USAGE_FILE=${config.USAGE_FILE}`);
+  if (config.FILE_BROWSER_ROOT) advLines.push(`FILE_BROWSER_ROOT=${config.FILE_BROWSER_ROOT}`);
   if (advLines.length > 0) {
     lines.push('# Advanced');
     lines.push(...advLines);

--- a/server/lib/config.ts
+++ b/server/lib/config.ts
@@ -77,6 +77,7 @@ export const config = {
   // Paths (configurable via env, with OpenClaw defaults)
   dist: path.join(PROJECT_ROOT, 'dist'),
   agentLogPath: path.join(PROJECT_ROOT, 'agent-log.json'),
+  fileBrowserRoot: process.env.FILE_BROWSER_ROOT || '',
   memoryPath: process.env.MEMORY_PATH || path.join(HOME, '.openclaw', 'workspace', 'MEMORY.md'),
   memoryDir: process.env.MEMORY_DIR || path.join(HOME, '.openclaw', 'workspace', 'memory'),
   sessionsDir: process.env.SESSIONS_DIR || path.join(HOME, '.openclaw', 'agents', 'main', 'sessions'),
@@ -288,6 +289,19 @@ export function validateConfig(): void {
       }
     } else {
       console.warn(`[config] ⚠ Unknown Whisper model: ${config.whisperModel}`);
+    }
+  }
+
+  // ── FILE_BROWSER_ROOT validation ───────────────────────────────────────
+  if (config.fileBrowserRoot) {
+    try {
+      const stat = fs.statSync(config.fileBrowserRoot);
+      if (!stat.isDirectory()) {
+        throw new Error('FILE_BROWSER_ROOT is not a directory');
+      }
+    } catch {
+      console.warn('[config] ⚠ FILE_BROWSER_ROOT is not a directory or is inaccessible, falling back to default');
+      (config as typeof config & { fileBrowserRoot: string }).fileBrowserRoot = '';
     }
   }
 }

--- a/server/lib/file-ops.ts
+++ b/server/lib/file-ops.ts
@@ -14,6 +14,7 @@ import {
   isExcluded,
   resolveWorkspacePath,
 } from './file-utils.js';
+import { config } from './config.js';
 import { withMutex } from './mutex.js';
 
 const TRASH_DIR = '.trash';
@@ -366,9 +367,14 @@ export async function moveEntry(params: { sourcePath: string; targetDirPath: str
     const targetRel = toWorkspaceRelative(targetAbs);
     assertNotProtectedTarget(targetRel);
 
-    // Prevent bypassing trash metadata by moving directly into .trash via generic move.
+    // Allow moves to .trash in custom workspaces (treated as regular directory)
     if (!isInTrash(sourceRel) && isInTrash(targetRel)) {
-      throw new FileOpError(422, 'use_trash_api', 'Use the trash action for deleting items');
+      const customRoot = config.fileBrowserRoot;
+      if (customRoot && customRoot.trim() !== '') {
+        // Custom workspace: allow .trash moves
+      } else {
+        throw new FileOpError(422, 'use_trash_api', 'Use the trash action for deleting items');
+      }
     }
 
     if (sourceAbs === targetAbs) {

--- a/server/lib/file-utils.test.ts
+++ b/server/lib/file-utils.test.ts
@@ -1,0 +1,215 @@
+/** Tests for file-utils.ts - exclusion rules, workspace root, and path validation. */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+describe('file-utils', () => {
+  let tmpDir: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    originalEnv = { ...process.env };
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'file-utils-test-'));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    process.env = originalEnv;
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('exclusion rules with FILE_BROWSER_ROOT', () => {
+    describe('dynamic exclusion rules', () => {
+      it('disables exclusions when FILE_BROWSER_ROOT is set', async () => {
+        process.env.FILE_BROWSER_ROOT = '/custom/workspace';
+        vi.resetModules();
+        
+        const { isExcluded } = await import('./file-utils.js');
+        
+        // When FILE_BROWSER_ROOT is set, exclusions are disabled
+        expect(isExcluded('node_modules')).toBe(false);
+        expect(isExcluded('.git')).toBe(false);
+        expect(isExcluded('dist')).toBe(false);
+      });
+
+      it('enables exclusions when FILE_BROWSER_ROOT is not set', async () => {
+        delete process.env.FILE_BROWSER_ROOT;
+        vi.resetModules();
+        
+        const { isExcluded } = await import('./file-utils.js');
+        
+        // When FILE_BROWSER_ROOT is not set, exclusions are enabled
+        expect(isExcluded('node_modules')).toBe(true);
+        expect(isExcluded('.git')).toBe(true);
+        expect(isExcluded('dist')).toBe(true);
+        expect(isExcluded('src')).toBe(false);
+        expect(isExcluded('README.md')).toBe(false);
+      });
+
+      it('handles empty string FILE_BROWSER_ROOT correctly', async () => {
+        // Test that empty string behaves like unset (enables exclusions)
+        process.env.FILE_BROWSER_ROOT = '';
+        vi.resetModules();
+        
+        const { isExcluded } = await import('./file-utils.js');
+        
+        // Empty string should enable exclusions
+        expect(isExcluded('node_modules')).toBe(true);
+        expect(isExcluded('.git')).toBe(true);
+        expect(isExcluded('src')).toBe(false);
+      });
+    });
+  });
+
+  describe('getWorkspaceRoot', () => {
+    it('returns FILE_BROWSER_ROOT when set', async () => {
+      process.env.FILE_BROWSER_ROOT = '/custom/root/path';
+      vi.resetModules();
+      
+      const { getWorkspaceRoot } = await import('./file-utils.js');
+      expect(getWorkspaceRoot()).toBe(path.resolve('/custom/root/path'));
+    });
+
+    it('returns parent of MEMORY.md when FILE_BROWSER_ROOT is not set', async () => {
+      delete process.env.FILE_BROWSER_ROOT;
+      vi.resetModules();
+      
+      const { getWorkspaceRoot } = await import('./file-utils.js');
+      const result = getWorkspaceRoot();
+      // Should return parent of default memory path
+      expect(result).toContain('.openclaw');
+      expect(result).toContain('workspace');
+    });
+
+    it('returns parent of MEMORY.md when FILE_BROWSER_ROOT is empty string', async () => {
+      process.env.FILE_BROWSER_ROOT = '';
+      vi.resetModules();
+      
+      const { getWorkspaceRoot } = await import('./file-utils.js');
+      const result = getWorkspaceRoot();
+      // Should return parent of default memory path
+      expect(result).toContain('.openclaw');
+      expect(result).toContain('workspace');
+    });
+  });
+
+  describe('resolveWorkspacePath with filesystem root custom workspace', () => {
+    it('allows resolving child paths when root is "/" (or drive root)', async () => {
+      const fsRoot = path.parse(os.tmpdir()).root;
+      process.env.FILE_BROWSER_ROOT = fsRoot;
+      vi.resetModules();
+
+      const { resolveWorkspacePath } = await import('./file-utils.js');
+      const relTmpDir = path.relative(fsRoot, os.tmpdir());
+      const candidate = path.join(relTmpDir, 'non-existent.txt');
+
+      const resolved = await resolveWorkspacePath(candidate, { allowNonExistent: true });
+      expect(resolved).toBe(path.resolve(fsRoot, candidate));
+    });
+  });
+
+  describe('isBinary', () => {
+    it('identifies common binary file extensions', async () => {
+      const { isBinary } = await import('./file-utils.js');
+      
+      // Images
+      expect(isBinary('image.png')).toBe(true);
+      expect(isBinary('photo.jpg')).toBe(true);
+      expect(isBinary('graphic.jpeg')).toBe(true);
+      expect(isBinary('animation.gif')).toBe(true);
+      expect(isBinary('modern.webp')).toBe(true);
+      expect(isBinary('vector.svg')).toBe(true);
+      expect(isBinary('icon.ico')).toBe(true);
+      
+      // Audio/Video
+      expect(isBinary('music.mp3')).toBe(true);
+      expect(isBinary('video.mp4')).toBe(true);
+      expect(isBinary('audio.wav')).toBe(true);
+      expect(isBinary('sound.ogg')).toBe(true);
+      expect(isBinary('lossless.flac')).toBe(true);
+      expect(isBinary('web-video.webm')).toBe(true);
+      
+      // Archives
+      expect(isBinary('archive.zip')).toBe(true);
+      expect(isBinary('source.tar')).toBe(true);
+      expect(isBinary('compressed.gz')).toBe(true);
+      expect(isBinary('archive.bz2')).toBe(true);
+      expect(isBinary('packed.7z')).toBe(true);
+      expect(isBinary('archive.rar')).toBe(true);
+      
+      // Documents
+      expect(isBinary('document.pdf')).toBe(true);
+      expect(isBinary('office.doc')).toBe(true);
+      expect(isBinary('spreadsheet.xls')).toBe(true);
+      expect(isBinary('presentation.docx')).toBe(true);
+      expect(isBinary('data.xlsx')).toBe(true);
+      
+      // Executables and libraries
+      expect(isBinary('program.exe')).toBe(true);
+      expect(isBinary('library.dll')).toBe(true);
+      expect(isBinary('shared.so')).toBe(true);
+      expect(isBinary('mac-library.dylib')).toBe(true);
+      
+      // Fonts
+      expect(isBinary('font.woff')).toBe(true);
+      expect(isBinary('font.woff2')).toBe(true);
+      expect(isBinary('font.ttf')).toBe(true);
+      expect(isBinary('font.eot')).toBe(true);
+      
+      // Databases
+      expect(isBinary('database.sqlite')).toBe(true);
+      expect(isBinary('data.db')).toBe(true);
+    });
+
+    it('identifies text files as non-binary', async () => {
+      const { isBinary } = await import('./file-utils.js');
+      
+      expect(isBinary('script.js')).toBe(false);
+      expect(isBinary('style.css')).toBe(false);
+      expect(isBinary('page.html')).toBe(false);
+      expect(isBinary('data.json')).toBe(false);
+      expect(isBinary('config.xml')).toBe(false);
+      expect(isBinary('document.md')).toBe(false);
+      expect(isBinary('readme.txt')).toBe(false);
+      expect(isBinary('script.py')).toBe(false);
+      expect(isBinary('script.ts')).toBe(false);
+      expect(isBinary('component.jsx')).toBe(false);
+    });
+
+    it('handles case insensitive extensions', async () => {
+      const { isBinary } = await import('./file-utils.js');
+      
+      expect(isBinary('IMAGE.PNG')).toBe(true);
+      expect(isBinary('Music.MP3')).toBe(true);
+      expect(isBinary('Document.PDF')).toBe(true);
+      expect(isBinary('Script.JS')).toBe(false);
+      expect(isBinary('Style.CSS')).toBe(false);
+    });
+
+    it('handles files without extensions', async () => {
+      const { isBinary } = await import('./file-utils.js');
+      
+      expect(isBinary('Makefile')).toBe(false);
+      expect(isBinary('README')).toBe(false);
+      expect(isBinary('executable')).toBe(false);
+    });
+
+    it('handles files with multiple dots', async () => {
+      const { isBinary } = await import('./file-utils.js');
+      
+      expect(isBinary('app.config.json')).toBe(false);
+      expect(isBinary('bundle.min.js')).toBe(false);
+      expect(isBinary('photo.thumbnail.jpg')).toBe(true);
+      expect(isBinary('archive.v1.tar.gz')).toBe(true);
+    });
+  });
+
+  describe('MAX_FILE_SIZE constant', () => {
+    it('exports the correct file size limit', async () => {
+      const { MAX_FILE_SIZE } = await import('./file-utils.js');
+      expect(MAX_FILE_SIZE).toBe(1_048_576); // 1 MB
+    });
+  });
+});

--- a/server/lib/file-utils.ts
+++ b/server/lib/file-utils.ts
@@ -12,13 +12,15 @@ import fs from 'node:fs/promises';
 import { config } from './config.js';
 
 // ── Exclusion rules ──────────────────────────────────────────────────
+// When FILE_BROWSER_ROOT is set, disable all exclusions to show complete directory structure
+// When using default workspace, apply standard exclusions for safety and cleanliness
 
-const EXCLUDED_NAMES = new Set([
+const DEFAULT_EXCLUDED_NAMES = new Set([
   'node_modules', '.git', 'dist', 'build', 'server-dist', 'certs',
   '.env', 'agent-log.json',
 ]);
 
-const EXCLUDED_PATTERNS = [
+const DEFAULT_EXCLUDED_PATTERNS = [
   /^\.env(\.|$)/,   // .env, .env.local, .env.production, etc.
   /\.log$/,
 ];
@@ -33,10 +35,26 @@ const BINARY_EXTENSIONS = new Set([
   '.sqlite', '.db',
 ]);
 
+const EMPTY_EXCLUDED_NAMES = new Set<string>();
+const EMPTY_EXCLUDED_PATTERNS: RegExp[] = [];
+
+/** Get exclusion names based on current config state */
+function getExcludedNames(): Set<string> {
+  return config.fileBrowserRoot && config.fileBrowserRoot.trim() !== '' ? EMPTY_EXCLUDED_NAMES : DEFAULT_EXCLUDED_NAMES;
+}
+
+/** Get exclusion patterns based on current config state */
+function getExcludedPatterns(): RegExp[] {
+  return config.fileBrowserRoot && config.fileBrowserRoot.trim() !== '' ? EMPTY_EXCLUDED_PATTERNS : DEFAULT_EXCLUDED_PATTERNS;
+}
+
 /** Check if a file/directory name should be excluded from the tree. */
 export function isExcluded(name: string): boolean {
-  if (EXCLUDED_NAMES.has(name)) return true;
-  return EXCLUDED_PATTERNS.some(p => p.test(name));
+  const excludedNames = getExcludedNames();
+  const excludedPatterns = getExcludedPatterns();
+
+  if (excludedNames.has(name)) return true;
+  return excludedPatterns.some(p => p.test(name));
 }
 
 /** Check if a file extension indicates binary content. */
@@ -46,9 +64,10 @@ export function isBinary(name: string): boolean {
 
 // ── Workspace root ───────────────────────────────────────────────────
 
-/** Resolve the workspace root directory (parent of MEMORY.md). */
+/** Resolve the workspace root directory. Uses FILE_BROWSER_ROOT if set and valid, otherwise parent of MEMORY.md. */
 export function getWorkspaceRoot(): string {
-  return path.dirname(config.memoryPath);
+  const customRoot = config.fileBrowserRoot.trim();
+  return customRoot ? path.resolve(customRoot) : path.dirname(config.memoryPath);
 }
 
 // ── Path validation ──────────────────────────────────────────────────
@@ -72,6 +91,7 @@ export async function resolveWorkspacePath(
   options?: { allowNonExistent?: boolean },
 ): Promise<string | null> {
   const root = getWorkspaceRoot();
+  const rootPrefix = root.endsWith(path.sep) ? root : root + path.sep;
 
   // Block obvious traversal attempts
   const normalized = path.normalize(relativePath);
@@ -88,14 +108,14 @@ export async function resolveWorkspacePath(
   const resolved = path.resolve(root, normalized);
 
   // Must be within workspace root
-  if (!resolved.startsWith(root + path.sep) && resolved !== root) {
+  if (!resolved.startsWith(rootPrefix) && resolved !== root) {
     return null;
   }
 
   // Resolve symlinks and re-check
   try {
     const real = await fs.realpath(resolved);
-    if (!real.startsWith(root + path.sep) && real !== root) {
+    if (!real.startsWith(rootPrefix) && real !== root) {
       return null;
     }
     return real;
@@ -107,7 +127,7 @@ export async function resolveWorkspacePath(
     const parent = path.dirname(resolved);
     try {
       const realParent = await fs.realpath(parent);
-      if (!realParent.startsWith(root + path.sep) && realParent !== root) {
+      if (!realParent.startsWith(rootPrefix) && realParent !== root) {
         return null;
       }
       return resolved;

--- a/server/routes/file-browser.test.ts
+++ b/server/routes/file-browser.test.ts
@@ -20,11 +20,16 @@ describe('file-browser routes', () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  async function buildApp() {
+  async function buildApp(opts?: { fileBrowserRoot?: string }) {
+    vi.resetModules();
     vi.doMock('../lib/config.js', () => ({
       config: {
-        auth: false, port: 3000, host: '127.0.0.1', sslPort: 3443,
+        auth: false,
+        port: 3000,
+        host: '127.0.0.1',
+        sslPort: 3443,
         memoryPath: path.join(tmpDir, 'MEMORY.md'),
+        fileBrowserRoot: opts?.fileBrowserRoot ?? '',
       },
       SESSION_COOKIE_NAME: 'nerve_session_3000',
     }));
@@ -364,6 +369,161 @@ describe('file-browser routes', () => {
       });
 
       expect(restoreRes.status).toBe(409);
+    });
+
+    it('uses normal trash behavior when FILE_BROWSER_ROOT is not set', async () => {
+      await fs.writeFile(path.join(tmpDir, 'test.txt'), 'test content');
+
+      const app = await buildApp();
+      const res = await app.request('/api/files/trash', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: 'test.txt' }),
+      });
+
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { ok: boolean; from: string; to: string; undoTtlMs?: number };
+      expect(json.ok).toBe(true);
+      expect(json.from).toBe('test.txt');
+      expect(json.to.startsWith('.trash/')).toBe(true);
+      expect(json.undoTtlMs).toBeGreaterThan(0);
+
+      // Verify file is moved to trash, not deleted
+      const originalPath = path.join(tmpDir, 'test.txt');
+      await expect(fs.readFile(originalPath, 'utf-8')).rejects.toThrow();
+
+      const trashPath = path.join(tmpDir, json.to);
+      await expect(fs.readFile(trashPath, 'utf-8')).resolves.toBe('test content');
+    });
+  });
+
+  describe('workspace info in tree response', () => {
+    it('includes workspace info when FILE_BROWSER_ROOT is not set', async () => {
+      await fs.writeFile(path.join(tmpDir, 'test.md'), '# Test');
+
+      const app = await buildApp();
+      const res = await app.request('/api/files/tree');
+      expect(res.status).toBe(200);
+
+      const json = (await res.json()) as {
+        ok: boolean;
+        entries: Array<{ name: string; type: string }>;
+        workspaceInfo?: { isCustomWorkspace: boolean; rootPath: string };
+      };
+
+      expect(json.ok).toBe(true);
+      expect(json.workspaceInfo).toBeDefined();
+      expect(json.workspaceInfo!.isCustomWorkspace).toBe(false);
+      expect(json.workspaceInfo!.rootPath).toBe(tmpDir);
+    });
+
+    it('includes workspace info when FILE_BROWSER_ROOT is set', async () => {
+      const customRoot = path.join(tmpDir, 'custom-workspace');
+      await fs.mkdir(customRoot);
+      await fs.writeFile(path.join(customRoot, 'test.md'), '# Test');
+
+      const app = await buildApp({ fileBrowserRoot: customRoot });
+      const res = await app.request('/api/files/tree');
+      expect(res.status).toBe(200);
+      
+      const json = (await res.json()) as { 
+        ok: boolean; 
+        entries: Array<{ name: string; type: string }>;
+        workspaceInfo?: { isCustomWorkspace: boolean; rootPath: string };
+      };
+      
+      expect(json.ok).toBe(true);
+      expect(json.workspaceInfo).toBeDefined();
+      expect(json.workspaceInfo).toEqual({
+        isCustomWorkspace: true,
+        rootPath: customRoot,
+      });
+    });
+  });
+
+  describe('POST /api/files/trash with FILE_BROWSER_ROOT', () => {
+    it('permanently deletes when FILE_BROWSER_ROOT is set', async () => {
+      const customRoot = path.join(tmpDir, 'custom-workspace');
+      await fs.mkdir(customRoot);
+      await fs.writeFile(path.join(customRoot, 'test.txt'), 'test content');
+
+      const app = await buildApp({ fileBrowserRoot: customRoot });
+      const res = await app.request('/api/files/trash', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: 'test.txt' }),
+      });
+
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { ok: boolean; from: string; to: string; undoTtlMs?: number };
+      expect(json.ok).toBe(true);
+      expect(json.from).toBe('test.txt');
+      expect(json.to).toBe('');
+      expect(json.undoTtlMs).toBeUndefined();
+
+      // Verify file was actually deleted from filesystem
+      const originalPath = path.join(customRoot, 'test.txt');
+      await expect(fs.readFile(originalPath, 'utf-8')).rejects.toThrow();
+    });
+
+    it('permanently deletes directories when FILE_BROWSER_ROOT is set', async () => {
+      const customRoot = path.join(tmpDir, 'custom-workspace');
+      await fs.mkdir(customRoot);
+      const testDir = path.join(customRoot, 'test-dir');
+      await fs.mkdir(testDir);
+      await fs.writeFile(path.join(testDir, 'file.txt'), 'content');
+
+      const app = await buildApp({ fileBrowserRoot: customRoot });
+      const res = await app.request('/api/files/trash', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: 'test-dir' }),
+      });
+
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { ok: boolean; from: string; to: string; undoTtlMs?: number };
+      expect(json.ok).toBe(true);
+      expect(json.from).toBe('test-dir');
+      expect(json.to).toBe('');
+      expect(json.undoTtlMs).toBeUndefined();
+
+      // Verify directory was actually deleted from filesystem
+      const originalDir = path.join(customRoot, 'test-dir');
+      await expect(fs.access(originalDir)).rejects.toThrow();
+    });
+
+    it('prevents deletion of workspace root with "." path', async () => {
+      const customRoot = path.join(tmpDir, 'custom-workspace');
+      await fs.mkdir(customRoot);
+
+      const app = await buildApp({ fileBrowserRoot: customRoot });
+      const res = await app.request('/api/files/trash', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: '.' }),
+      });
+
+      expect(res.status).toBe(400);
+      const json = (await res.json()) as { ok: boolean; error: string };
+      expect(json.ok).toBe(false);
+      expect(json.error).toBe('Deleting workspace root is not allowed');
+    });
+
+    it('prevents deletion of workspace root with "./" path', async () => {
+      const customRoot = path.join(tmpDir, 'custom-workspace');
+      await fs.mkdir(customRoot);
+
+      const app = await buildApp({ fileBrowserRoot: customRoot });
+      const res = await app.request('/api/files/trash', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: './' }),
+      });
+
+      expect(res.status).toBe(400);
+      const json = (await res.json()) as { ok: boolean; error: string };
+      expect(json.ok).toBe(false);
+      expect(json.error).toBe('Deleting workspace root is not allowed');
     });
   });
 

--- a/server/routes/file-browser.ts
+++ b/server/routes/file-browser.ts
@@ -21,6 +21,7 @@ import {
   isBinary,
   MAX_FILE_SIZE,
 } from '../lib/file-utils.js';
+import { config } from '../lib/config.js';
 import {
   FileOpError,
   moveEntry,
@@ -73,7 +74,10 @@ async function listDirectory(
     if (inTrash) {
       // Internal metadata file for restore bookkeeping.
       if (item.name === '.index.json') continue;
-    } else if (item.name.startsWith('.') && item.name !== '.nerveignore' && item.name !== '.trash') {
+    // FILE_BROWSER_ROOT: Show all files when custom root is set, but always hide .trash folder
+    } else if (!config.fileBrowserRoot && item.name.startsWith('.') && item.name !== '.nerveignore' && item.name !== '.trash') {
+      continue;
+    } else if (config.fileBrowserRoot && item.name === '.trash') {
       continue;
     }
 
@@ -148,7 +152,15 @@ app.get('/api/files/tree', async (c) => {
 
   const entries = await listDirectory(targetDir, subPath, depth);
 
-  return c.json({ ok: true, root: subPath || '.', entries });
+  return c.json({ 
+    ok: true, 
+    root: subPath || '.', 
+    entries,
+    workspaceInfo: {
+      isCustomWorkspace: !!config.fileBrowserRoot,
+      rootPath: getWorkspaceRoot(),
+    }
+  });
 });
 
 // ── GET /api/files/read ──────────────────────────────────────────────
@@ -330,8 +342,30 @@ app.post('/api/files/trash', async (c) => {
   }
 
   try {
-    const result = await trashEntry({ path: body.path });
-    return c.json({ ok: true, ...result });
+    // Custom directory browser root uses permanent deletion (no trash)
+    if (config.fileBrowserRoot) {
+      const requestedPath = body.path.trim();
+      if (requestedPath === '.' || requestedPath === './') {
+        return c.json({ ok: false, error: 'Deleting workspace root is not allowed' }, 400);
+      }
+      
+      const resolved = await resolveWorkspacePath(requestedPath);
+      if (!resolved) {
+        return c.json({ ok: false, error: 'Invalid or excluded path' }, 403);
+      }
+
+      const rootRealPath = await fs.realpath(getWorkspaceRoot()).catch(() => getWorkspaceRoot());
+      if (resolved === rootRealPath) {
+        return c.json({ ok: false, error: 'Deleting workspace root is not allowed' }, 400);
+      }
+
+      await fs.rm(resolved, { recursive: true, force: true });
+      return c.json({ ok: true, from: body.path, to: '' });
+    } else {
+      // Default workspace: use trash
+      const result = await trashEntry({ path: body.path });
+      return c.json({ ok: true, ...result });
+    }
   } catch (err) {
     return handleFileOpError(c, err);
   }

--- a/src/features/file-browser/FileTreePanel.test.tsx
+++ b/src/features/file-browser/FileTreePanel.test.tsx
@@ -1,0 +1,498 @@
+/** Tests for FileTreePanel component - custom workspace UI and confirmation modal. */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { FileTreePanel } from './FileTreePanel';
+import { useFileTree } from './hooks/useFileTree';
+
+// Mock the useFileTree hook
+vi.mock('./hooks/useFileTree', () => ({
+  useFileTree: vi.fn(),
+}));
+
+// Mock the ConfirmDialog component
+vi.mock('../../components/ConfirmDialog', () => ({
+  ConfirmDialog: ({ open, title, message, onConfirm, onCancel }: {
+    open: boolean;
+    title: string;
+    message: string;
+    onConfirm: () => void;
+    onCancel: () => void;
+  }) => {
+    if (!open) return null;
+    return (
+      <div data-testid="confirm-dialog">
+        <h2>{title}</h2>
+        <p>{message}</p>
+        <button onClick={onConfirm} data-testid="confirm-button">
+          Confirm
+        </button>
+        <button onClick={onCancel} data-testid="cancel-button">
+          Cancel
+        </button>
+      </div>
+    );
+  },
+}));
+
+// Mock file icons
+vi.mock('./utils/fileIcons', () => ({
+  FileIcon: ({ name }: { name: string }) => <div data-testid={`file-icon-${name}`} />,
+  FolderIcon: ({ open }: { open: boolean }) => <div data-testid={`folder-icon-${open ? 'open' : 'closed'}`} />,
+}));
+
+const mockOnOpenFile = vi.fn();
+const mockOnRemapOpenPaths = vi.fn();
+const mockOnCloseOpenPaths = vi.fn();
+
+const defaultMockHook = {
+  entries: [
+    { name: 'src', path: 'src', type: 'directory' as const, children: null },
+    { name: 'package.json', path: 'package.json', type: 'file' as const, children: null },
+  ],
+  loading: false,
+  error: null,
+  expandedPaths: new Set(),
+  selectedPath: null,
+  loadingPaths: new Set(),
+  workspaceInfo: null,
+  toggleDirectory: vi.fn(),
+  selectFile: vi.fn(),
+  refresh: vi.fn(),
+  handleFileChange: vi.fn(),
+};
+
+describe('FileTreePanel', () => {
+  let mockUseFileTree: vi.MockedFunction<typeof useFileTree>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+    // Use the statically imported mocked hook
+    mockUseFileTree = vi.mocked(useFileTree);
+    
+    // Mock localStorage
+    const localStorageMock = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    };
+    vi.stubGlobal('localStorage', localStorageMock);
+    mockUseFileTree.mockReturnValue(defaultMockHook);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe('header display', () => {
+    it('shows "Workspace" when not using custom workspace', () => {
+      render(
+        <FileTreePanel
+          onOpenFile={mockOnOpenFile}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+        />
+      );
+
+      expect(screen.getByText('Workspace')).toBeInTheDocument();
+    });
+
+    it('shows custom root path when using custom workspace', () => {
+      mockUseFileTree.mockReturnValue({
+        ...defaultMockHook,
+        workspaceInfo: {
+          isCustomWorkspace: true,
+          rootPath: '/home/user/custom-workspace',
+        },
+      });
+
+      render(
+        <FileTreePanel
+          onOpenFile={mockOnOpenFile}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+        />
+      );
+
+      expect(screen.getByText('/home/user/custom-workspace')).toBeInTheDocument();
+      expect(screen.queryByText('Workspace')).not.toBeInTheDocument();
+    });
+
+    it('shows custom root path for different custom workspaces', () => {
+      mockUseFileTree.mockReturnValue({
+        ...defaultMockHook,
+        workspaceInfo: {
+          isCustomWorkspace: true,
+          rootPath: '/var/www/project',
+        },
+      });
+
+      render(
+        <FileTreePanel
+          onOpenFile={mockOnOpenFile}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+        />
+      );
+
+      expect(screen.getByText('/var/www/project')).toBeInTheDocument();
+    });
+  });
+
+  describe('context menu for deletion', () => {
+    it('shows "Move to Trash" for default workspace', async () => {
+      render(
+        <FileTreePanel
+          onOpenFile={mockOnOpenFile}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+        />
+      );
+
+      // Simulate context menu
+      const contextMenuEvent = new MouseEvent('contextmenu', { bubbles: true });
+      fireEvent.contextMenu(screen.getByText('src'), contextMenuEvent);
+
+      await waitFor(() => {
+        expect(screen.getByText('Move to Trash')).toBeInTheDocument();
+        expect(screen.queryByText('Permanently Delete')).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows "Permanently Delete" for custom workspace', async () => {
+      mockUseFileTree.mockReturnValue({
+        ...defaultMockHook,
+        workspaceInfo: {
+          isCustomWorkspace: true,
+          rootPath: '/custom/workspace',
+        },
+      });
+
+      render(
+        <FileTreePanel
+          onOpenFile={mockOnOpenFile}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+        />
+      );
+
+      // Simulate context menu
+      const contextMenuEvent = new MouseEvent('contextmenu', { bubbles: true });
+      fireEvent.contextMenu(screen.getByText('src'), contextMenuEvent);
+
+      await waitFor(() => {
+        expect(screen.getByText('Permanently Delete')).toBeInTheDocument();
+        expect(screen.queryByText('Move to Trash')).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows confirmation modal when clicking "Permanently Delete"', async () => {
+      mockUseFileTree.mockReturnValue({
+        ...defaultMockHook,
+        workspaceInfo: {
+          isCustomWorkspace: true,
+          rootPath: '/custom/workspace',
+        },
+      });
+
+      // Mock fetch for the delete operation
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: true, from: 'test.txt', to: '' }),
+      } as Response);
+
+      render(
+        <FileTreePanel
+          onOpenFile={mockOnOpenFile}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+        />
+      );
+
+      // Open context menu
+      const contextMenuEvent = new MouseEvent('contextmenu', { bubbles: true });
+      fireEvent.contextMenu(screen.getByText('src'), contextMenuEvent);
+
+      // Click "Permanently Delete"
+      const deleteButton = await screen.findByText('Permanently Delete');
+      fireEvent.click(deleteButton);
+
+      // Should show confirmation modal
+      await waitFor(() => {
+        expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument();
+        expect(screen.getByText('Permanently Delete')).toBeInTheDocument();
+        expect(screen.getByText(/Are you sure you want to permanently delete/)).toBeInTheDocument();
+      });
+    });
+
+    it('does not show confirmation modal for "Move to Trash"', async () => {
+      // Mock fetch for trash operation
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: true, from: 'test.txt', to: '.trash/test.txt', undoTtlMs: 10000 }),
+      } as Response);
+
+      render(
+        <FileTreePanel
+          onOpenFile={mockOnOpenFile}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+        />
+      );
+
+      // Open context menu
+      const contextMenuEvent = new MouseEvent('contextmenu', { bubbles: true });
+      fireEvent.contextMenu(screen.getByText('src'), contextMenuEvent);
+
+      // Click "Move to Trash"
+      const trashButton = await screen.findByText('Move to Trash');
+      fireEvent.click(trashButton);
+
+      // Should NOT show confirmation modal
+      expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('confirmation modal interactions', () => {
+    it('closes modal when clicking cancel', async () => {
+      mockUseFileTree.mockReturnValue({
+        ...defaultMockHook,
+        workspaceInfo: {
+          isCustomWorkspace: true,
+          rootPath: '/custom/workspace',
+        },
+      });
+
+      render(
+        <FileTreePanel
+          onOpenFile={mockOnOpenFile}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+        />
+      );
+
+      // Open context menu and click "Permanently Delete"
+      const contextMenuEvent = new MouseEvent('contextmenu', { bubbles: true });
+      fireEvent.contextMenu(screen.getByText('src'), contextMenuEvent);
+      
+      const deleteButton = await screen.findByText('Permanently Delete');
+      fireEvent.click(deleteButton);
+
+      // Modal should be open
+      await waitFor(() => {
+        expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument();
+      });
+
+      // Click cancel
+      const cancelButton = screen.getByTestId('cancel-button');
+      fireEvent.click(cancelButton);
+
+      // Modal should be closed
+      await waitFor(() => {
+        expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+      });
+    });
+
+    it('performs deletion when clicking confirm', async () => {
+      mockUseFileTree.mockReturnValue({
+        ...defaultMockHook,
+        workspaceInfo: {
+          isCustomWorkspace: true,
+          rootPath: '/custom/workspace',
+        },
+      });
+
+      // Mock fetch for the delete operation
+      const mockFetch = vi.mocked(global.fetch);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: true, from: 'test.txt', to: '' }),
+      } as Response);
+
+      render(
+        <FileTreePanel
+          onOpenFile={mockOnOpenFile}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+        />
+      );
+
+      // Open context menu and click "Permanently Delete"
+      const contextMenuEvent = new MouseEvent('contextmenu', { bubbles: true });
+      fireEvent.contextMenu(screen.getByText('src'), contextMenuEvent);
+      
+      const deleteButton = await screen.findByText('Permanently Delete');
+      fireEvent.click(deleteButton);
+
+      // Click confirm
+      const confirmButton = await screen.findByTestId('confirm-button');
+      fireEvent.click(confirmButton);
+
+      // Wait for modal to close
+      await waitFor(() => {
+        expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('toast messages', () => {
+    it('shows success toast for permanent deletion', async () => {
+      mockUseFileTree.mockReturnValue({
+        ...defaultMockHook,
+        workspaceInfo: {
+          isCustomWorkspace: true,
+          rootPath: '/custom/workspace',
+        },
+      });
+
+      // Mock fetch for successful deletion
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: true, from: 'test.txt', to: '' }),
+      } as Response);
+
+      render(
+        <FileTreePanel
+          onOpenFile={mockOnOpenFile}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+        />
+      );
+
+      // Trigger permanent deletion
+      const contextMenuEvent = new MouseEvent('contextmenu', { bubbles: true });
+      fireEvent.contextMenu(screen.getByText('src'), contextMenuEvent);
+      
+      const deleteButton = await screen.findByText('Permanently Delete');
+      fireEvent.click(deleteButton);
+
+      const confirmButton = await screen.findByTestId('confirm-button');
+      fireEvent.click(confirmButton);
+
+      expect(await screen.findByText('Permanently deleted test.txt')).toBeInTheDocument();
+    });
+
+    it('shows error toast for failed permanent deletion', async () => {
+      mockUseFileTree.mockReturnValue({
+        ...defaultMockHook,
+        workspaceInfo: {
+          isCustomWorkspace: true,
+          rootPath: '/custom/workspace',
+        },
+      });
+
+      // Mock fetch for failed deletion
+      global.fetch = vi.fn().mockRejectedValue(new Error('Delete failed'));
+
+      render(
+        <FileTreePanel
+          onOpenFile={mockOnOpenFile}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+        />
+      );
+
+      // Trigger permanent deletion
+      const contextMenuEvent = new MouseEvent('contextmenu', { bubbles: true });
+      fireEvent.contextMenu(screen.getByText('src'), contextMenuEvent);
+      
+      const deleteButton = await screen.findByText('Permanently Delete');
+      fireEvent.click(deleteButton);
+
+      const confirmButton = await screen.findByTestId('confirm-button');
+      fireEvent.click(confirmButton);
+
+      expect(await screen.findByText('Delete failed')).toBeInTheDocument();
+    });
+
+    it('renders correctly in custom workspace mode', async () => {
+      mockUseFileTree.mockReturnValue({
+        ...defaultMockHook,
+        workspaceInfo: {
+          isCustomWorkspace: true,
+          rootPath: '/custom/workspace',
+        },
+      });
+
+      render(
+        <FileTreePanel
+          onOpenFile={mockOnOpenFile}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+        />
+      );
+
+      // Verify custom workspace header is shown
+      expect(screen.getByText('/custom/workspace')).toBeInTheDocument();
+      
+      // Verify context menu shows permanent delete options
+      const contextMenuEvent = new MouseEvent('contextmenu', { bubbles: true });
+      fireEvent.contextMenu(screen.getByText('src'), contextMenuEvent);
+      
+      expect(screen.getByText('Permanently Delete')).toBeInTheDocument();
+      expect(screen.queryByText('Move to Trash')).not.toBeInTheDocument();
+      
+      // Close the context menu
+      fireEvent.click(document.body);
+    });
+  });
+
+  describe('integration with useFileTree hook', () => {
+    it('passes workspaceInfo from hook to UI', () => {
+      const customWorkspaceInfo = {
+        isCustomWorkspace: true,
+        rootPath: '/home/user/project',
+      };
+      
+      mockUseFileTree.mockReturnValue({
+        ...defaultMockHook,
+        workspaceInfo: customWorkspaceInfo,
+      });
+
+      render(
+        <FileTreePanel
+          onOpenFile={mockOnOpenFile}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+        />
+      );
+
+      expect(screen.getByText('/home/user/project')).toBeInTheDocument();
+    });
+
+    it('updates UI when workspaceInfo changes', async () => {
+      const { rerender } = render(
+        <FileTreePanel
+          onOpenFile={mockOnOpenFile}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+        />
+      );
+
+      // Initially shows "Workspace"
+      expect(screen.getByText('Workspace')).toBeInTheDocument();
+
+      // Update hook to return custom workspace
+      mockUseFileTree.mockReturnValue({
+        ...defaultMockHook,
+        workspaceInfo: {
+          isCustomWorkspace: true,
+          rootPath: '/new/custom/path',
+        },
+      });
+
+      rerender(
+        <FileTreePanel
+          onOpenFile={mockOnOpenFile}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+        />
+      );
+
+      expect(screen.getByText('/new/custom/path')).toBeInTheDocument();
+      expect(screen.queryByText('Workspace')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/file-browser/FileTreePanel.tsx
+++ b/src/features/file-browser/FileTreePanel.tsx
@@ -9,6 +9,7 @@ import { useRef, useState, useCallback, useEffect } from 'react';
 import { PanelLeftClose, PanelLeftOpen, RefreshCw, Pencil, Trash2, RotateCcw, X } from 'lucide-react';
 import { FileTreeNode } from './FileTreeNode';
 import { useFileTree } from './hooks/useFileTree';
+import { ConfirmDialog } from '../../components/ConfirmDialog';
 import type { TreeEntry } from './types';
 
 const MIN_WIDTH = 160;
@@ -76,7 +77,7 @@ export function FileTreePanel({
 }: FileTreePanelProps) {
   const {
     entries, loading, error, expandedPaths, selectedPath,
-    loadingPaths, toggleDirectory, selectFile, refresh, handleFileChange,
+    loadingPaths, workspaceInfo, toggleDirectory, selectFile, refresh, handleFileChange,
   } = useFileTree();
 
   // React to external file changes
@@ -112,6 +113,9 @@ export function FileTreePanel({
 
   const [toast, setToast] = useState<FileTreeToast | null>(null);
   const toastTimerRef = useRef<number | null>(null);
+
+  // Permanent delete confirmation state
+  const [deleteConfirmation, setDeleteConfirmation] = useState<{ entry: TreeEntry } | null>(null);
 
   const clearToastTimer = useCallback(() => {
     if (toastTimerRef.current !== null) {
@@ -255,6 +259,19 @@ export function FileTreePanel({
     try {
       // Dragging onto .trash behaves like explicit trash action.
       if (targetDirPath === '.trash' && !sourcePath.startsWith('.trash/')) {
+        // In custom workspaces, treat drag-to-trash as regular move since undo system doesn't exist
+        if (workspaceInfo?.isCustomWorkspace) {
+          const result = await postFileOp<FileOpResult>('/api/files/move', {
+            sourcePath,
+            targetDirPath: '.trash',
+          });
+          refresh();
+          onRemapOpenPaths?.(result.from, result.to);
+          selectFile(result.to);
+          showToast({ type: 'success', message: `Moved ${basename(result.from)} to .trash` }, 3000);
+          return;
+        }
+
         const result = await postFileOp<FileOpResult>('/api/files/trash', { path: sourcePath });
         onCloseOpenPaths?.(result.from);
         refresh();
@@ -282,7 +299,7 @@ export function FileTreePanel({
       const message = err instanceof Error ? err.message : 'Move failed';
       showToast({ type: 'error', message }, 4500);
     }
-  }, [onCloseOpenPaths, onRemapOpenPaths, postFileOp, refresh, selectFile, showToast]);
+  }, [onCloseOpenPaths, onRemapOpenPaths, postFileOp, refresh, selectFile, showToast, workspaceInfo]);
 
   const canDropToTarget = useCallback((source: TreeEntry, targetDirPath: string): boolean => {
     if (source.path === '.trash') return false;
@@ -361,6 +378,14 @@ export function FileTreePanel({
       return;
     }
 
+    // Show confirmation for permanent deletion
+    if (workspaceInfo?.isCustomWorkspace) {
+      setDeleteConfirmation({ entry });
+      setContextMenu(null);
+      return;
+    }
+
+    // Normal trash behavior (no confirmation)
     try {
       const result = await postFileOp<FileOpResult>('/api/files/trash', { path: entry.path });
       onCloseOpenPaths?.(result.from);
@@ -379,6 +404,23 @@ export function FileTreePanel({
       const message = err instanceof Error ? err.message : 'Move to Trash failed';
       showToast({ type: 'error', message }, 4500);
       setContextMenu(null);
+    }
+  }, [onCloseOpenPaths, postFileOp, refresh, showToast, workspaceInfo]);
+
+  const confirmPermanentDelete = useCallback(async (entry: TreeEntry) => {
+    try {
+      const result = await postFileOp<FileOpResult>('/api/files/trash', { path: entry.path });
+      onCloseOpenPaths?.(result.from);
+      refresh();
+      showToast(
+        { type: 'success', message: `Permanently deleted ${basename(result.from)}` },
+        3000
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Permanent deletion failed';
+      showToast({ type: 'error', message }, 4500);
+    } finally {
+      setDeleteConfirmation(null);
     }
   }, [onCloseOpenPaths, postFileOp, refresh, showToast]);
 
@@ -509,7 +551,7 @@ export function FileTreePanel({
         onDrop={handleRootDrop}
       >
         <span className="text-[10px] font-semibold tracking-wider text-muted-foreground uppercase">
-          Workspace
+          {workspaceInfo?.isCustomWorkspace ? workspaceInfo.rootPath : 'Workspace'}
         </span>
         <div className="flex items-center gap-0.5">
           <button
@@ -618,7 +660,7 @@ export function FileTreePanel({
               onClick={() => { void moveToTrash(menuEntry); }}
             >
               <Trash2 size={12} />
-              Move to Trash
+              {workspaceInfo?.isCustomWorkspace ? 'Permanently Delete' : 'Move to Trash'}
             </button>
           )}
 
@@ -663,6 +705,20 @@ export function FileTreePanel({
         aria-orientation="vertical"
         aria-label="Resize file explorer"
       />
+
+      {/* Permanent delete confirmation dialog */}
+      {deleteConfirmation && (
+        <ConfirmDialog
+          open={true}
+          title="Permanently Delete"
+          message={`Are you sure you want to permanently delete "${deleteConfirmation.entry.name}"? This action cannot be undone.`}
+          confirmLabel="Permanently Delete"
+          cancelLabel="Cancel"
+          variant="danger"
+          onConfirm={() => confirmPermanentDelete(deleteConfirmation.entry)}
+          onCancel={() => setDeleteConfirmation(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/features/file-browser/hooks/useFileTree.test.ts
+++ b/src/features/file-browser/hooks/useFileTree.test.ts
@@ -1,0 +1,681 @@
+/** Tests for useFileTree hook - workspace info handling and tree operations. */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useFileTree } from './useFileTree';
+import type { TreeEntry } from '../types';
+
+// Mock fetch globally
+global.fetch = vi.fn();
+
+describe('useFileTree', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock localStorage
+    const localStorageMock = {
+      getItem: vi.fn(),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+      clear: vi.fn(),
+    };
+    vi.stubGlobal('localStorage', localStorageMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  describe('workspace info handling', () => {
+    it('initializes with null workspaceInfo', () => {
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: true, entries: [] }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      expect(result.current.workspaceInfo).toBeNull();
+    });
+
+    it('sets workspaceInfo when API response includes it', async () => {
+      const mockWorkspaceInfo = {
+        isCustomWorkspace: true,
+        rootPath: '/home/user/custom-workspace',
+      };
+
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'file.txt', path: 'file.txt', type: 'file' as const, children: null },
+          ],
+          workspaceInfo: mockWorkspaceInfo,
+        }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.workspaceInfo).toEqual(mockWorkspaceInfo);
+      });
+    });
+
+    it('sets workspaceInfo with default workspace when not using custom workspace', async () => {
+      const mockWorkspaceInfo = {
+        isCustomWorkspace: false,
+        rootPath: '/home/user/.openclaw/workspace',
+      };
+
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'src', path: 'src', type: 'directory' as const, children: null },
+          ],
+          workspaceInfo: mockWorkspaceInfo,
+        }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.workspaceInfo).toEqual(mockWorkspaceInfo);
+      });
+    });
+
+    it('handles API response without workspaceInfo gracefully', async () => {
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'package.json', path: 'package.json', type: 'file' as const, children: null },
+          ],
+        }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.entries).toHaveLength(1);
+        expect(result.current.workspaceInfo).toBeNull();
+      });
+    });
+
+    it('updates workspaceInfo when subsequent calls return different info', async () => {
+      const mockFetch = vi.mocked(fetch);
+      
+      // First call - custom workspace
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [],
+          workspaceInfo: {
+            isCustomWorkspace: true,
+            rootPath: '/custom/path',
+          },
+        }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.workspaceInfo?.isCustomWorkspace).toBe(true);
+      });
+
+      // Second call - default workspace
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [],
+          workspaceInfo: {
+            isCustomWorkspace: false,
+            rootPath: '/default/path',
+          },
+        }),
+      } as Response);
+
+      // Trigger a refresh
+      result.current.refresh();
+
+      await waitFor(() => {
+        expect(result.current.workspaceInfo?.isCustomWorkspace).toBe(false);
+        expect(result.current.workspaceInfo?.rootPath).toBe('/default/path');
+      });
+    });
+  });
+
+  describe('existing functionality still works', () => {
+    it('loads entries on mount', async () => {
+      const mockEntries: TreeEntry[] = [
+        { name: 'src', path: 'src', type: 'directory', children: null },
+        { name: 'package.json', path: 'package.json', type: 'file', children: null },
+      ];
+
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: mockEntries,
+          workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+        }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      expect(result.current.loading).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+        expect(result.current.entries).toEqual(mockEntries);
+      });
+    });
+
+    it('handles fetch errors gracefully', async () => {
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+        expect(result.current.error).toBeTruthy();
+      });
+    });
+
+    it('handles API error responses', async () => {
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        json: async () => ({ error: 'Server error' }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+        expect(result.current.entries).toEqual([]);
+      });
+    });
+
+    it('toggles directory expansion', async () => {
+      const mockFetch = vi.mocked(fetch);
+      
+      // Initial load
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'src', path: 'src', type: 'directory', children: null },
+          ],
+          workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+        }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.entries).toHaveLength(1);
+      });
+
+      // Toggle directory
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'index.ts', path: 'src/index.ts', type: 'file', children: null },
+          ],
+        }),
+      } as Response);
+
+      result.current.toggleDirectory('src');
+
+      await waitFor(() => {
+        expect(result.current.expandedPaths.has('src')).toBe(true);
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('?path=src&depth=1')
+        );
+      });
+    });
+
+    it('selects files', async () => {
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'test.txt', path: 'test.txt', type: 'file', children: null },
+          ],
+          workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+        }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.entries).toHaveLength(1);
+      });
+
+      result.current.selectFile('test.txt');
+      // Test that the function can be called without throwing
+      expect(typeof result.current.selectFile).toBe('function');
+    });
+
+    it('persists expanded paths in localStorage', async () => {
+      const mockLocalStorage = vi.mocked(localStorage);
+      mockLocalStorage.getItem.mockReturnValue('["src","components"]');
+
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [],
+          workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+        }),
+      } as Response);
+
+      renderHook(() => useFileTree());
+
+      expect(mockLocalStorage.getItem).toHaveBeenCalledWith('nerve-file-tree-expanded');
+    });
+  });
+
+  describe('return object includes workspaceInfo', () => {
+    it('exports workspaceInfo in the return object', async () => {
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [],
+          workspaceInfo: { isCustomWorkspace: true, rootPath: '/custom' },
+        }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      // Check that workspaceInfo is in the return object
+      expect('workspaceInfo' in result.current).toBe(true);
+      expect(result.current.workspaceInfo).toBeNull(); // Initially null
+
+      await waitFor(() => {
+        expect(result.current.workspaceInfo).toEqual({
+          isCustomWorkspace: true,
+          rootPath: '/custom',
+        });
+      });
+    });
+
+    it('includes all expected return properties', async () => {
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [],
+          workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+        }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      const returnKeys = Object.keys(result.current);
+      const expectedKeys = [
+        'entries',
+        'loading',
+        'error',
+        'expandedPaths',
+        'selectedPath',
+        'loadingPaths',
+        'workspaceInfo',
+        'toggleDirectory',
+        'selectFile',
+        'refresh',
+        'handleFileChange',
+      ];
+
+      expect(returnKeys).toEqual(expect.arrayContaining(expectedKeys));
+      expect(returnKeys).toHaveLength(expectedKeys.length);
+    });
+  });
+
+  describe('cache eviction on invalid paths', () => {
+    it('evicts path from expandedPaths on 404 error', async () => {
+      const mockLocalStorage = vi.mocked(localStorage);
+      mockLocalStorage.getItem.mockReturnValue('["src","invalid-dir"]');
+
+      const mockFetch = vi.mocked(fetch);
+      
+      // Initial load succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'src', path: 'src', type: 'directory', children: null },
+          ],
+          workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+        }),
+      } as Response);
+
+      // Fetch for 'src' succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'index.ts', path: 'src/index.ts', type: 'file', children: null },
+          ],
+        }),
+      } as Response);
+
+      // Fetch for 'invalid-dir' returns 404
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ ok: false, error: 'Directory not found' }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // 'invalid-dir' should be removed from expandedPaths
+      await waitFor(() => {
+        expect(result.current.expandedPaths.has('invalid-dir')).toBe(false);
+        expect(result.current.expandedPaths.has('src')).toBe(true);
+      });
+    });
+
+    it('evicts path from expandedPaths on 400 Invalid path error', async () => {
+      const mockFetch = vi.mocked(fetch);
+      
+      // Initial load succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'src', path: 'src', type: 'directory', children: null },
+          ],
+          workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+        }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Toggle a directory that returns 400 Invalid path
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ ok: false, error: 'Invalid path' }),
+      } as Response);
+
+      result.current.toggleDirectory('src');
+
+      await waitFor(() => {
+        expect(result.current.expandedPaths.has('src')).toBe(false);
+      });
+    });
+
+    it('evicts path from expandedPaths on 400 Not a directory error', async () => {
+      const mockFetch = vi.mocked(fetch);
+      
+      // Initial load succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'file.txt', path: 'file.txt', type: 'directory', children: null },
+          ],
+          workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+        }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Toggle what appears to be a directory but is actually a file
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ ok: false, error: 'Not a directory' }),
+      } as Response);
+
+      result.current.toggleDirectory('file.txt');
+
+      await waitFor(() => {
+        expect(result.current.expandedPaths.has('file.txt')).toBe(false);
+      });
+    });
+
+    it('does not evict path on server error statuses (500)', async () => {
+      const mockFetch = vi.mocked(fetch);
+      
+      // Initial load succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'src', path: 'src', type: 'directory', children: null },
+          ],
+          workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+        }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Toggle directory - returns 500 server error
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        json: async () => ({ ok: false, error: 'Server error' }),
+      } as Response);
+
+      result.current.toggleDirectory('src');
+
+      await waitFor(() => {
+        // Path should still be in expandedPaths (transient error, might work later)
+        expect(result.current.expandedPaths.has('src')).toBe(true);
+      });
+    });
+
+    it('persists cache eviction to localStorage', async () => {
+      const mockLocalStorage = vi.mocked(localStorage);
+      mockLocalStorage.getItem.mockReturnValue('[]');
+
+      const mockFetch = vi.mocked(fetch);
+      
+      // Initial load succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'src', path: 'src', type: 'directory', children: null },
+          ],
+          workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+        }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      const writesBeforeToggle = mockLocalStorage.setItem.mock.calls.length;
+
+      // Toggle directory that returns 404
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ ok: false, error: 'Directory not found' }),
+      } as Response);
+
+      result.current.toggleDirectory('src');
+
+      await waitFor(() => {
+        expect(result.current.expandedPaths.has('src')).toBe(false);
+      });
+
+      // Verify localStorage.setItem was called to persist the change
+      await waitFor(() => {
+        expect(mockLocalStorage.setItem.mock.calls.length).toBeGreaterThan(writesBeforeToggle);
+        expect(mockLocalStorage.setItem).toHaveBeenLastCalledWith(
+          'nerve-file-tree-expanded',
+          expect.not.stringContaining('src'),
+        );
+      });
+    });
+  });
+
+  describe('regression: existing behavior unchanged', () => {
+    it('still loads children successfully on valid paths', async () => {
+      const mockFetch = vi.mocked(fetch);
+      
+      // Initial load
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'src', path: 'src', type: 'directory', children: null },
+          ],
+          workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+        }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Toggle directory - succeeds
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'index.ts', path: 'src/index.ts', type: 'file', children: null },
+          ],
+        }),
+      } as Response);
+
+      result.current.toggleDirectory('src');
+
+      await waitFor(() => {
+        expect(result.current.expandedPaths.has('src')).toBe(true);
+        expect(result.current.entries[0].children).toHaveLength(1);
+      });
+    });
+
+    it('still handles network errors without evicting from cache', async () => {
+      const mockFetch = vi.mocked(fetch);
+      
+      // Initial load
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'src', path: 'src', type: 'directory', children: null },
+          ],
+          workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+        }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Toggle directory - network error
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      result.current.toggleDirectory('src');
+
+      await waitFor(() => {
+        // Path should still be in expandedPaths (might work on retry)
+        expect(result.current.expandedPaths.has('src')).toBe(true);
+      });
+    });
+
+    it('still collapses directories when toggled again', async () => {
+      const mockFetch = vi.mocked(fetch);
+      
+      // Initial load
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'src', path: 'src', type: 'directory', children: null },
+          ],
+          workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+        }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      // Expand directory
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'index.ts', path: 'src/index.ts', type: 'file', children: null },
+          ],
+        }),
+      } as Response);
+
+      result.current.toggleDirectory('src');
+
+      await waitFor(() => {
+        expect(result.current.expandedPaths.has('src')).toBe(true);
+      });
+
+      // Collapse directory
+      result.current.toggleDirectory('src');
+
+      await waitFor(() => {
+        expect(result.current.expandedPaths.has('src')).toBe(false);
+      });
+    });
+  });
+});

--- a/src/features/file-browser/hooks/useFileTree.ts
+++ b/src/features/file-browser/hooks/useFileTree.ts
@@ -3,6 +3,7 @@ import type { TreeEntry } from '../types';
 
 const STORAGE_KEY = 'nerve-file-tree-expanded';
 
+/** Load expanded paths from localStorage for persistence. */
 function loadExpandedPaths(): Set<string> {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
@@ -11,6 +12,7 @@ function loadExpandedPaths(): Set<string> {
   return new Set<string>();
 }
 
+/** Save expanded paths to localStorage for persistence. */
 function saveExpandedPaths(paths: Set<string>) {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify([...paths]));
@@ -34,6 +36,7 @@ function mergeChildren(
   });
 }
 
+/** Hook for managing file tree state with workspace info and persistence. */
 export function useFileTree() {
   const [entries, setEntries] = useState<TreeEntry[]>([]);
   const [loading, setLoading] = useState(true);
@@ -41,6 +44,7 @@ export function useFileTree() {
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(loadExpandedPaths);
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [loadingPaths, setLoadingPaths] = useState<Set<string>>(new Set());
+  const [workspaceInfo, setWorkspaceInfo] = useState<{ isCustomWorkspace: boolean; rootPath: string } | null>(null);
   const mountedRef = useRef(true);
 
   useEffect(() => {
@@ -58,8 +62,24 @@ export function useFileTree() {
     try {
       const params = dirPath ? `?path=${encodeURIComponent(dirPath)}&depth=1` : '?depth=1';
       const res = await fetch(`/api/files/tree${params}`);
+      
+      // Permanent errors (404, 400, 403) - evict from expanded paths cache
+      if (!res.ok && (res.status === 404 || res.status === 400 || res.status === 403)) {
+        if (dirPath) {
+          setExpandedPaths((prev) => {
+            const next = new Set(prev);
+            next.delete(dirPath);
+            return next;
+          });
+        }
+        return null;
+      }
+      
       if (!res.ok) return null;
       const data = await res.json();
+      if (data.ok && data.workspaceInfo) {
+        setWorkspaceInfo(data.workspaceInfo);
+      }
       return data.ok ? data.entries : null;
     } catch {
       return null;
@@ -92,6 +112,8 @@ export function useFileTree() {
           if (r) tree = mergeChildren(tree, r.path, r.children);
         }
         setEntries(tree);
+        
+        // Note: fetchChildren already handles evicting invalid paths from expandedPaths
       }
     } else {
       setError('Failed to load file tree');
@@ -199,6 +221,7 @@ export function useFileTree() {
     expandedPaths,
     selectedPath,
     loadingPaths,
+    workspaceInfo,
     toggleDirectory,
     selectFile,
     refresh,


### PR DESCRIPTION
## What

Enhanced the file browser tree cache to automatically evict invalid directory paths when the API returns permanent errors (400/404), preventing stale cache entries and unnecessary API calls.

## Why

Invalid directory paths persist forever in the expanded paths cache, causing failed API calls and poor UX when directories are deleted or become inaccessible. Users see loading states that never resolve and have no way to clear stale paths except manually editing localStorage.

## How

Modified `fetchChildren` in `useFileTree.ts` to detect 400/404 responses and automatically remove those paths from the expandedPaths cache. The changes persist to localStorage automatically. Transient errors (500, network) are preserved to allow retries.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [x] New features include tests
- [ ] UI changes include a screenshot or screen recording


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom workspace roots via configuration, allowing override of the default workspace location
  * When using a custom workspace root, file deletions are now permanent and cannot be undone, with UI updated to reflect this behavior

* **Documentation**
  * Updated configuration documentation with new environment variables for workspace and file path management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->