### PR TITLE
fix(kanban): move runtime store out of server-dist and migrate legacy data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,9 @@ src/test/*.js
 # Local review artifacts
 wave-reviews/
 
-# Kanban runtime data
+# Kanban runtime data (legacy in-repo paths)
 server/data/kanban/tasks.json
 server/data/kanban/audit.log
+server-dist/data/kanban/tasks.json
+server-dist/data/kanban/audit.log
 node_modules

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -513,11 +513,11 @@ The kanban board provides task management with agent execution, drag-and-drop re
 ### Store Design
 
 ```
-server/data/kanban/tasks.json   -- single JSON file (tasks + proposals + config)
-server/data/kanban/audit.log    -- append-only audit log (JSONL)
+${NERVE_DATA_DIR:-~/.nerve}/kanban/tasks.json   -- single JSON file (tasks + proposals + config)
+${NERVE_DATA_DIR:-~/.nerve}/kanban/audit.log    -- append-only audit log (JSONL)
 ```
 
-All data lives in one JSON file (`StoreData`). Every mutation acquires an async mutex, reads the file, applies the change, and writes back atomically via temp-file rename. This guarantees consistency under concurrent requests without a database.
+All data lives in one JSON file (`StoreData`). Every mutation acquires an async mutex, reads the file, applies the change, and writes back atomically via temp-file rename. This guarantees consistency under concurrent requests without a database. On first startup, the store migrates legacy data from `server-dist/data/kanban/` or `server/data/kanban/` into the canonical runtime directory if needed.
 
 | File | Purpose |
 |------|---------|

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -307,7 +307,7 @@ The updater stores state in `~/.nerve/updater/`. These are not configurable via 
 
 ## Kanban
 
-Kanban board configuration is stored in the data file (`server/data/kanban/tasks.json`), not in `.env`. Manage it via the REST API:
+Kanban board configuration is stored in the runtime data file (`${NERVE_DATA_DIR:-~/.nerve}/kanban/tasks.json`), not in `.env`. Manage it via the REST API:
 
 ```bash
 # Read current config

--- a/server/lib/kanban-store.test.ts
+++ b/server/lib/kanban-store.test.ts
@@ -16,8 +16,14 @@ import type { KanbanTask } from './kanban-store.js';
 let store: KanbanStore;
 let tmpDir: string;
 let filePath: string;
+let originalNerveDataDir: string | undefined;
+let originalNerveProjectRoot: string | undefined;
+let originalCwd: string;
 
 beforeEach(async () => {
+  originalNerveDataDir = process.env.NERVE_DATA_DIR;
+  originalNerveProjectRoot = process.env.NERVE_PROJECT_ROOT;
+  originalCwd = process.cwd();
   tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'kanban-test-'));
   filePath = path.join(tmpDir, 'tasks.json');
   store = new KanbanStore(filePath);
@@ -25,6 +31,11 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  if (originalNerveDataDir === undefined) delete process.env.NERVE_DATA_DIR;
+  else process.env.NERVE_DATA_DIR = originalNerveDataDir;
+  if (originalNerveProjectRoot === undefined) delete process.env.NERVE_PROJECT_ROOT;
+  else process.env.NERVE_PROJECT_ROOT = originalNerveProjectRoot;
+  process.chdir(originalCwd);
   await fs.promises.rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -1067,5 +1078,120 @@ describe('migration', () => {
     fs.writeFileSync(filePath, JSON.stringify({ meta: { schemaVersion: 1 } }));
     const result = await store.listTasks();
     expect(result.total).toBe(0);
+  });
+});
+
+describe('default path and legacy migration', () => {
+  it('stores default data under NERVE_DATA_DIR/kanban', async () => {
+    process.env.NERVE_DATA_DIR = path.join(tmpDir, 'nerve-data');
+    process.env.NERVE_PROJECT_ROOT = path.join(tmpDir, 'project');
+
+    const defaultStore = new KanbanStore();
+    await defaultStore.init();
+
+    const canonicalPath = path.join(process.env.NERVE_DATA_DIR, 'kanban', 'tasks.json');
+    expect(fs.existsSync(canonicalPath)).toBe(true);
+
+    const raw = JSON.parse(fs.readFileSync(canonicalPath, 'utf-8'));
+    expect(raw.tasks).toEqual([]);
+  });
+
+  it('migrates legacy server-dist data into the canonical store', async () => {
+    const projectRoot = path.join(tmpDir, 'project');
+    const legacyPath = path.join(projectRoot, 'server-dist', 'data', 'kanban', 'tasks.json');
+    process.env.NERVE_DATA_DIR = path.join(tmpDir, 'nerve-data');
+    process.env.NERVE_PROJECT_ROOT = projectRoot;
+
+    const legacyStore = new KanbanStore(legacyPath);
+    await legacyStore.init();
+    await legacyStore.createTask({ title: 'Recovered from server-dist', createdBy: 'operator' });
+
+    const defaultStore = new KanbanStore();
+    await defaultStore.init();
+
+    const result = await defaultStore.listTasks();
+    expect(result.total).toBe(1);
+    expect(result.items[0].title).toBe('Recovered from server-dist');
+    expect(fs.existsSync(path.join(process.env.NERVE_DATA_DIR, 'kanban', 'audit.log'))).toBe(true);
+  });
+
+  it('lazy-initializes and migrates before reads', async () => {
+    const projectRoot = path.join(tmpDir, 'project');
+    const legacyPath = path.join(projectRoot, 'server-dist', 'data', 'kanban', 'tasks.json');
+    process.env.NERVE_DATA_DIR = path.join(tmpDir, 'nerve-data');
+    process.env.NERVE_PROJECT_ROOT = projectRoot;
+
+    const legacyStore = new KanbanStore(legacyPath);
+    await legacyStore.init();
+    await legacyStore.createTask({ title: 'Recovered without explicit init', createdBy: 'operator' });
+
+    const defaultStore = new KanbanStore();
+    const result = await defaultStore.listTasks();
+
+    expect(result.total).toBe(1);
+    expect(result.items[0].title).toBe('Recovered without explicit init');
+  });
+
+  it('migrates legacy server data into the canonical store', async () => {
+    const projectRoot = path.join(tmpDir, 'project');
+    const legacyPath = path.join(projectRoot, 'server', 'data', 'kanban', 'tasks.json');
+    process.env.NERVE_DATA_DIR = path.join(tmpDir, 'nerve-data');
+    process.env.NERVE_PROJECT_ROOT = projectRoot;
+
+    const legacyStore = new KanbanStore(legacyPath);
+    await legacyStore.init();
+    await legacyStore.createTask({ title: 'Recovered from server', createdBy: 'operator' });
+
+    const defaultStore = new KanbanStore();
+    await defaultStore.init();
+
+    const result = await defaultStore.listTasks();
+    expect(result.total).toBe(1);
+    expect(result.items[0].title).toBe('Recovered from server');
+  });
+
+  it('prefers the canonical store when canonical and legacy data both exist', async () => {
+    const projectRoot = path.join(tmpDir, 'project');
+    const canonicalDir = path.join(tmpDir, 'nerve-data', 'kanban');
+    const legacyPath = path.join(projectRoot, 'server-dist', 'data', 'kanban', 'tasks.json');
+    process.env.NERVE_DATA_DIR = path.join(tmpDir, 'nerve-data');
+    process.env.NERVE_PROJECT_ROOT = projectRoot;
+
+    const legacyStore = new KanbanStore(legacyPath);
+    await legacyStore.init();
+    await legacyStore.createTask({ title: 'Legacy task', createdBy: 'operator' });
+
+    const canonicalStore = new KanbanStore(path.join(canonicalDir, 'tasks.json'));
+    await canonicalStore.init();
+    await canonicalStore.createTask({ title: 'Canonical task', createdBy: 'operator' });
+
+    const defaultStore = new KanbanStore();
+    await defaultStore.init();
+
+    const result = await defaultStore.listTasks();
+    expect(result.total).toBe(1);
+    expect(result.items[0].title).toBe('Canonical task');
+  });
+
+  it('prefers the richer legacy candidate over an empty one', async () => {
+    const projectRoot = path.join(tmpDir, 'project');
+    const emptyLegacyPath = path.join(projectRoot, 'server-dist', 'data', 'kanban', 'tasks.json');
+    const richLegacyPath = path.join(projectRoot, 'server', 'data', 'kanban', 'tasks.json');
+    process.env.NERVE_DATA_DIR = path.join(tmpDir, 'nerve-data');
+    process.env.NERVE_PROJECT_ROOT = projectRoot;
+
+    const emptyStore = new KanbanStore(emptyLegacyPath);
+    await emptyStore.init();
+
+    const richStore = new KanbanStore(richLegacyPath);
+    await richStore.init();
+    await richStore.createTask({ title: 'Rich legacy task', createdBy: 'operator' });
+
+    const defaultStore = new KanbanStore();
+    await defaultStore.init();
+
+    const result = await defaultStore.listTasks();
+    expect(result.total).toBe(1);
+    expect(result.items[0].title).toBe('Rich legacy task');
   });
 });

--- a/server/lib/kanban-store.ts
+++ b/server/lib/kanban-store.ts
@@ -1,13 +1,17 @@
 /**
  * Kanban task store — JSON file persistence with mutex-protected I/O.
  *
- * Data lives at `server/data/kanban/tasks.json`. Every mutating operation
- * acquires the store mutex, reads the file, applies the change, and writes
- * back atomically. CAS version checks prevent stale overwrites.
+ * Runtime data lives under `${NERVE_DATA_DIR:-~/.nerve}/kanban/tasks.json`.
+ * Legacy installs may still have data under `server-dist/data/kanban/` or
+ * `server/data/kanban/`, so the store performs a one-time migration into the
+ * canonical runtime directory on first init. Every mutating operation acquires
+ * the store mutex, reads the file, applies the change, and writes back
+ * atomically. CAS version checks prevent stale overwrites.
  * @module
  */
 
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import crypto from 'node:crypto';
 import { fileURLToPath } from 'node:url';
@@ -278,12 +282,21 @@ export class KanbanStore {
   private readonly filePath: string;
   private readonly auditPath: string;
   private readonly withLock: ReturnType<typeof createMutex>;
+  private readonly legacyCandidatePaths: string[];
 
   constructor(filePath?: string) {
     const __dirname = path.dirname(fileURLToPath(import.meta.url));
-    const dataDir = path.resolve(__dirname, '..', 'data', 'kanban');
+    const projectRoot = process.env.NERVE_PROJECT_ROOT || path.resolve(__dirname, '..', '..');
+    const dataRoot = process.env.NERVE_DATA_DIR || path.join(os.homedir() || process.cwd(), '.nerve');
+    const dataDir = path.join(dataRoot, 'kanban');
     this.filePath = filePath || path.join(dataDir, 'tasks.json');
     this.auditPath = path.join(path.dirname(this.filePath), 'audit.log');
+    this.legacyCandidatePaths = filePath
+      ? []
+      : [
+          path.join(projectRoot, 'server-dist', 'data', 'kanban', 'tasks.json'),
+          path.join(projectRoot, 'server', 'data', 'kanban', 'tasks.json'),
+        ];
     this.withLock = createMutex();
   }
 
@@ -356,6 +369,52 @@ export class KanbanStore {
     return data;
   }
 
+  private async loadLegacyCandidate(filePath: string): Promise<{
+    filePath: string;
+    auditPath: string;
+    data: StoreData;
+    contentScore: number;
+    mtimeMs: number;
+  } | null> {
+    try {
+      const raw = await fs.promises.readFile(filePath, 'utf-8');
+      const parsed = JSON.parse(raw) as StoreData;
+      const data = this.migrate(parsed);
+      const stats = await fs.promises.stat(filePath);
+      return {
+        filePath,
+        auditPath: path.join(path.dirname(filePath), 'audit.log'),
+        data,
+        contentScore: data.tasks.length + data.proposals.length,
+        mtimeMs: stats.mtimeMs,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  private async migrateLegacyStoreIfNeeded(): Promise<boolean> {
+    if (this.legacyCandidatePaths.length === 0) return false;
+
+    const candidates = (await Promise.all(this.legacyCandidatePaths.map((filePath) => this.loadLegacyCandidate(filePath))))
+      .filter((candidate): candidate is NonNullable<typeof candidate> => candidate !== null)
+      .sort((a, b) => b.contentScore - a.contentScore || b.mtimeMs - a.mtimeMs);
+
+    if (candidates.length === 0) return false;
+
+    const selected = candidates[0];
+    await this.writeRaw(selected.data);
+
+    try {
+      await fs.promises.copyFile(selected.auditPath, this.auditPath);
+    } catch {
+      // audit log migration is best-effort
+    }
+
+    console.log(`[kanban-store] migrated legacy store from ${selected.filePath} to ${this.filePath}`);
+    return true;
+  }
+
   private async audit(entry: AuditEntry): Promise<void> {
     try {
       const dir = path.dirname(this.auditPath);
@@ -374,16 +433,27 @@ export class KanbanStore {
     await this.withLock(async () => {
       try {
         await fs.promises.access(this.filePath);
+        return;
       } catch {
+        // canonical store missing, continue
+      }
+
+      const migrated = await this.migrateLegacyStoreIfNeeded();
+      if (!migrated) {
         await this.writeRaw(emptyStore());
       }
     });
   }
 
+  private async withStore<T>(fn: () => Promise<T>): Promise<T> {
+    await this.init();
+    return this.withLock(fn);
+  }
+
   // ── Tasks: List ──────────────────────────────────────────────────
 
   async listTasks(filters: TaskFilters = {}): Promise<TaskListResult> {
-    return this.withLock(async () => {
+    return this.withStore(async () => {
       const data = await this.readRaw();
       let tasks = data.tasks;
 
@@ -433,7 +503,7 @@ export class KanbanStore {
   // ── Tasks: Get ───────────────────────────────────────────────────
 
   async getTask(id: string): Promise<KanbanTask> {
-    return this.withLock(async () => {
+    return this.withStore(async () => {
       const data = await this.readRaw();
       const task = data.tasks.find((t) => t.id === id);
       if (!task) throw new TaskNotFoundError(id);
@@ -457,7 +527,7 @@ export class KanbanStore {
     dueAt?: number;
     estimateMin?: number;
   }): Promise<KanbanTask> {
-    return this.withLock(async () => {
+    return this.withStore(async () => {
       const data = await this.readRaw();
 
       // Compute columnOrder — append to end of target column
@@ -523,7 +593,7 @@ export class KanbanStore {
     >,
     actor?: string,
   ): Promise<KanbanTask> {
-    return this.withLock(async () => {
+    return this.withStore(async () => {
       const data = await this.readRaw();
       const idx = data.tasks.findIndex((t) => t.id === id);
       if (idx === -1) throw new TaskNotFoundError(id);
@@ -561,7 +631,7 @@ export class KanbanStore {
   // ── Tasks: Delete ────────────────────────────────────────────────
 
   async deleteTask(id: string, actor?: string): Promise<void> {
-    return this.withLock(async () => {
+    return this.withStore(async () => {
       const data = await this.readRaw();
       const idx = data.tasks.findIndex((t) => t.id === id);
       if (idx === -1) throw new TaskNotFoundError(id);
@@ -581,7 +651,7 @@ export class KanbanStore {
     targetIndex: number,
     actor?: string,
   ): Promise<KanbanTask> {
-    return this.withLock(async () => {
+    return this.withStore(async () => {
       const data = await this.readRaw();
       const idx = data.tasks.findIndex((t) => t.id === id);
       if (idx === -1) throw new TaskNotFoundError(id);
@@ -632,14 +702,14 @@ export class KanbanStore {
   // ── Config ───────────────────────────────────────────────────────
 
   async getConfig(): Promise<KanbanBoardConfig> {
-    return this.withLock(async () => {
+    return this.withStore(async () => {
       const data = await this.readRaw();
       return data.config;
     });
   }
 
   async updateConfig(patch: Partial<KanbanBoardConfig>): Promise<KanbanBoardConfig> {
-    return this.withLock(async () => {
+    return this.withStore(async () => {
       const data = await this.readRaw();
       data.config = { ...data.config, ...patch };
       if (patch.columns) data.config.columns = patch.columns;
@@ -657,7 +727,7 @@ export class KanbanStore {
     options?: { model?: string; thinking?: 'off' | 'low' | 'medium' | 'high' },
     actor?: string,
   ): Promise<KanbanTask> {
-    return this.withLock(async () => {
+    return this.withStore(async () => {
       const data = await this.readRaw();
       const idx = data.tasks.findIndex((t) => t.id === id);
       if (idx === -1) throw new TaskNotFoundError(id);
@@ -710,7 +780,7 @@ export class KanbanStore {
   // ── Workflow: Approve ────────────────────────────────────────────
 
   async approveTask(id: string, note?: string, actor?: string): Promise<KanbanTask> {
-    return this.withLock(async () => {
+    return this.withStore(async () => {
       const data = await this.readRaw();
       const idx = data.tasks.findIndex((t) => t.id === id);
       if (idx === -1) throw new TaskNotFoundError(id);
@@ -755,7 +825,7 @@ export class KanbanStore {
   // ── Workflow: Reject ─────────────────────────────────────────────
 
   async rejectTask(id: string, note: string, actor?: string): Promise<KanbanTask> {
-    return this.withLock(async () => {
+    return this.withStore(async () => {
       const data = await this.readRaw();
       const idx = data.tasks.findIndex((t) => t.id === id);
       if (idx === -1) throw new TaskNotFoundError(id);
@@ -803,7 +873,7 @@ export class KanbanStore {
   // ── Workflow: Abort ──────────────────────────────────────────────
 
   async abortTask(id: string, note?: string, actor?: string): Promise<KanbanTask> {
-    return this.withLock(async () => {
+    return this.withStore(async () => {
       const data = await this.readRaw();
       const idx = data.tasks.findIndex((t) => t.id === id);
       if (idx === -1) throw new TaskNotFoundError(id);
@@ -858,7 +928,7 @@ export class KanbanStore {
     result?: string,
     error?: string,
   ): Promise<KanbanTask> {
-    return this.withLock(async () => {
+    return this.withStore(async () => {
       const data = await this.readRaw();
       const idx = data.tasks.findIndex((t) => t.id === taskId);
       if (idx === -1) throw new TaskNotFoundError(taskId);
@@ -919,7 +989,7 @@ export class KanbanStore {
   // ── Stale run reconciliation ─────────────────────────────────────
 
   async reconcileStaleRuns(maxAgeMs: number): Promise<KanbanTask[]> {
-    return this.withLock(async () => {
+    return this.withStore(async () => {
       const data = await this.readRaw();
       const now = Date.now();
       const reconciled: KanbanTask[] = [];
@@ -971,7 +1041,7 @@ export class KanbanStore {
     sourceSessionKey?: string;
     proposedBy: TaskActor;
   }): Promise<KanbanProposal> {
-    return this.withLock(async () => {
+    return this.withStore(async () => {
       const data = await this.readRaw();
       const now = Date.now();
 
@@ -1014,7 +1084,7 @@ export class KanbanStore {
     id: string,
     actor: TaskActor = 'operator',
   ): Promise<{ proposal: KanbanProposal; task: KanbanTask }> {
-    return this.withLock(async () => {
+    return this.withStore(async () => {
       const data = await this.readRaw();
       const proposal = data.proposals.find((p) => p.id === id);
       if (!proposal) throw new ProposalNotFoundError(id);
@@ -1047,7 +1117,7 @@ export class KanbanStore {
     reason?: string,
     actor: TaskActor = 'operator',
   ): Promise<KanbanProposal> {
-    return this.withLock(async () => {
+    return this.withStore(async () => {
       const data = await this.readRaw();
       const proposal = data.proposals.find((p) => p.id === id);
       if (!proposal) throw new ProposalNotFoundError(id);
@@ -1067,7 +1137,7 @@ export class KanbanStore {
   }
 
   async listProposals(statusFilter?: ProposalStatus): Promise<KanbanProposal[]> {
-    return this.withLock(async () => {
+    return this.withStore(async () => {
       const data = await this.readRaw();
       let proposals = data.proposals;
       if (statusFilter) {


### PR DESCRIPTION
## Summary
## Summary

Move the kanban runtime store out of `server-dist` and into a stable runtime data directory, with one-time migration support for legacy stores.

## Root cause

The kanban store’s default path could resolve relative to the compiled server location, which meant production task data could end up in:

- `server-dist/data/kanban/tasks.json`
- `server-dist/data/kanban/audit.log`

Because `server-dist` is build output, rebuilds or deploys could wipe or replace the active task store.

## What changed

- changed the canonical kanban runtime location to:
  - `${NERVE_DATA_DIR:-~/.nerve}/kanban/tasks.json`
  - `${NERVE_DATA_DIR:-~/.nerve}/kanban/audit.log`
- added one-time migration from legacy locations:
  - `<project>/server-dist/data/kanban/tasks.json`
  - `<project>/server/data/kanban/tasks.json`
- made migration work on first access, not only explicit `init()`
- preserved explicit file-path injection for tests and overrides
- updated docs to reflect the canonical runtime location
- updated ignore rules for legacy in-repo kanban data paths

## Tests

Added coverage for:
- canonical default path resolution
- migration from legacy `server-dist`
- migration from legacy `server`
- lazy initialization before reads
- canonical store winning over legacy data
- richer legacy candidate winning over an empty one

## Verification

Ran:

```bash
npx vitest run server/lib/kanban-store.test.ts server/routes/kanban.test.ts
npm run build
```

All passed.

## Impact

After this change:
- live kanban data no longer lives in build output
- source and compiled server resolve the same stable runtime location
- legacy installs self-migrate on first access/startup
- rebuilds should no longer be able to wipe the active kanban store

## Notes

This fixes the storage bug. It does not recover previously lost tasks if the legacy store was already wiped before the fix landed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kanban data storage location is now customizable.
  * Legacy Kanban data automatically migrates to the new location on first startup.

* **Documentation**
  * Updated configuration and architecture documentation to reflect storage location changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->