### PR TITLE
docs: refresh changelog and technical docs for recent workspace updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Highlights
+
+**Workspace context now follows the owning top-level agent**. File browser state, Memory, Config, and Skills now switch with the selected top-level agent instead of leaking across agents, and dirty editor tabs now block cross-agent switches with an explicit save / discard / cancel choice (PR #123).
+
+**Agent runtime flows got tighter**. Subagents can now choose whether they stay visible after one-shot runs, subagent deletion is more reliable, and the model catalog waits longer on cold starts so configured Codex and other models are more likely to appear in the spawn dialog (PR #119, PR #120, PR #124).
+
+**Installer and mobile edge cases got another hardening pass**. Tailscale setup now supports distinct IP and Serve flows, wake word is disabled on mobile web, and the right sidebar can collapse narrower on smaller screens (PR #116, PR #118, PR #122).
+
+### Added
+- Tailscale IP and Tailscale Serve setup flows in the installer, with matching installer-step documentation (PR #116)
+- An **After run** selector for one-shot subagents, with **Keep** and **Delete** cleanup options (PR #120)
+
+### Changed
+- Workspace scope is now derived from the owning top-level agent, including when viewing subagent sessions (PR #123)
+- File browser tabs, selection state, drafts, Memory, Config, and Skills now persist per top-level agent instead of globally (PR #123)
+- Cross-agent workspace switches now show **Save and switch**, **Discard and switch**, or **Cancel** when dirty editor tabs exist (PR #123)
+- Model catalog fetches now allow a longer cold-start timeout before giving up, so configured Codex and other models appear more reliably in the spawn dialog (PR #124)
+- Mobile web now disables wake word and points users to manual mic activation instead (PR #118)
+- Right sidebar resizing now allows a narrower minimum width (PR #122)
+
+### Fixed
+- Subagent session deletion no longer fails on the Nerve side when the gateway closes a proxied WebSocket normally during delete flows (PR #119)
+- Agent-scoped workspace switching no longer leaks same-path editor state, save toasts, watcher refreshes, or async file reads across top-level agents (PR #123)
+- Tailscale origin handling is more robust during setup and follow-up gateway patching (PR #116)
+
 ---
 
 ## [1.4.9] — 2026-03-18

--- a/docs/API.md
+++ b/docs/API.md
@@ -246,8 +246,8 @@ data: {"event":"memory.changed","data":{"source":"api","action":"create","sectio
 |-------|---------|-------------|
 | `connected` | On initial connection | `{ ts }` |
 | `ping` | Every 30 seconds (keep-alive) | `{ ts }` |
-| `memory.changed` | Memory file modified via API | `{ source, action, section?, file? }` |
-| `file.changed` | Workspace file modified (by agent or externally) | `{ path, mtime }` |
+| `memory.changed` | Memory file modified via API or file watcher | `{ source, action?, section?, file?, agentId? }` |
+| `file.changed` | Workspace file modified by the file watcher | `{ path, agentId }` |
 | `tokens.updated` | Token usage changed | varies |
 | `status.changed` | Gateway status changed | varies |
 
@@ -641,11 +641,19 @@ Session data is cached for 60 seconds to avoid repeated filesystem scans.
 
 ## Memories
 
+All memory routes accept an optional `agentId` scope. If omitted, Nerve uses `main`. The UI normally derives this from the owning top-level agent when you switch sessions.
+
 ### `GET /api/memories`
 
-Returns parsed memory data from `MEMORY.md` (sections + bullet items) and the 7 most recent daily files (section headers only).
+Returns parsed memory data from `MEMORY.md` (sections + bullet items) and the 7 most recent daily files (section headers only) for the selected workspace agent.
 
 **Rate Limit:** General (60/min)
+
+**Query Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agentId` | `string` | No | Workspace agent id. Defaults to `main` |
 
 **Response:**
 
@@ -667,6 +675,7 @@ Returns the raw markdown content of a specific section.
 |-------|------|----------|-------------|
 | `title` | `string` | Yes | Section title (exact match) |
 | `date` | `string` | No | `YYYY-MM-DD` for daily files; omit for MEMORY.md |
+| `agentId` | `string` | No | Workspace agent id. Defaults to `main` |
 
 **Response:**
 
@@ -702,6 +711,7 @@ Creates a new memory entry. Writes a bullet point to `MEMORY.md` under the speci
 | `section` | `string` | No | Section heading (default: "General", max 200 chars) |
 | `category` | `"preference" \| "fact" \| "decision" \| "entity" \| "other"` | No | Category for vector store |
 | `importance` | `number` | No | 0–1 importance score (default: 0.7) |
+| `agentId` | `string` | No | Workspace agent id. Defaults to `main` |
 
 **Response:**
 
@@ -709,7 +719,7 @@ Creates a new memory entry. Writes a bullet point to `MEMORY.md` under the speci
 { "ok": true, "result": { "written": true, "section": "Preferences" } }
 ```
 
-Broadcasts `memory.changed` SSE event on success.
+Broadcasts `memory.changed` SSE event on success, tagged with the affected `agentId`.
 
 ### `PUT /api/memories/section`
 
@@ -730,6 +740,7 @@ Replaces the content of an existing section.
 | `title` | `string` | Yes | Section title (1–200 chars) |
 | `content` | `string` | Yes | New markdown content (max 50000 chars) |
 | `date` | `string` | No | `YYYY-MM-DD` for daily files; omit for MEMORY.md |
+| `agentId` | `string` | No | Workspace agent id. Defaults to `main` |
 
 ### `DELETE /api/memories`
 
@@ -749,6 +760,7 @@ Deletes a memory entry from the file.
 |-------|------|----------|-------------|
 | `query` | `string` | Yes | Text to find (exact match for items, section title for sections) |
 | `type` | `"section" \| "item" \| "daily"` | No | What to delete. `section`/`daily` removes header + all content. Default: item |
+| `agentId` | `string` | No | Workspace agent id. Defaults to `main` |
 | `date` | `string` | No | `YYYY-MM-DD` — required when `type` is `"daily"` |
 
 **Response:**
@@ -798,7 +810,7 @@ All fields are optional. A `ts` (epoch ms) is automatically set on write. The lo
 
 ### `GET /api/gateway/models`
 
-Returns available AI models from the OpenClaw gateway. Models are fetched via `openclaw models list` CLI and cached for 5 minutes.
+Returns available AI models from the OpenClaw gateway. Models are fetched via `openclaw models list`, cached for 5 minutes, and the CLI call allows a longer timeout so cold starts have more time to surface configured models in the spawn dialog.
 
 **Rate Limit:** General (60/min)
 
@@ -814,8 +826,10 @@ Returns available AI models from the OpenClaw gateway. Models are fetched via `o
 ```
 
 **Selection logic:**
-1. Configured/allowlisted models (from `agents.defaults.models` in OpenClaw config) — all included regardless of `available` flag
-2. If ≤0 results: falls back to all available models from the gateway
+1. Configured / allowlisted models (from `agents.defaults.models` in OpenClaw config) are fetched first and included regardless of `available` flag
+2. If that returns 0 models, Nerve falls back to `openclaw models list --all --json` and keeps only available entries
+
+The CLI timeout for model discovery is **15 seconds**, which helps cold or recently started OpenClaw installs surface configured models more reliably.
 
 ### `GET /api/gateway/session-info`
 
@@ -914,9 +928,17 @@ Unregisters a session's working directory.
 
 ## Workspace Files
 
+Workspace file routes accept an optional `agentId` scope. If omitted, Nerve uses the `main` workspace.
+
 ### `GET /api/workspace`
 
-Lists available workspace file keys and their existence status.
+Lists available workspace file keys and their existence status for the selected workspace agent.
+
+**Query Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agentId` | `string` | No | Workspace agent id. Defaults to `main` |
 
 **Response:**
 
@@ -940,6 +962,12 @@ Reads a workspace file by key.
 
 **Valid keys:** `soul`, `tools`, `identity`, `user`, `agents`, `heartbeat`
 
+**Query Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agentId` | `string` | No | Workspace agent id. Defaults to `main` |
+
 **Response:**
 
 ```json
@@ -955,8 +983,13 @@ Writes content to a workspace file.
 **Request Body:**
 
 ```json
-{ "content": "# Updated content\n\nNew text here." }
+{ "content": "# Updated content\n\nNew text here.", "agentId": "research" }
 ```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `content` | `string` | Yes | New file contents |
+| `agentId` | `string` | No | Workspace agent id. Defaults to `main` |
 
 Content must be a string, max 100 KB.
 
@@ -1028,9 +1061,17 @@ Returns the last 10 run history entries for a cron job.
 
 ### `GET /api/skills`
 
-Lists all OpenClaw skills via `openclaw skills list --json`.
+Lists all OpenClaw skills via `openclaw skills list --json` for the selected workspace agent.
+
+Nerve scopes this by creating a temporary OpenClaw config whose `agents.defaults.workspace` points at the selected agent workspace, then runs the CLI against that workspace.
 
 **Rate Limit:** General (60/min)
+
+**Query Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `agentId` | `string` | No | Workspace agent id. Defaults to `main` |
 
 **Response:**
 
@@ -1057,43 +1098,65 @@ Lists all OpenClaw skills via `openclaw skills list --json`.
 
 ## File Browser
 
-Browse, read, and edit workspace files. All paths are restricted to the workspace directory with traversal protection.
+Browse, read, and edit workspace files. All paths are restricted to the selected workspace directory with traversal protection.
+
+All file-browser routes accept an optional `agentId` scope. If omitted, Nerve uses `main`. If `FILE_BROWSER_ROOT` is set, file-browser agent scoping is bypassed and all sessions browse the same custom root.
 
 ### `GET /api/files/tree`
 
 Returns the workspace directory tree. Excludes `node_modules`, `.git`, `dist`, `server-dist`, and other build artifacts.
 
-**Response:**
-```json
-[
-  {
-    "name": "MEMORY.md",
-    "path": "MEMORY.md",
-    "type": "file"
-  },
-  {
-    "name": "memory",
-    "path": "memory",
-    "type": "directory",
-    "children": [...]
-  }
-]
-```
-
-### `GET /api/files/read`
-
-Read a file's contents with its modification time (for conflict detection on save).
-
 **Query Parameters:**
 
-| Param | Description |
-|-------|-------------|
-| `path` | Relative path within the workspace |
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | `string` | No | Relative directory path to expand. Defaults to root |
+| `depth` | `number` | No | Expansion depth, clamped to 1–5 |
+| `agentId` | `string` | No | Workspace agent id. Defaults to `main` |
 
 **Response:**
 ```json
 {
+  "ok": true,
+  "root": ".",
+  "entries": [
+    {
+      "name": "MEMORY.md",
+      "path": "MEMORY.md",
+      "type": "file",
+      "mtime": 1771355007542
+    },
+    {
+      "name": "memory",
+      "path": "memory",
+      "type": "directory",
+      "children": null
+    }
+  ],
+  "workspaceInfo": {
+    "isCustomWorkspace": false,
+    "rootPath": "/home/user/.openclaw/workspace"
+  }
+}
+```
+
+### `GET /api/files/read`
+
+Read a text file's contents with its modification time (for conflict detection on save).
+
+**Query Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | `string` | Yes | Relative path within the selected workspace |
+| `agentId` | `string` | No | Workspace agent id. Defaults to `main` |
+
+**Response:**
+```json
+{
+  "ok": true,
   "content": "# MEMORY.md\n...",
+  "size": 128,
   "mtime": 1771355007542
 }
 ```
@@ -1102,21 +1165,32 @@ Read a file's contents with its modification time (for conflict detection on sav
 
 | Status | Condition |
 |--------|-----------|
-| 400 | Missing `path`, path traversal detected, or binary file |
+| 400 | Missing `path`, not a file, or other invalid request |
+| 403 | Path traversal or excluded path |
 | 404 | File not found |
+| 413 | File too large |
+| 415 | Binary file |
 
-### `POST /api/files/write`
+### `PUT /api/files/write`
 
-Write file contents with optimistic concurrency via mtime comparison. If the file was modified since it was last read, returns 409 Conflict.
+Write text file contents with optimistic concurrency via mtime comparison. If the file was modified since it was last read, returns 409 Conflict.
 
 **Request Body:**
 ```json
 {
   "path": "MEMORY.md",
   "content": "# Updated content\n...",
-  "mtime": 1771355007542
+  "expectedMtime": 1771355007542,
+  "agentId": "research"
 }
 ```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | `string` | Yes | Relative file path within the selected workspace |
+| `content` | `string` | Yes | UTF-8 file contents |
+| `expectedMtime` | `number` | No | Expected current mtime for optimistic concurrency |
+| `agentId` | `string` | No | Workspace agent id. Defaults to `main` |
 
 **Response (success):**
 ```json
@@ -1130,8 +1204,60 @@ Write file contents with optimistic concurrency via mtime comparison. If the fil
 
 | Status | Condition |
 |--------|-----------|
-| 400 | Missing fields or path traversal |
-| 409 | File modified since last read (mtime mismatch) |
+| 400 | Missing fields or invalid request |
+| 403 | Path traversal or excluded path |
+| 409 | File modified since last read (`currentMtime` returned) |
+| 413 | Content too large |
+| 415 | Binary file write attempted |
+
+### `POST /api/files/rename`
+
+Rename a file or directory within the selected workspace.
+
+**Request Body:**
+```json
+{ "path": "notes/today.md", "newName": "tomorrow.md", "agentId": "research" }
+```
+
+### `POST /api/files/move`
+
+Move a file or directory into another directory within the selected workspace.
+
+**Request Body:**
+```json
+{ "sourcePath": "notes/today.md", "targetDirPath": "archive", "agentId": "research" }
+```
+
+### `POST /api/files/trash`
+
+Move a file or directory into `.trash` when using the default workspace root. If `FILE_BROWSER_ROOT` is set, deletion is permanent instead.
+
+**Request Body:**
+```json
+{ "path": "notes/today.md", "agentId": "research" }
+```
+
+### `POST /api/files/restore`
+
+Restore an item from `.trash` back to its original location.
+
+**Request Body:**
+```json
+{ "path": ".trash/2026-03-20-notes-today.md", "agentId": "research" }
+```
+
+### `GET /api/files/raw`
+
+Serves supported image files from the selected workspace for previews.
+
+**Query Parameters:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | `string` | Yes | Relative image path |
+| `agentId` | `string` | No | Workspace agent id. Defaults to `main` |
+
+Supported image types: `png`, `jpg`, `jpeg`, `gif`, `webp`, `avif`, `svg`, `ico`.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -114,7 +114,7 @@ Session management sidebar.
 | `SessionList.tsx` | Hierarchical session tree with parent-child relationships |
 | `SessionNode.tsx` | Individual session row with status indicator, context menu |
 | `SessionInfoPanel.tsx` | Session detail panel (model, tokens, thinking level) |
-| `SpawnAgentDialog.tsx` | Dialog for spawning sub-agents with task/model/thinking config |
+| `SpawnAgentDialog.tsx` | Dialog for spawning top-level agents and subagents with task, model, thinking, and subagent **After run** cleanup config |
 | `sessionTree.ts` | Builds tree structure from flat session list using `parentId` |
 | `statusUtils.ts` | Maps agent status to icons and labels |
 
@@ -139,18 +139,30 @@ Full workspace file browser with tabbed CodeMirror editor.
 #### `features/workspace/`
 Workspace file editor and management tabs.
 
+The workspace scope is derived from the **owning top-level agent**. Memory, Config, Skills, file-browser state, and persisted drafts follow that top-level agent. Crons and Kanban stay global.
+
 | File | Purpose |
 |------|---------|
-| `WorkspacePanel.tsx` | Container for workspace tabs |
+| `WorkspacePanel.tsx` | Container for workspace tabs, scoped by the current top-level workspace agent |
 | `WorkspaceTabs.tsx` | Tab switcher (Memory, Config, Crons, Skills) |
-| `tabs/MemoryTab.tsx` | View/edit MEMORY.md and daily files |
-| `tabs/ConfigTab.tsx` | Edit workspace files (SOUL.md, TOOLS.md, USER.md, etc.) |
-| `tabs/CronsTab.tsx` | Cron job management (list, create, toggle, run) |
+| `tabs/MemoryTab.tsx` | View/edit the selected top-level agent's `MEMORY.md` and daily files |
+| `tabs/ConfigTab.tsx` | Edit scoped workspace files (`SOUL.md`, `TOOLS.md`, `USER.md`, etc.) for the selected top-level agent |
+| `tabs/CronsTab.tsx` | Cron job management (list, create, toggle, run). Remains global |
 | `tabs/CronDialog.tsx` | Cron creation/edit dialog |
-| `tabs/SkillsTab.tsx` | View installed skills with eligibility status |
-| `hooks/useWorkspaceFile.ts` | Fetch/save workspace files via REST API |
+| `tabs/SkillsTab.tsx` | View installed skills for the selected top-level agent workspace |
+| `hooks/useWorkspaceFile.ts` | Fetch/save scoped workspace files via REST API + `agentId` |
 | `hooks/useCrons.ts` | Cron CRUD operations via REST API |
-| `hooks/useSkills.ts` | Fetch skills list |
+| `hooks/useSkills.ts` | Fetch scoped skills list via `agentId` |
+| `workspaceScope.ts` | Derives workspace scope and localStorage keys from the owning top-level agent |
+| `workspaceSwitchGuard.ts` | Pure guard logic for dirty-file prompts when switching between top-level agents |
+
+### Workspace scope rules
+
+- Root sessions use their own top-level agent as workspace scope
+- Subagent and cron-run views inherit the owning top-level agent workspace
+- The child session itself does **not** create a separate workspace scope
+- Cross-agent dirty file prompts only fire when the owning top-level agent changes
+- Crons and Kanban stay global even while Memory, Config, Skills, and file-browser state switch per agent
 
 #### `features/settings/`
 Settings drawer with tabbed sections.
@@ -332,24 +344,30 @@ Applied in order in `app.ts`:
 | `/api/voice-phrases/:lang` | `routes/voice-phrases.ts` | GET, PUT | Read/save language-specific stop/cancel/wake phrase overrides |
 | `/api/agentlog` | `routes/agent-log.ts` | GET, POST | Agent activity log persistence. Zod-validated entries. Mutex-protected file I/O |
 | `/api/tokens` | `routes/tokens.ts` | GET | Token usage statistics — scans session transcripts, persists high water mark |
-| `/api/memories` | `routes/memories.ts` | GET, POST, DELETE | Memory management — reads MEMORY.md + daily files, stores/deletes via gateway tool invocation |
-| `/api/memories/section` | `routes/memories.ts` | GET, PUT | Read/replace a specific memory section by title |
-| `/api/gateway/models` | `routes/gateway.ts` | GET | Available models via `openclaw models list`. Allowlist support |
+| `/api/memories` | `routes/memories.ts` | GET, POST, DELETE | Agent-scoped memory management — reads `MEMORY.md` + daily files, stores/deletes via gateway tool invocation |
+| `/api/memories/section` | `routes/memories.ts` | GET, PUT | Read/replace a specific memory section by title, scoped via `agentId` |
+| `/api/gateway/models` | `routes/gateway.ts` | GET | Available models via `openclaw models list`, with longer cold-start timeout, allowlist support, and `--all` fallback |
 | `/api/gateway/session-info` | `routes/gateway.ts` | GET | Current session model/thinking level |
 | `/api/gateway/session-patch` | `routes/gateway.ts` | POST | Change model/effort for a session |
 | `/api/server-info` | `routes/server-info.ts` | GET | Server time, gateway uptime, agent name |
 | `/api/version` | `routes/version.ts` | GET | Package version from `package.json` |
 | `/api/git-info` | `routes/git-info.ts` | GET, POST, DELETE | Git branch/status. Session workdir registration |
-| `/api/workspace/:key` | `routes/workspace.ts` | GET, PUT | Read/write workspace files (strict key→file allowlist: soul, tools, identity, user, agents, heartbeat) |
+| `/api/workspace` | `routes/workspace.ts` | GET | List allowlisted workspace files for the selected agent workspace |
+| `/api/workspace/:key` | `routes/workspace.ts` | GET, PUT | Read/write allowlisted workspace files (`soul`, `tools`, `identity`, `user`, `agents`, `heartbeat`) via `agentId` |
 | `/api/crons` | `routes/crons.ts` | GET, POST, PATCH, DELETE | Cron job CRUD via gateway tool invocation |
 | `/api/crons/:id/toggle` | `routes/crons.ts` | POST | Toggle cron enabled/disabled |
 | `/api/crons/:id/run` | `routes/crons.ts` | POST | Run cron job immediately |
 | `/api/crons/:id/runs` | `routes/crons.ts` | GET | Cron run history |
-| `/api/skills` | `routes/skills.ts` | GET | List skills via `openclaw skills list --json` |
+| `/api/skills` | `routes/skills.ts` | GET | List skills for the selected agent workspace via a scoped OpenClaw config |
 | `/api/files` | `routes/files.ts` | GET | Serve local image files (MIME-type restricted, directory traversal blocked) |
-| `/api/files/tree` | `routes/file-browser.ts` | GET | Workspace directory tree (excludes node_modules, .git, etc.) |
-| `/api/files/read` | `routes/file-browser.ts` | GET | Read file contents with mtime for conflict detection |
-| `/api/files/write` | `routes/file-browser.ts` | POST | Write file with mtime-based optimistic concurrency (409 on conflict) |
+| `/api/files/tree` | `routes/file-browser.ts` | GET | Agent-scoped workspace directory tree (excludes node_modules, .git, etc.) |
+| `/api/files/read` | `routes/file-browser.ts` | GET | Read scoped file contents with mtime for conflict detection |
+| `/api/files/write` | `routes/file-browser.ts` | PUT | Write scoped file contents with optimistic concurrency (409 on conflict) |
+| `/api/files/rename` | `routes/file-browser.ts` | POST | Rename a file or directory within the selected workspace |
+| `/api/files/move` | `routes/file-browser.ts` | POST | Move a file or directory within the selected workspace |
+| `/api/files/trash` | `routes/file-browser.ts` | POST | Trash a file or directory, or permanently delete when using `FILE_BROWSER_ROOT` |
+| `/api/files/restore` | `routes/file-browser.ts` | POST | Restore a trashed file or directory |
+| `/api/files/raw` | `routes/file-browser.ts` | GET | Serve scoped image previews from the selected workspace |
 | `/api/claude-code-limits` | `routes/claude-code-limits.ts` | GET | Claude Code rate limits via PTY + CLI parsing |
 | `/api/codex-limits` | `routes/codex-limits.ts` | GET | Codex rate limits via OpenAI API with local file fallback |
 | `/api/kanban/tasks` | `routes/kanban.ts` | GET, POST | Task CRUD -- list (with filters/pagination) and create |
@@ -374,7 +392,7 @@ Applied in order in `app.ts`:
 | `lib/ws-proxy.ts` | WebSocket proxy — client→gateway with session cookie auth on upgrade and Ed25519 device identity injection |
 | `lib/device-identity.ts` | Ed25519 keypair generation/persistence (`~/.nerve/device-identity.json`). Builds signed connect blocks for gateway auth |
 | `lib/gateway-client.ts` | HTTP client for gateway tool invocation API (`/tools/invoke`) |
-| `lib/file-watcher.ts` | Watches MEMORY.md, `memory/`, and workspace directory (recursive). Broadcasts `file.changed` SSE events for real-time sync |
+| `lib/file-watcher.ts` | Discovers agent workspaces, watches each `MEMORY.md` and `memory/` directory, and optionally watches full workspaces recursively. Broadcasts agent-tagged `memory.changed` / `file.changed` SSE events |
 | `lib/file-utils.ts` | File browser utilities — path validation, directory exclusions, binary file detection |
 | `lib/files.ts` | Async file helpers (`readJSON`, `writeJSON`, `readText`) |
 | `lib/mutex.ts` | Async mutex for serializing file read-modify-write. Includes keyed mutex variant |
@@ -444,7 +462,8 @@ Browser → GET /api/events → SSE stream (text/event-stream)
 ```
 
 Events pushed by the server:
-- `memory.changed` — File watcher detects MEMORY.md or daily file changes
+- `memory.changed` — File watcher or memory API detects `MEMORY.md` / daily file changes, tagged with `agentId`
+- `file.changed` — File watcher detects a workspace file change, tagged with `agentId`
 - `tokens.updated` — Token usage data changed
 - `status.changed` — Gateway status changed
 - `ping` — Keep-alive every 30 seconds

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -256,13 +256,13 @@ REPLICATE_BASE_URL=https://api.replicate.com/v1
 
 | Variable | Default | Description |
 |---------|---------|-------------|
-| `FILE_BROWSER_ROOT` | `""` (disabled) | If set, overrides OpenClaw workspace as the root directory for the workspace directory tree. In this mode, default exclusion rules are disabled and delete operations are permanent (no `.trash` recovery). |
-| `MEMORY_PATH` | `~/.openclaw/workspace/MEMORY.md` | Path to the agent's long-term memory file |
-| `MEMORY_DIR` | `~/.openclaw/workspace/memory/` | Directory for daily memory files (`YYYY-MM-DD.md`) |
+| `FILE_BROWSER_ROOT` | `""` (disabled) | If set, overrides the file browser root directory for all sessions. In this mode, file-browser `agentId` scoping is bypassed, default exclusion rules are disabled, and delete operations are permanent (no `.trash` recovery). |
+| `MEMORY_PATH` | `~/.openclaw/workspace/MEMORY.md` | Path to the main agent's long-term memory file |
+| `MEMORY_DIR` | `~/.openclaw/workspace/memory/` | Directory for the main agent's daily memory files (`YYYY-MM-DD.md`) |
 | `SESSIONS_DIR` | `~/.openclaw/agents/main/sessions/` | Session transcript directory (scanned for token usage) |
 | `USAGE_FILE` | `~/.openclaw/token-usage.json` | Persistent cumulative token usage data |
 | `NERVE_VOICE_PHRASES_PATH` | `~/.nerve/voice-phrases.json` | Override location for per-language voice phrase overrides |
-| `NERVE_WATCH_WORKSPACE_RECURSIVE` | `false` | Enables recursive `fs.watch` for the entire workspace (legacy behavior). Disabled by default to prevent Linux inotify `ENOSPC` watcher exhaustion. |
+| `NERVE_WATCH_WORKSPACE_RECURSIVE` | `false` | Re-enables recursive `fs.watch` for full workspace `file.changed` SSE events outside `MEMORY.md` and `memory/`. Disabled by default to prevent Linux inotify `ENOSPC` watcher exhaustion. Memory watchers stay enabled for discovered agent workspaces even when this is `false`. |
 | `WORKSPACE_ROOT` | *(auto-detected)* | Allowed base directory for git workdir registration. Auto-derived from `git worktree list` or parent of `process.cwd()` |
 
 ```bash

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -446,13 +446,14 @@ MEMORY_PATH=/path/to/.openclaw/workspace/MEMORY.md
 
 **Symptom:** Model selector is empty or shows only the current model.
 
-**Cause:** Models are fetched via `GET /api/gateway/models`, which runs `openclaw models list --json`.
+**Cause:** Models are fetched via `GET /api/gateway/models`. Nerve first runs `openclaw models list --json` for configured / allowlisted models, waits up to 15 seconds for cold starts, and falls back to `openclaw models list --all --json` if needed. If those CLI calls fail or return nothing, the dropdown can stay sparse.
 
 **Fix:**
+- Wait a moment after a cold start, then reopen the spawn dialog or refresh the page
 - Ensure the `openclaw` binary is in PATH (the server searches multiple locations — see `lib/openclaw-bin.ts`)
 - Set `OPENCLAW_BIN` env var to the explicit path
-- Check server logs for model list errors
-- An allowlist can restrict visible models (configured server-side)
+- Check server logs for model list errors or timeouts
+- If you use an allowlist, verify the expected Codex or other models are configured there
 
 ### Model change doesn't take effect
 


### PR DESCRIPTION
## Summary

Refresh the changelog and technical docs to match recent Nerve changes after `1.4.9`.

## Updates
- filled in `CHANGELOG.md` `Unreleased`
- documented top-level agent scoped workspace behavior
- documented dirty cross-agent workspace switch guarding
- documented subagent `After run` cleanup behavior
- documented model catalog cold-start timeout / fallback behavior
- synced API, architecture, configuration, and troubleshooting docs with current routes and behavior

## Notes
- no runtime code changes
- `README.md` intentionally excluded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace now scoped to selected top-level agent
  * Added "After run" cleanup option for subagents (Keep or Delete)
  * New file operations: rename, move, trash, restore

* **Changed**
  * Cross-agent workspace switching requires explicit action when unsaved changes exist
  * Model catalog has longer cold-start timeout for improved reliability
  * Mobile web enhancements including disabled wake word and adjusted layouts

* **Fixed**
  * Improved subagent session deletion reliability
  * Reduced cross-agent state leakage

* **Documentation**
  * Updated API documentation with agent-scoped operations
  * Refreshed architecture and configuration guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->