### PR TITLE
fix(file-browser): evict invalid paths from tree cache

### DIFF
--- a/src/features/file-browser/hooks/useFileTree.test.ts
+++ b/src/features/file-browser/hooks/useFileTree.test.ts
@@ -559,6 +559,132 @@ describe('useFileTree', () => {
     });
   });
 
+  describe('permanent error cache cleanup', () => {
+    it('prunes descendant expanded paths when a parent directory returns 404 on restore', async () => {
+      const mockLocalStorage = vi.mocked(localStorage);
+      mockLocalStorage.getItem.mockReturnValue('["src","src/components","src/components/button"]');
+
+      const mockFetch = vi.mocked(fetch);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'src', path: 'src', type: 'directory', children: null },
+          ],
+          workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+        }),
+      } as Response);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ ok: false, error: 'Directory not found' }),
+      } as Response);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'button.tsx', path: 'src/components/button.tsx', type: 'file', children: null },
+          ],
+        }),
+      } as Response);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [],
+        }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      await waitFor(() => {
+        expect(result.current.expandedPaths.has('src')).toBe(false);
+        expect(result.current.expandedPaths.has('src/components')).toBe(false);
+        expect(result.current.expandedPaths.has('src/components/button')).toBe(false);
+      });
+    });
+
+    it('clears cached children after a permanent error so a later expand refetches', async () => {
+      const mockFetch = vi.mocked(fetch);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'src', path: 'src', type: 'directory', children: null },
+          ],
+          workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+        }),
+      } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'index.ts', path: 'src/index.ts', type: 'file', children: null },
+          ],
+        }),
+      } as Response);
+
+      result.current.toggleDirectory('src');
+
+      await waitFor(() => {
+        expect(result.current.expandedPaths.has('src')).toBe(true);
+        expect(result.current.entries.find((entry) => entry.path === 'src')?.children).toHaveLength(1);
+        expect(result.current.entries.find((entry) => entry.path === 'src')?.children?.[0]?.path).toBe('src/index.ts');
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ ok: false, error: 'Directory not found' }),
+      } as Response);
+
+      result.current.handleFileChange('src/index.ts');
+
+      await waitFor(() => {
+        expect(result.current.expandedPaths.has('src')).toBe(false);
+        expect(result.current.entries.find((entry) => entry.path === 'src')?.children).toBeNull();
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [
+            { name: 'main.ts', path: 'src/main.ts', type: 'file', children: null },
+          ],
+        }),
+      } as Response);
+
+      result.current.toggleDirectory('src');
+
+      await waitFor(() => {
+        expect(result.current.expandedPaths.has('src')).toBe(true);
+        expect(result.current.entries.find((entry) => entry.path === 'src')?.children).toHaveLength(1);
+        expect(result.current.entries.find((entry) => entry.path === 'src')?.children?.[0]?.path).toBe('src/main.ts');
+      });
+    });
+  });
+
   describe('regression: existing behavior unchanged', () => {
     it('still loads children successfully on valid paths', async () => {
       const mockFetch = vi.mocked(fetch);
@@ -596,7 +722,7 @@ describe('useFileTree', () => {
 
       await waitFor(() => {
         expect(result.current.expandedPaths.has('src')).toBe(true);
-        expect(result.current.entries[0].children).toHaveLength(1);
+        expect(result.current.entries.find((entry) => entry.path === 'src')?.children).toHaveLength(1);
       });
     });
 

--- a/src/features/file-browser/hooks/useFileTree.ts
+++ b/src/features/file-browser/hooks/useFileTree.ts
@@ -36,6 +36,21 @@ function mergeChildren(
   });
 }
 
+/** Clear cached children for a directory entry and reset to unloaded state */
+function clearEntryFromTree(entries: TreeEntry[], targetPath: string): TreeEntry[] {
+  return entries.map((entry) => {
+    if (entry.path === targetPath && entry.type === 'directory') {
+      // Reset to unloaded state
+      return { ...entry, children: null };
+    }
+    if (entry.children && entry.type === 'directory') {
+      // Recursively process children
+      return { ...entry, children: clearEntryFromTree(entry.children, targetPath) };
+    }
+    return entry;
+  });
+}
+
 /** Hook for managing file tree state with workspace info and persistence. */
 export function useFileTree() {
   const [entries, setEntries] = useState<TreeEntry[]>([]);
@@ -63,12 +78,22 @@ export function useFileTree() {
       const params = dirPath ? `?path=${encodeURIComponent(dirPath)}&depth=1` : '?depth=1';
       const res = await fetch(`/api/files/tree${params}`);
       if (!res.ok) {
-        if (res.status === 400 || res.status === 404) {
-          // Evict this path from expanded paths
+        if (dirPath && (res.status === 400 || res.status === 404)) {
+          // Evict this path from expandedPaths and clear cached children
           setExpandedPaths(prev => {
             const next = new Set(prev);
-            next.delete(dirPath);
+            // Remove the path and all descendants
+            for (const path of next) {
+              if (path === dirPath || path.startsWith(`${dirPath}/`)) {
+                next.delete(path);
+              }
+            }
             return next;
+          });
+
+          // Clear cached children for this entry
+          setEntries(prev => {
+            return clearEntryFromTree(prev, dirPath);
           });
         }
         return null;
@@ -81,7 +106,7 @@ export function useFileTree() {
     } catch {
       return null;
     }
-  }, [setExpandedPaths]);
+  }, [setExpandedPaths, setEntries]);
 
   // Initial load
   const loadRoot = useCallback(async () => {


### PR DESCRIPTION
## What

Enhanced the file browser tree cache to automatically evict invalid directory paths when the API returns permanent errors (400/404), preventing stale cache entries and unnecessary API calls.

## Why

Invalid directory paths persist forever in the expanded paths cache, causing failed API calls and poor UX when directories are deleted or become inaccessible. Users see loading states that never resolve and have no way to clear stale paths except manually editing localStorage.

## How

Modified `fetchChildren` in `useFileTree.ts` to detect 400/404 responses and automatically remove those paths from the expandedPaths cache. The changes persist to localStorage automatically. Transient errors (500, network) are preserved to allow retries.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [x] New features include tests
- [ ] UI changes include a screenshot or screen recording


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File browser now evicts invalid (400/404) or not-found paths — including nested descendants — and clears their cached children to prevent re-expansion of inaccessible directories.
  * Improved handling of server errors so valid expansions are preserved and expansion state persistence remains consistent.

* **Tests**
  * Added comprehensive tests covering eviction, error scenarios (400/404/500), persistence to storage, cascading cleanup, and regression cases for expansion/collapse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->