### PR TITLE
Allow the right sidebar to shrink to 15%

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -680,7 +680,7 @@ export default function App({ onLogout }: AppProps) {
               leftPercent={panelRatio}
               onResize={setPanelRatio}
               minLeftPercent={30}
-              maxLeftPercent={75}
+              maxLeftPercent={85}
               rightWidthPx={fileBrowserCollapsed ? desktopRightPanelWidth : null}
               onRightWidthChange={fileBrowserCollapsed ? undefined : setDesktopRightPanelWidth}
               leftClassName="shell-panel boot-panel rounded-[28px] overflow-hidden"

--- a/src/components/ResizablePanels.test.tsx
+++ b/src/components/ResizablePanels.test.tsx
@@ -1,0 +1,37 @@
+/** Tests for the ResizablePanels component. */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ResizablePanels } from './ResizablePanels';
+
+describe('ResizablePanels', () => {
+  it('allows the right sidebar to shrink to 15% by clamping the left pane to 85%', () => {
+    const onResize = vi.fn();
+    const { container } = render(
+      <ResizablePanels
+        left={<div>Left</div>}
+        right={<div>Right</div>}
+        leftPercent={55}
+        onResize={onResize}
+      />,
+    );
+
+    const panelRoot = container.firstElementChild as HTMLDivElement;
+    vi.spyOn(panelRoot, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      left: 0,
+      top: 0,
+      right: 1000,
+      bottom: 500,
+      width: 1000,
+      height: 500,
+      toJSON: () => ({}),
+    } as DOMRect);
+
+    fireEvent.mouseDown(screen.getByTitle('Drag to resize. Double click to reset'));
+    fireEvent.mouseMove(window, { clientX: 900 });
+    fireEvent.mouseUp(window);
+
+    expect(onResize).toHaveBeenCalledWith(85);
+  });
+});

--- a/src/components/ResizablePanels.tsx
+++ b/src/components/ResizablePanels.tsx
@@ -12,7 +12,7 @@ interface ResizablePanelsProps {
   onResize: (leftPercent: number) => void;
   /** Minimum left-pane width percentage. @default 30 */
   minLeftPercent?: number;
-  /** Maximum left-pane width percentage. @default 75 */
+  /** Maximum left-pane width percentage. @default 85 */
   maxLeftPercent?: number;
   /** Additional class names for the left pane wrapper. */
   leftClassName?: string;
@@ -37,7 +37,7 @@ export function ResizablePanels({
   leftPercent,
   onResize,
   minLeftPercent = 30,
-  maxLeftPercent = 75,
+  maxLeftPercent = 85,
   leftClassName = '',
   rightClassName = '',
   rightWidthPx = null,


### PR DESCRIPTION
## Summary

Allow the main right sidebar in Nerve to shrink down to 15% of the available width.

## Changes

- increase the main split max left width from `75%` to `85%`
- keep the existing left-side minimum unchanged
- add a regression test covering the 85/15 clamp behavior

## Verification

- `npx vitest run src/components/ResizablePanels.test.tsx`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Left panel now expands to 85% maximum width (previously 75%) during resizing, enabling more screen real estate for chat content.

* **Tests**
  * Added comprehensive test suite for panel resizing functionality to validate constraint enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->