### PR TITLE
Harden installer edge cases and service startup paths

### DIFF
--- a/docs/INSTALLER-STEPS.md
+++ b/docs/INSTALLER-STEPS.md
@@ -96,6 +96,7 @@ The script runs these checks in order:
   - Debian:
     - when running as root, auto-installs `build-essential` (unless dry-run)
     - when running as a normal user, exits with the explicit `sudo apt install build-essential` command
+    - dry-run mirrors that split instead of pretending non-root installs would succeed automatically
   - macOS: triggers Xcode CLI tools install and waits
   - otherwise: prints manual install commands and exits
 
@@ -295,6 +296,7 @@ Determines service user/home by:
 ### 5B.1 Wrapper script creation
 Creates `<INSTALL_DIR>/start.sh` that:
 
+- changes into `<INSTALL_DIR>` first so manual invocation resolves `.env` the same way as the service
 - sets `NODE_ENV=production`
 - executes `node server-dist/index.js`
 

--- a/install.sh
+++ b/install.sh
@@ -257,7 +257,7 @@ fi
 INTERACTIVE=false
 if [[ -t 0 ]]; then
   INTERACTIVE=true
-elif tty -s < /dev/tty 2>/dev/null; then
+elif { tty -s < /dev/tty; } 2>/dev/null; then
   INTERACTIVE=true
 fi
 
@@ -421,7 +421,11 @@ check_build_tools() {
   # Auto-install on Debian/Ubuntu
   if command -v apt-get &>/dev/null; then
     if [[ "$DRY_RUN" == "true" ]]; then
-      dry "Would install build-essential via apt"
+      if [[ $EUID -eq 0 ]]; then
+        dry "Would install build-essential via apt"
+      else
+        dry "Would require manual install: sudo apt install build-essential"
+      fi
       return 0
     fi
     if [[ $EUID -eq 0 ]]; then
@@ -1014,6 +1018,7 @@ setup_launchd() {
 #!/bin/bash
 # Nerve start wrapper — .env is loaded by the Node server at runtime.
 SCRIPT_DIR="\$(cd "\$(dirname "\$0")" && pwd)"
+cd "\${SCRIPT_DIR}"
 export PATH="${node_dir_escaped}:\${PATH}"
 export NODE_ENV=production
 exec node "\${SCRIPT_DIR}/server-dist/index.js"


### PR DESCRIPTION
## Summary

This PR hardens the Nerve installer and setup flow in a few failure-prone areas without changing the overall install experience.

The main focus is making the installer behave more safely and predictably when rerun against existing installs, when ports are already occupied, and when service startup depends on generated config. It also removes one redundant build step and updates the installer reference docs to match the actual behavior.

## What Changed

- Fixed the auto-config port conflict path in `install.sh` so it no longer references an undefined variable and now fails cleanly when a non-interactive install cannot use the default port.
- Hardened interactive detection so headless runs do not get misclassified as interactive and fall into broken `/dev/tty` prompt loops.
- Added overwrite protection for existing install directories:
  - interactive runs warn before discarding local repo changes
  - non-interactive runs refuse to overwrite a dirty checkout
- Fixed dry-run behavior so a successful simulation exits `0` instead of returning a partial-failure code because `.env` is not present.
- Removed the redundant second server build from the installer since `npm run build` already includes `build:server`.
- Fixed the Debian build-tools path so auto-install only runs when the installer is already root; otherwise it exits with the explicit `sudo apt install build-essential` command instead of failing mid-flow.
- Fixed the macOS `launchd` wrapper so it no longer `source`s raw `.env` content. The Node server loads `.env` itself at runtime, which avoids shell parsing issues and startup breakage from values containing spaces.
- Updated `docs/INSTALLER-STEPS.md` to match the current installer behavior.

## Why

These fixes address a few installer behaviors that were either brittle or too destructive:

- port conflicts could crash or loop instead of failing cleanly
- rerunning the installer against a dirty checkout could silently blow away local changes
- dry-run had misleading exit semantics
- the launchd wrapper could break on valid dotenv values that are not shell-safe
- Debian prerequisite installation assumed root in a path many users will hit as an unprivileged user

## Validation

- `bash -n install.sh`
- `git diff --check`
- `bash ./install.sh --dry-run --skip-setup`
- real install rehearsal into `/tmp` to verify:
  - clean non-interactive failure on port conflict
  - refusal to overwrite a dirty existing checkout in non-interactive mode

## Notes

- This PR intentionally keeps the installer opinionated about managed install directories; it now warns before destructive update behavior instead of silently proceeding.
- No product/runtime functionality changed outside installer/setup/service startup paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Installation guide reorganized and clarified (section renames, interactive vs non-interactive flows, port handling, and clearer error guidance).

* **Bug Fixes**
  * Installer detects and warns about local repository changes and avoids overwriting in non-interactive mode.
  * Port-conflict handling improved with clear prompts or clean failures.
  * FFmpeg/build-tools install failures now surface as warnings with guidance.

* **Refactor**
  * Consolidated build messaging ("Building project", "Client and server built"); dry-run reliably reports success and more informative dry-run warnings.
* **Behavior**
  * Runtime now loads environment at start so env updates take effect without reinstalling service entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->