### PR TITLE
Fix subagent session deletion

### DIFF
--- a/server/lib/ws-proxy.test.ts
+++ b/server/lib/ws-proxy.test.ts
@@ -195,6 +195,52 @@ describe('ws-proxy', () => {
   });
 
   describe('message relaying', () => {
+    it('forwards restricted session mutations for control-ui clients instead of intercepting them', async () => {
+      const ws = new WebSocket(
+        `ws://127.0.0.1:${proxyPort}/ws?target=${encodeURIComponent(mockGw.url + '/ws')}`,
+      );
+
+      const challenge = await waitForMessage(ws);
+      expect(JSON.parse(challenge).event).toBe('connect.challenge');
+
+      ws.send(JSON.stringify({
+        type: 'req',
+        method: 'connect',
+        id: 'c-control-1',
+        params: { auth: { token: 'test-token' }, client: { id: 'openclaw-control-ui', mode: 'webchat' } },
+      }));
+
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('timeout waiting for connect response')), 5000);
+        ws.on('message', (data) => {
+          try {
+            const msg = JSON.parse(data.toString());
+            if (msg.type === 'res' && msg.id === 'c-control-1') {
+              clearTimeout(timer);
+              resolve();
+            }
+          } catch { /* ignore */ }
+        });
+      });
+
+      mockGw.clearReceived();
+      ws.send(JSON.stringify({
+        type: 'req',
+        method: 'sessions.delete',
+        id: 'delete-1',
+        params: { key: 'agent:main:subagent:test', deleteTranscript: true },
+      }));
+
+      await mockGw.expectMessages(1);
+      const deleteMsg = mockGw.received.find((m) => {
+        const d = m.data as Record<string, unknown>;
+        return d.type === 'req' && d.method === 'sessions.delete';
+      });
+      expect(deleteMsg).toBeTruthy();
+
+      ws.close();
+    });
+
     it('relays gateway messages to client', async () => {
       const ws = new WebSocket(
         `ws://127.0.0.1:${proxyPort}/ws?target=${encodeURIComponent(mockGw.url + '/ws')}`,

--- a/server/lib/ws-proxy.ts
+++ b/server/lib/ws-proxy.ts
@@ -41,6 +41,7 @@ const RESTRICTED_METHODS = new Set([
   'sessions.reset',
   'sessions.compact',
 ]);
+const CONTROL_UI_CLIENT_ID = 'openclaw-control-ui';
 
 /**
  * Execute a gateway RPC call via the CLI, bypassing webchat restrictions.
@@ -221,6 +222,8 @@ function createGatewayRelay(
   let savedConnectMsg: Record<string, unknown> | null = null;
   /** Whether the saved connect message has been dispatched to the gateway */
   let connectSent = false;
+  /** Whether this connection is using the privileged OpenClaw control UI client id */
+  let isControlUiClient = false;
   /** Timeout handle for challenge nonce deadline */
   let challengeTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -257,6 +260,11 @@ function createGatewayRelay(
       clearTimeout(challengeTimer);
       challengeTimer = null;
     }
+  }
+
+  function updateClientKindFromConnect(msg: Record<string, unknown>): void {
+    const params = (msg.params || {}) as ConnectParams;
+    isControlUiClient = params.client?.id === CONTROL_UI_CLIENT_ID;
   }
 
   /**
@@ -397,6 +405,7 @@ function createGatewayRelay(
           const msg = JSON.parse(data.toString());
           if (msg.type === 'req' && msg.method === 'connect' && msg.params) {
             savedConnectMsg = msg;
+            updateClientKindFromConnect(msg);
             return; // Do NOT add to pending buffer
           }
         } catch { /* pass through */ }
@@ -418,6 +427,7 @@ function createGatewayRelay(
           if (msg.type === 'req' && msg.method === 'connect' && msg.params) {
             // Last-write-wins if multiple connect frames arrive before dispatch.
             savedConnectMsg = msg;
+            updateClientKindFromConnect(msg);
             if (challengeNonce) {
               dispatchConnect(challengeNonce);
             } else {
@@ -442,6 +452,7 @@ function createGatewayRelay(
         // Intercept connect request — defer until challenge nonce arrives
         if (!handshakeComplete && msg.type === 'req' && msg.method === 'connect' && msg.params) {
           savedConnectMsg = msg;
+          updateClientKindFromConnect(msg);
           if (challengeNonce) {
             dispatchConnect(challengeNonce);
           } else {
@@ -450,8 +461,9 @@ function createGatewayRelay(
           return;
         }
 
-        // Intercept restricted RPC methods — proxy via CLI (full scopes)
-        if (msg.type === 'req' && RESTRICTED_METHODS.has(msg.method)) {
+        // Intercept restricted RPC methods for plain webchat clients only.
+        // Control UI clients are allowed to call these directly on the gateway.
+        if (msg.type === 'req' && RESTRICTED_METHODS.has(msg.method) && !isControlUiClient) {
           const reqId = msg.id;
           gatewayCall(msg.method, msg.params || {})
             .then((result) => {

--- a/src/hooks/useWebSocket.test.ts
+++ b/src/hooks/useWebSocket.test.ts
@@ -111,6 +111,38 @@ describe('useWebSocket', () => {
   });
 
   describe('Connect handshake payload', () => {
+    it('should identify as the OpenClaw control UI client', async () => {
+      const wsInstances: MockWebSocket[] = [];
+      const OriginalMockWS = MockWebSocket;
+      (globalThis as unknown as { WebSocket: typeof MockWebSocket }).WebSocket = class extends OriginalMockWS {
+        constructor(url: string) {
+          super(url);
+          wsInstances.push(this);
+        }
+      };
+
+      const { result } = renderHook(() => useWebSocket());
+
+      act(() => {
+        result.current.connect('ws://localhost:8080', 'test-token');
+      });
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      const ws = wsInstances[0];
+      act(() => {
+        ws.simulateMessage({ type: 'event', event: 'connect.challenge', payload: { nonce: 'n0' } });
+      });
+
+      const connectReq = getConnectRequest(ws);
+      const client = (connectReq?.params as { client?: { id?: string; mode?: string } } | undefined)?.client;
+
+      expect(client?.id).toBe('openclaw-control-ui');
+      expect(client?.mode).toBe('webchat');
+    });
+
     it('should include a stable per-tab client.instanceId in connect params', async () => {
       const wsInstances: MockWebSocket[] = [];
       const OriginalMockWS = MockWebSocket;

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -162,7 +162,7 @@ export function useWebSocket(): UseWebSocketReturn {
             params: {
               minProtocol: 3, maxProtocol: 3,
               client: {
-                id: 'webchat-ui',
+                id: 'openclaw-control-ui',
                 version: '0.1.0',
                 platform: 'web',
                 mode: 'webchat',


### PR DESCRIPTION
## Summary

Fix subagent session deletion by making Nerve identify as the OpenClaw control UI instead of a webchat client.

This removes the broken CLI fallback path for control-ui session mutations and lets `sessions.delete` go directly through the gateway as intended.

## Changes

- change gateway client id from `webchat-ui` to `openclaw-control-ui`
- only intercept restricted session mutations for plain webchat clients
- add regression tests for:
  - control-ui handshake identity
  - forwarding `sessions.delete` for control-ui clients

## Verification

- `npx vitest run src/hooks/useWebSocket.test.ts server/lib/ws-proxy.test.ts`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced WebSocket client identification and permission handling to distinguish control UI clients.
  * Control UI now has direct access to previously restricted gateway methods.

* **Tests**
  * Added test coverage for client identification during connection handshake.
  * Added test for updated message relay and permission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->