### PR TITLE
fix(realtime): keep reconnecting after auth challenge failures

### DIFF
--- a/src/hooks/useWebSocket.test.ts
+++ b/src/hooks/useWebSocket.test.ts
@@ -356,6 +356,67 @@ describe('useWebSocket', () => {
 
       expect(result.current.reconnectAttempt).toBe(0);
     });
+
+    it('should keep reconnecting after a reconnect auth failure', async () => {
+      const wsInstances: MockWebSocket[] = [];
+      const OriginalMockWS = MockWebSocket;
+      (globalThis as unknown as { WebSocket: typeof MockWebSocket }).WebSocket = class extends OriginalMockWS {
+        constructor(url: string) {
+          super(url);
+          wsInstances.push(this);
+        }
+      };
+
+      const { result } = renderHook(() => useWebSocket());
+
+      act(() => {
+        result.current.connect('ws://localhost:8080', 'test-token');
+      });
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      const firstWs = wsInstances[0];
+      act(() => {
+        simulateAuthHandshake(firstWs);
+      });
+
+      act(() => {
+        firstWs.close();
+      });
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(wsInstances.length).toBeGreaterThanOrEqual(2);
+      const reconnectWs = wsInstances[1];
+      act(() => {
+        reconnectWs.simulateMessage({ type: 'event', event: 'connect.challenge', payload: { nonce: 'retry-1' } });
+      });
+
+      const reconnectReq = getConnectRequest(reconnectWs);
+      expect(reconnectReq).toBeTruthy();
+      const reconnectReqId = reconnectReq?.id as string;
+
+      act(() => {
+        reconnectWs.simulateMessage({
+          type: 'res',
+          id: reconnectReqId,
+          ok: false,
+          error: { message: 'temporary auth issue' },
+        });
+      });
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(result.current.connectionState).toBe('reconnecting');
+      expect(result.current.reconnectAttempt).toBeGreaterThan(0);
+      expect(wsInstances.length).toBeGreaterThanOrEqual(3);
+    });
   });
 
   describe('RPC Timeout Handling', () => {

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -194,7 +194,8 @@ export function useWebSocket(): UseWebSocketReturn {
               const errMsg = 'Auth failed: ' + (response.error?.message || 'unknown');
               setConnectError(errMsg);
               setConnectionState('disconnected');
-              intentionalDisconnectRef.current = true; // prevent reconnect on auth failure
+              // Treat auth failures during reconnect like transient failures so the
+              // socket keeps retrying instead of getting stuck until a manual reload.
               ws.close();
               connectRejectRef.current?.(new Error(errMsg));
             }


### PR DESCRIPTION
## What

Fixes a websocket reconnect bug where an auth-related failure during the reconnect path could stop further retry attempts until the page was manually reloaded.

## Why

Closes #138.

The current reconnect flow can misclassify a reconnect auth failure as an intentional disconnect. When that happens, the client stops retrying and realtime updates stay down until the user reloads the UI.

## How

- keep the websocket reconnect loop alive after auth-related reconnect failures instead of treating them like intentional disconnects
- add focused regression coverage in `src/hooks/useWebSocket.test.ts` for continuing reconnect attempts after an auth-challenge failure
- keep scope limited to the missing reconnect-hardening delta only

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [ ] New features include tests
- [ ] UI changes include a screenshot or screen recording


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket reconnection handling during authentication failures, allowing the connection to properly attempt recovery through existing auto-reconnect mechanisms instead of remaining disconnected.

* **Tests**
  * Added test case verifying correct reconnection state and behavior when authentication fails during reconnect attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->