### PR TITLE
fix: restore iPhone input sizing and finish cron font scaling

### DIFF
--- a/src/features/settings/fontSizeFollowups.test.ts
+++ b/src/features/settings/fontSizeFollowups.test.ts
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+const indexCss = fs.readFileSync(path.join(repoRoot, 'src/index.css'), 'utf8');
+const cronsTabSource = fs.readFileSync(path.join(repoRoot, 'src/features/workspace/tabs/CronsTab.tsx'), 'utf8');
+const cronDialogSource = fs.readFileSync(path.join(repoRoot, 'src/features/workspace/tabs/CronDialog.tsx'), 'utf8');
+
+describe('font size follow-up regressions', () => {
+  it('keeps mobile cockpit form controls at a fixed 16px to avoid iPhone auto-zoom', () => {
+    expect(indexCss).toMatch(
+      /@media \(max-width: 640px\)[\s\S]*?\.cockpit-input,\s*\.cockpit-select,\s*\.cockpit-textarea\s*\{\s*font-size:\s*16px;\s*\}/,
+    );
+  });
+
+  it('removes remaining fixed px typography from the cron list UI', () => {
+    expect(cronsTabSource).not.toMatch(/text-\[[0-9.]+px\]/);
+  });
+
+  it('removes remaining fixed px typography from the cron dialog UI', () => {
+    expect(cronDialogSource).not.toMatch(/text-\[[0-9.]+px\]/);
+  });
+});

--- a/src/features/workspace/tabs/CronDialog.tsx
+++ b/src/features/workspace/tabs/CronDialog.tsx
@@ -97,7 +97,7 @@ function SectionShell({
           {eyebrow}
         </div>
         <div className="text-base font-semibold tracking-[-0.03em] text-foreground">{title}</div>
-        <p className="text-[12.5px] leading-5 text-muted-foreground">{description}</p>
+        <p className="text-[0.833rem] leading-5 text-muted-foreground">{description}</p>
       </div>
       <div className="mt-3 space-y-2.5">{children}</div>
     </section>

--- a/src/features/workspace/tabs/CronsTab.tsx
+++ b/src/features/workspace/tabs/CronsTab.tsx
@@ -189,8 +189,8 @@ function CronRow({ job, onToggle, onRun, onDelete, onEdit, onFetchRuns }: {
                 <span>{job.enabled ? 'Live' : 'Off'}</span>
               </button>
                 <div className="min-w-0 space-y-0.5">
-                  <div className="text-[12.5px] font-semibold leading-tight text-foreground break-words">{name}</div>
-                  <div className="text-[10.5px] leading-4.5 text-muted-foreground">{humanSchedule(job)}</div>
+                  <div className="text-[0.833rem] font-semibold leading-tight text-foreground break-words">{name}</div>
+                  <div className="text-[0.7rem] leading-4.5 text-muted-foreground">{humanSchedule(job)}</div>
                 </div>
               </div>
               <div className="flex items-center gap-1 self-start">
@@ -229,7 +229,7 @@ function CronRow({ job, onToggle, onRun, onDelete, onEdit, onFetchRuns }: {
                           setActionsOpen(false);
                           onEdit(job);
                         }}
-                        className="flex min-h-8 w-full items-center gap-2 rounded-lg px-2.5 text-[10.5px] font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
+                        className="flex min-h-8 w-full items-center gap-2 rounded-lg px-2.5 text-[0.7rem] font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.04] hover:text-foreground"
                         aria-label={`Edit ${name}`}
                       >
                         <Pencil size={12} />
@@ -237,7 +237,7 @@ function CronRow({ job, onToggle, onRun, onDelete, onEdit, onFetchRuns }: {
                       </button>
                       <button
                         onClick={handleDeleteClick}
-                        className={`flex min-h-8 w-full items-center gap-2 rounded-lg px-2.5 text-[10.5px] font-medium transition-colors ${
+                        className={`flex min-h-8 w-full items-center gap-2 rounded-lg px-2.5 text-[0.7rem] font-medium transition-colors ${
                           confirmingDelete
                             ? 'text-red hover:bg-red/10 hover:text-red'
                             : 'text-muted-foreground hover:bg-foreground/[0.04] hover:text-red'
@@ -264,18 +264,18 @@ function CronRow({ job, onToggle, onRun, onDelete, onEdit, onFetchRuns }: {
 
             <div aria-live="polite" aria-atomic="true" className="space-y-1">
               {running && (
-                <div className="text-[10.5px] text-primary flex items-center gap-1.5">
+                <div className="text-[0.7rem] text-primary flex items-center gap-1.5">
                   <Loader2 size={10} className="animate-spin" />
                   <span>Running now.</span>
                 </div>
               )}
               {job.lastError && !taskSucceeded && !running && (
-                <div className="text-[10.5px] text-red/80 truncate" title={job.lastError}>
+                <div className="text-[0.7rem] text-red/80 truncate" title={job.lastError}>
                   {job.lastError}
                 </div>
               )}
               {isDeliveryFailure && !running && (
-                <div className="text-[10.5px] text-orange/80 truncate" title={job.lastError}>
+                <div className="text-[0.7rem] text-orange/80 truncate" title={job.lastError}>
                   Delivery failed. Check cron settings.
                 </div>
               )}
@@ -287,7 +287,7 @@ function CronRow({ job, onToggle, onRun, onDelete, onEdit, onFetchRuns }: {
             <div className="cockpit-divider" />
             <div className="space-y-1.5">
               {!runs.length && (
-                <div className="text-[10.5px] text-muted-foreground">
+                <div className="text-[0.7rem] text-muted-foreground">
                   No run history yet.
                 </div>
               )}
@@ -307,10 +307,10 @@ function CronRow({ job, onToggle, onRun, onDelete, onEdit, onFetchRuns }: {
                         )}
                       </div>
                       {r.error && (
-                        <div className="text-[10.5px] text-red/80 break-words" title={r.error}>{r.error}</div>
+                        <div className="text-[0.7rem] text-red/80 break-words" title={r.error}>{r.error}</div>
                       )}
                       {r.summary && (
-                        <div className="text-[10.5px] leading-4.5 text-foreground/70 line-clamp-2">{r.summary.slice(0, 150)}{r.summary.length > 150 ? '…' : ''}</div>
+                        <div className="text-[0.7rem] leading-4.5 text-foreground/70 line-clamp-2">{r.summary.slice(0, 150)}{r.summary.length > 150 ? '…' : ''}</div>
                       )}
                     </div>
                   </div>
@@ -397,7 +397,7 @@ export function CronsTab() {
                   )}
                   {toolbarSummary.nextRelative ? (
                     <div className="shell-panel flex min-w-0 items-center gap-1.5 rounded-lg px-2 py-1">
-                      <span className="cockpit-kicker shrink-0 text-[7.5px] tracking-[0.16em]">
+                      <span className="cockpit-kicker shrink-0 text-[0.5rem] tracking-[0.16em]">
                         <Clock3 size={10} className="text-primary" />
                         Next run
                       </span>
@@ -410,7 +410,7 @@ export function CronsTab() {
                       {toolbarSummary.enabledCount} live
                     </span>
                   ) : (
-                    <span className="text-[10.5px] text-muted-foreground">
+                    <span className="text-[0.7rem] text-muted-foreground">
                       No live crons
                     </span>
                   )}
@@ -423,7 +423,7 @@ export function CronsTab() {
                 onClick={handleAdd}
                 aria-label="Add cron job"
                 title="Add cron job"
-                className="shell-chip min-h-8 rounded-lg px-2.5 text-[10.5px] font-medium"
+                className="shell-chip min-h-8 rounded-lg px-2.5 text-[0.7rem] font-medium"
               >
                 <Plus size={13} />
                 <span>New cron</span>
@@ -458,7 +458,7 @@ export function CronsTab() {
           {!isLoading && !jobs.length && !error && (
             <div className="cockpit-surface px-4 py-5 text-center">
               <div className="space-y-1">
-                <div className="text-[12.5px] font-medium text-foreground">No scheduled tasks yet</div>
+                <div className="text-[0.833rem] font-medium text-foreground">No scheduled tasks yet</div>
                 <p className="text-[0.733rem] leading-4.5 text-muted-foreground">
                   Create one to schedule a private task or a main-thread reminder.
                 </p>

--- a/src/index.css
+++ b/src/index.css
@@ -524,7 +524,7 @@
   .cockpit-input,
   .cockpit-select,
   .cockpit-textarea {
-    font-size: 1.067rem;
+    font-size: 16px;
   }
 
   .cockpit-note {


### PR DESCRIPTION
## Summary

- restore fixed 16px mobile cockpit input sizing so iPhone browsers do not auto-zoom on focus
- convert the remaining cron UI fixed px text sizes to rem so font scaling stays consistent
- add regression tests covering both follow-up fixes

## Verification

- `npx vitest run src/features/settings/fontSizeFollowups.test.ts`
- `npx eslint . --quiet --ignore-pattern '.worktrees/**'`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved typography sizing consistency throughout cron job management components including job names, schedules, action buttons, and status indicators for better readability.
  * Enhanced mobile form input font sizing to improve accessibility and user experience on smaller screen sizes.

* **Tests**
  * Added regression test coverage to verify font sizing standards are maintained across the application components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->