### PR TITLE
fix: restore older agent chats in sidebar

### DIFF
--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { SessionProvider, useSessionContext } from './SessionContext';
+import { getSessionKey } from '@/types';
+
+const mockUseGateway = vi.fn();
+let rpcMock: ReturnType<typeof vi.fn>;
+
+vi.mock('./GatewayContext', () => ({
+  useGateway: () => mockUseGateway(),
+}));
+
+function jsonResponse(data: unknown): Response {
+  return {
+    ok: true,
+    json: async () => data,
+  } as Response;
+}
+
+function SessionLabels() {
+  const { sessions, currentSession } = useSessionContext();
+
+  return (
+    <div>
+      <div data-testid="current-session">{currentSession}</div>
+      {sessions.map((session) => (
+        <div key={getSessionKey(session)}>{session.label || session.displayName || getSessionKey(session)}</div>
+      ))}
+    </div>
+  );
+}
+
+describe('SessionContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    rpcMock = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'sessions.list') {
+        const filtered = params && Object.prototype.hasOwnProperty.call(params, 'activeMinutes');
+        return {
+          sessions: filtered
+            ? [
+                { sessionKey: 'agent:main:main', label: 'Main' },
+                { sessionKey: 'agent:main:cron:daily-digest', label: 'Cron: Daily Digest' },
+              ]
+            : [
+                { sessionKey: 'agent:main:main', label: 'Main' },
+                { sessionKey: 'agent:designer:main', label: 'Designer', updatedAt: 1774099479671 },
+                { sessionKey: 'agent:main:cron:daily-digest', label: 'Cron: Daily Digest' },
+              ],
+        };
+      }
+      return {};
+    });
+
+    mockUseGateway.mockReturnValue({
+      connectionState: 'connected',
+      rpc: rpcMock,
+      subscribe: vi.fn(() => () => {}),
+    });
+
+    globalThis.fetch = vi.fn((input: string | URL | Request) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+      if (url.includes('/api/server-info')) return Promise.resolve(jsonResponse({ agentName: 'Jen' }));
+      if (url.includes('/api/agentlog')) return Promise.resolve(jsonResponse([]));
+      if (url.includes('/api/sessions/hidden')) return Promise.resolve(jsonResponse({ ok: true, sessions: [] }));
+      return Promise.resolve(jsonResponse({}));
+    }) as typeof fetch;
+  });
+
+  it('uses the full gateway session list for sidebar refreshes so older agent chats stay visible', async () => {
+    render(
+      <SessionProvider>
+        <SessionLabels />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Designer')).toBeInTheDocument();
+    });
+
+    expect(rpcMock).toHaveBeenCalledWith('sessions.list', { limit: 1000 });
+    expect(rpcMock).not.toHaveBeenCalledWith('sessions.list', expect.objectContaining({ activeMinutes: expect.any(Number) }));
+  });
+});

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -20,7 +20,8 @@ const BUSY_STATES = new Set(['running', 'thinking', 'tool_use', 'delta', 'starte
 const IDLE_STATES = new Set(['idle', 'done', 'error', 'final', 'aborted', 'completed']);
 
 // sessions.list query defaults.
-// Wider window + higher cap avoids dropping subagents from the sidebar in busy workspaces.
+// Keep spawn/discovery polling on a recent active-window query, but use the
+// full session list for the sidebar so older root chats stay visible.
 const SESSIONS_ACTIVE_MINUTES = 24 * 60; // 24h
 const SESSIONS_LIMIT = 200;
 const FULL_SESSIONS_LIMIT = 1000;
@@ -417,11 +418,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const refreshSessions = useCallback(async () => {
     if (connectionState !== 'connected') return;
     try {
-      const [res, hiddenCronSessions] = await Promise.all([
-        rpc('sessions.list', { activeMinutes: SESSIONS_ACTIVE_MINUTES, limit: SESSIONS_LIMIT }) as Promise<SessionsListResponse>,
-        fetchHiddenCronSessions(SESSIONS_ACTIVE_MINUTES, SESSIONS_LIMIT),
-      ]);
-      const newSessions = mergeSessionLists(res?.sessions || [], hiddenCronSessions);
+      const newSessions = await listAuthoritativeSessions();
       const nextCurrentSession = pickDefaultSessionKey(newSessions, currentSessionRef.current);
       
       // Smart diffing: preserve object references for unchanged sessions.
@@ -475,7 +472,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     } finally {
       setSessionsLoading(false);
     }
-  }, [connectionState, fetchHiddenCronSessions, mergeSessionLists, rpc]);
+  }, [connectionState, listAuthoritativeSessions]);
 
   // Update session in list from WebSocket event data
   const updateSessionFromEvent = useCallback((sessionKey: string, updates: Partial<Session>) => {


### PR DESCRIPTION
## Summary

- restore older root/main agent chats in the sidebar by using the full authoritative session list during sidebar refreshes
- keep the active-window query behavior for spawn/discovery paths
- add a regression test covering the sidebar refresh behavior

## Root cause

The sidebar refresh path called `sessions.list` with `activeMinutes: 24 * 60`, which filtered out older root chats.

## Validation

- `npm test -- --run src/contexts/SessionContext.test.tsx`
- `npx eslint src/contexts/SessionContext.tsx src/contexts/SessionContext.test.tsx`
- `npm run build`
- verified live after restarting the local Nerve service: older agent chats reappeared in the sidebar


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for session context and session management behavior.

* **Refactor**
  * Simplified session refresh mechanism to use a single authoritative source. Session sidebar now consistently displays the complete session list for improved visibility of older root chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->