### PR TITLE
feat(file-browser): add safe workspace path resolve and reveal

### DIFF
--- a/server/routes/file-browser.test.ts
+++ b/server/routes/file-browser.test.ts
@@ -91,6 +91,34 @@ describe('file-browser routes', () => {
     });
   });
 
+  describe('GET /api/files/resolve', () => {
+    it('classifies workspace files as openable targets', async () => {
+      await fs.writeFile(path.join(tmpDir, 'docs-note.md'), '# hi');
+      const app = await buildApp();
+
+      const res = await app.request('/api/files/resolve?path=docs-note.md');
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { ok: boolean; path: string; type: string; binary: boolean };
+      expect(json).toEqual({ ok: true, path: 'docs-note.md', type: 'file', binary: false });
+    });
+
+    it('classifies workspace directories as revealable targets', async () => {
+      await fs.mkdir(path.join(tmpDir, 'docs'), { recursive: true });
+      const app = await buildApp();
+
+      const res = await app.request('/api/files/resolve?path=docs');
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { ok: boolean; path: string; type: string; binary: boolean };
+      expect(json).toEqual({ ok: true, path: 'docs', type: 'directory', binary: false });
+    });
+
+    it('returns 403 for invalid or excluded targets', async () => {
+      const app = await buildApp();
+      const res = await app.request('/api/files/resolve?path=../../etc');
+      expect(res.status).toBe(403);
+    });
+  });
+
   describe('GET /api/files/read', () => {
     it('returns 400 when path is missing', async () => {
       const app = await buildApp();

--- a/server/routes/file-browser.ts
+++ b/server/routes/file-browser.ts
@@ -269,6 +269,50 @@ app.get('/api/files/tree', async (c) => {
   }
 });
 
+// ── GET /api/files/resolve ───────────────────────────────────────────
+
+app.get('/api/files/resolve', async (c) => {
+  const targetPath = c.req.query('path');
+  if (!targetPath) {
+    return c.json({ ok: false, error: 'Missing path parameter' }, 400);
+  }
+
+  let workspace: ScopedWorkspace;
+  try {
+    workspace = resolveScopedWorkspace(c.req.query('agentId'));
+  } catch (err) {
+    return handleAgentWorkspaceError(c, err);
+  }
+
+  if (!(await isWorkspaceLocal(workspace.workspaceRoot))) {
+    return c.json({ ok: false, error: 'Not supported for remote workspaces', code: 'REMOTE_WORKSPACE' }, 501);
+  }
+
+  const resolved = await resolveWorkspacePathForRoot(workspace.workspaceRoot, targetPath);
+  if (!resolved) {
+    return c.json({ ok: false, error: 'Invalid or excluded path' }, 403);
+  }
+
+  let stat;
+  try {
+    stat = await fs.stat(resolved);
+  } catch {
+    return c.json({ ok: false, error: 'Path not found' }, 404);
+  }
+
+  const relative = path.relative(workspace.workspaceRoot, resolved).split(path.sep).join('/');
+  if (!relative || relative === '.') {
+    return c.json({ ok: false, error: 'Path not found' }, 404);
+  }
+
+  return c.json({
+    ok: true,
+    path: relative,
+    type: stat.isDirectory() ? 'directory' : 'file',
+    binary: stat.isFile() ? isBinary(path.basename(resolved)) : false,
+  });
+});
+
 // ── GET /api/files/read ──────────────────────────────────────────────
 
 app.get('/api/files/read', async (c) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ import { createCommands } from '@/features/command-palette/commands';
 import { PanelErrorBoundary } from '@/components/PanelErrorBoundary';
 import { SpawnAgentDialog } from '@/features/sessions/SpawnAgentDialog';
 import { FileTreePanel, TabbedContentArea, useOpenFiles, type FileTreeChangeEvent } from '@/features/file-browser';
+import { isImageFile } from '@/features/file-browser/utils/fileTypes';
 import { buildAgentRootSessionKey, getSessionDisplayLabel } from '@/features/sessions/sessionKeys';
 import { shouldGuardWorkspaceSwitch } from '@/features/workspace/workspaceSwitchGuard';
 import { getWorkspaceAgentId, getWorkspaceRootSessionKey } from '@/features/workspace/workspaceScope';
@@ -124,6 +125,12 @@ export default function App({ onLogout }: AppProps) {
 
   // Track file change events for tree refresh. Sequence keeps repeated same-path updates visible.
   const [lastChangedEvent, setLastChangedEvent] = useState<FileTreeChangeEvent | null>(null);
+  const [revealRequest, setRevealRequest] = useState<{
+    id: number;
+    path: string;
+    kind: 'file' | 'directory';
+    agentId: string;
+  } | null>(null);
   const fileTreeChangeSequenceRef = useRef(0);
 
   const initialCompactLayout = typeof window !== 'undefined' && window.matchMedia('(max-width: 900px)').matches;
@@ -320,6 +327,28 @@ export default function App({ onLogout }: AppProps) {
     setPendingTaskId(taskId);
     setViewMode('kanban');
   }, [setViewMode]);
+
+  const openWorkspacePath = useCallback(async (targetPath: string) => {
+    const params = new URLSearchParams({ path: targetPath, agentId: workspaceAgentId });
+    const res = await fetch(`/api/files/resolve?${params.toString()}`);
+    const data = await res.json().catch(() => null) as {
+      ok?: boolean;
+      path?: string;
+      type?: 'file' | 'directory';
+      binary?: boolean;
+    } | null;
+
+    if (!res.ok || !data?.ok || !data.path || !data.type) return;
+
+    if (data.type === 'file' && (!data.binary || isImageFile(data.path))) {
+      setRevealRequest(null);
+      await openFile(data.path);
+      return;
+    }
+
+    setFileBrowserCollapsed(false);
+    setRevealRequest({ id: Date.now(), path: data.path, kind: data.type, agentId: workspaceAgentId });
+  }, [openFile, setFileBrowserCollapsed, workspaceAgentId]);
 
   const toggleMobileTopBar = useCallback(() => {
     setIsMobileTopBarHidden((prev) => !prev);
@@ -627,6 +656,7 @@ export default function App({ onLogout }: AppProps) {
             isFileBrowserCollapsed={fileBrowserCollapsed}
             onToggleMobileTopBar={isCompactLayout ? toggleMobileTopBar : undefined}
             isMobileTopBarHidden={isMobileTopBarHidden}
+            onOpenWorkspacePath={openWorkspacePath}
           />
         </PanelErrorBoundary>
       }
@@ -839,6 +869,7 @@ export default function App({ onLogout }: AppProps) {
                 workspaceAgentId={workspaceAgentId}
                 onOpenFile={openFile}
                 lastChangedEvent={lastChangedEvent}
+                revealRequest={revealRequest}
                 onRemapOpenPaths={remapOpenPaths}
                 onCloseOpenPaths={closeOpenPathsByPrefix}
                 isCompactLayout={false}
@@ -864,6 +895,7 @@ export default function App({ onLogout }: AppProps) {
                     workspaceAgentId={workspaceAgentId}
                     onOpenFile={openFile}
                     lastChangedEvent={lastChangedEvent}
+                    revealRequest={revealRequest}
                     onRemapOpenPaths={remapOpenPaths}
                     onCloseOpenPaths={closeOpenPathsByPrefix}
                     isCompactLayout={true}

--- a/src/features/chat/ChatPanel.tsx
+++ b/src/features/chat/ChatPanel.tsx
@@ -41,6 +41,8 @@ interface ChatPanelProps {
   onToggleMobileTopBar?: () => void;
   /** Whether the mobile top bar is currently hidden. */
   isMobileTopBarHidden?: boolean;
+  /** Open or reveal a safe workspace path in the file explorer/editor. */
+  onOpenWorkspacePath?: (path: string) => void | Promise<void>;
 }
 
 export interface ChatPanelHandle {
@@ -56,6 +58,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
   onWakeWordState, onReset, searchOpen, onSearchClose, id, agentName = 'Agent',
   loadMore, hasMore = false, onToggleFileBrowser, isFileBrowserCollapsed = true,
   onToggleMobileTopBar, isMobileTopBarHidden = false,
+  onOpenWorkspacePath,
 }, ref) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const messageRefs = useRef<Map<number, HTMLDivElement>>(new Map());
@@ -329,6 +332,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
                 searchQuery={search.query}
                 isCurrentMatch={isCurrentMatch}
                 agentName={agentName}
+                onOpenWorkspacePath={onOpenWorkspacePath}
               />
             </div>
           );

--- a/src/features/chat/MessageBubble.tsx
+++ b/src/features/chat/MessageBubble.tsx
@@ -43,6 +43,7 @@ interface MessageBubbleProps {
   searchQuery?: string;
   isCurrentMatch?: boolean;
   agentName?: string;
+  onOpenWorkspacePath?: (path: string) => void | Promise<void>;
 }
 
 const borderClass = (role: string) => {
@@ -71,7 +72,7 @@ function RoleBadge({ role, agentName = 'Agent' }: { role: string; agentName?: st
   return <span className="cockpit-badge">System</span>;
 }
 
-function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memoryKey, onToggleCollapse, onToggleMemory, firstMessageTime, searchQuery, isCurrentMatch, agentName }: MessageBubbleProps) {
+function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memoryKey, onToggleCollapse, onToggleMemory, firstMessageTime, searchQuery, isCurrentMatch, agentName, onOpenWorkspacePath }: MessageBubbleProps) {
   const isUser = msg.role === 'user';
   const isAssistant = msg.role === 'assistant';
   const isSystem = msg.role === 'system' || msg.role === 'event';
@@ -188,7 +189,7 @@ function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memory
         {!isCollapsed && (
           <div className="ml-3 border-l border-primary/12 px-3 pb-2 pt-1 text-[0.8rem] text-foreground/70 msg-body-intermediate">
             <Suspense fallback={<span className="text-muted-foreground text-xs">…</span>}>
-              <MarkdownRenderer content={msg.rawText} searchQuery={searchQuery} />
+              <MarkdownRenderer content={msg.rawText} searchQuery={searchQuery} onOpenWorkspacePath={onOpenWorkspacePath} />
             </Suspense>
           </div>
         )}
@@ -218,7 +219,7 @@ function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memory
           ) : (
             <div className="text-muted-foreground/70 text-[0.8rem] flex-1 min-w-0 msg-body-intermediate">
               <Suspense fallback={<span className="text-muted-foreground text-xs">…</span>}>
-                <MarkdownRenderer content={displayContent} searchQuery={searchQuery} suppressImages={isAssistant} />
+                <MarkdownRenderer content={displayContent} searchQuery={searchQuery} suppressImages={isAssistant} onOpenWorkspacePath={onOpenWorkspacePath} />
               </Suspense>
             </div>
           )}
@@ -284,7 +285,7 @@ function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memory
             )}
             {displayContent && (
               <Suspense fallback={<div className="text-muted-foreground text-xs">Loading…</div>}>
-                <MarkdownRenderer content={displayContent} searchQuery={searchQuery} suppressImages={isAssistant} />
+                <MarkdownRenderer content={displayContent} searchQuery={searchQuery} suppressImages={isAssistant} onOpenWorkspacePath={onOpenWorkspacePath} />
               </Suspense>
             )}
           </div>

--- a/src/features/file-browser/FileTreePanel.test.tsx
+++ b/src/features/file-browser/FileTreePanel.test.tsx
@@ -71,6 +71,7 @@ const defaultMockHook = {
   selectFile: vi.fn(),
   refresh: vi.fn(),
   handleFileChange: vi.fn(),
+  revealPath: vi.fn(),
 };
 
 describe('FileTreePanel', () => {
@@ -96,6 +97,42 @@ describe('FileTreePanel', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  describe('reveal requests', () => {
+    it('reveals the requested path once for the active workspace', () => {
+      const revealPath = vi.fn();
+      mockUseFileTree.mockReturnValue({
+        ...defaultMockHook,
+        revealPath,
+      });
+
+      const { rerender } = render(
+        <FileTreePanel
+          workspaceAgentId="main"
+          onOpenFile={mockOnOpenFile}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+          revealRequest={{ id: 1, path: 'src/index.ts', kind: 'file', agentId: 'main' }}
+          collapsed={false}
+        />,
+      );
+
+      expect(revealPath).toHaveBeenCalledWith('src/index.ts', 'file', 'main');
+
+      rerender(
+        <FileTreePanel
+          workspaceAgentId="main"
+          onOpenFile={mockOnOpenFile}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+          revealRequest={{ id: 1, path: 'src/index.ts', kind: 'file', agentId: 'main' }}
+          collapsed={false}
+        />,
+      );
+
+      expect(revealPath).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('header display', () => {

--- a/src/features/file-browser/FileTreePanel.tsx
+++ b/src/features/file-browser/FileTreePanel.tsx
@@ -62,6 +62,8 @@ interface FileTreePanelProps {
   onCloseOpenPaths?: (pathPrefix: string, targetAgentId?: string) => void;
   /** Called externally when a file changes (SSE) — refreshes affected directory. */
   lastChangedEvent?: FileTreeChangeEvent | null;
+  /** Ask the tree to reveal and select a workspace path. */
+  revealRequest?: { id: number; path: string; kind: 'file' | 'directory'; agentId: string } | null;
   /** Layout hint retained for compatibility with existing callers. */
   isCompactLayout?: boolean;
   /** Callback to notify parent of collapse state changes */
@@ -100,13 +102,14 @@ export function FileTreePanel({
   onRemapOpenPaths,
   onCloseOpenPaths,
   lastChangedEvent,
+  revealRequest,
   isCompactLayout = false,
   onCollapseChange,
   collapsed,
 }: FileTreePanelProps) {
   const {
     entries, loading, error, expandedPaths, selectedPath,
-    loadingPaths, workspaceInfo, toggleDirectory, selectFile, refresh, handleFileChange,
+    loadingPaths, workspaceInfo, toggleDirectory, selectFile, refresh, handleFileChange, revealPath,
   } = useFileTree(workspaceAgentId);
 
   // React to external file changes. Sequence keeps repeated same-path events distinct,
@@ -120,6 +123,16 @@ export function FileTreePanel({
     lastHandledChangeSequenceRef.current = lastChangedEvent.sequence;
     handleFileChange(lastChangedEvent.path);
   }, [handleFileChange, lastChangedEvent, workspaceAgentId]);
+
+  const lastHandledRevealIdRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!revealRequest) return;
+    if (revealRequest.agentId !== workspaceAgentId) return;
+    if (lastHandledRevealIdRef.current === revealRequest.id) return;
+
+    lastHandledRevealIdRef.current = revealRequest.id;
+    void revealPath(revealRequest.path, revealRequest.kind, workspaceAgentId);
+  }, [revealPath, revealRequest, workspaceAgentId]);
 
   const panelRef = useRef<HTMLDivElement>(null);
   const widthRef = useRef(loadWidth());

--- a/src/features/file-browser/hooks/useFileTree.test.ts
+++ b/src/features/file-browser/hooks/useFileTree.test.ts
@@ -352,6 +352,55 @@ describe('useFileTree', () => {
       expect(typeof result.current.selectFile).toBe('function');
     });
 
+    it('reveals a nested workspace path by expanding its parent directories', async () => {
+      const mockFetch = vi.mocked(fetch);
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            entries: [
+              { name: 'src', path: 'src', type: 'directory' as const, children: null },
+            ],
+            workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+          }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            entries: [
+              { name: 'features', path: 'src/features', type: 'directory' as const, children: null },
+            ],
+          }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            entries: [
+              { name: 'demo.tsx', path: 'src/features/demo.tsx', type: 'file' as const, children: null },
+            ],
+          }),
+        } as Response);
+
+      const { result } = renderHook(() => useFileTree());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      await act(async () => {
+        await result.current.revealPath('src/features/demo.tsx', 'file');
+      });
+
+      await waitFor(() => {
+        expect(result.current.expandedPaths.has('src')).toBe(true);
+        expect(result.current.expandedPaths.has('src/features')).toBe(true);
+        expect(result.current.selectedPath).toBe('src/features/demo.tsx');
+      });
+    });
+
     it('persists expanded paths in localStorage', async () => {
       const mockLocalStorage = vi.mocked(localStorage);
       mockLocalStorage.getItem.mockReturnValue('["src","components"]');
@@ -424,6 +473,7 @@ describe('useFileTree', () => {
         'selectFile',
         'refresh',
         'handleFileChange',
+        'revealPath',
       ];
 
       expect(returnKeys).toEqual(expect.arrayContaining(expectedKeys));

--- a/src/features/file-browser/hooks/useFileTree.ts
+++ b/src/features/file-browser/hooks/useFileTree.ts
@@ -87,6 +87,17 @@ function clearEntryFromTree(entries: TreeEntry[], targetPath: string): TreeEntry
   });
 }
 
+function findEntry(entries: TreeEntry[], targetPath: string): TreeEntry | null {
+  for (const entry of entries) {
+    if (entry.path === targetPath) return entry;
+    if (entry.type === 'directory' && entry.children) {
+      const found = findEntry(entry.children, targetPath);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
 function buildTreeUrl(dirPath: string, agentId: string): string {
   const params = new URLSearchParams({ depth: '1', agentId });
   if (dirPath) params.set('path', dirPath);
@@ -97,6 +108,7 @@ function buildTreeUrl(dirPath: string, agentId: string): string {
 export function useFileTree(agentId = DEFAULT_AGENT_ID) {
   const scopedAgentId = normalizeAgentId(agentId);
   const [entries, setEntries] = useState<TreeEntry[]>([]);
+  const entriesRef = useRef<TreeEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => loadExpandedPaths(scopedAgentId));
@@ -123,6 +135,10 @@ export function useFileTree(agentId = DEFAULT_AGENT_ID) {
       mountedRef.current = false;
     };
   }, []);
+
+  useEffect(() => {
+    entriesRef.current = entries;
+  }, [entries]);
 
   // Persist expanded paths
   useEffect(() => {
@@ -234,17 +250,6 @@ export function useFileTree(agentId = DEFAULT_AGENT_ID) {
 
     if (expandedPaths.has(dirPath)) return;
 
-    const findEntry = (treeEntries: TreeEntry[], target: string): TreeEntry | null => {
-      for (const entry of treeEntries) {
-        if (entry.path === target) return entry;
-        if (entry.children) {
-          const found = findEntry(entry.children, target);
-          if (found) return found;
-        }
-      }
-      return null;
-    };
-
     const entry = findEntry(entries, dirPath);
     if (entry?.children !== null && entry?.children !== undefined) return;
 
@@ -314,6 +319,66 @@ export function useFileTree(agentId = DEFAULT_AGENT_ID) {
     }
   }, [expandedPaths, refreshDirectory]);
 
+  const ensureDirectoryLoaded = useCallback(async (dirPath: string, requestAgentId = agentIdRef.current) => {
+    const entry = findEntry(entriesRef.current, dirPath);
+    if (entry?.type !== 'directory') return;
+    if (entry.children !== null && entry.children !== undefined) return;
+
+    setLoadingPaths((prev) => new Set([...prev, dirPath]));
+    const children = await fetchChildren(dirPath, requestAgentId);
+    if (!mountedRef.current || agentIdRef.current !== requestAgentId) return;
+
+    setLoadingPaths((prev) => {
+      const next = new Set(prev);
+      next.delete(dirPath);
+      return next;
+    });
+
+    if (children) {
+      setEntries((prev) => {
+        const next = mergeChildren(prev, dirPath, children);
+        entriesRef.current = next;
+        return next;
+      });
+    }
+  }, [fetchChildren]);
+
+  const revealPath = useCallback(async (
+    targetPath: string,
+    kind: 'file' | 'directory',
+    targetAgentId = scopedAgentId,
+  ) => {
+    const requestAgentId = normalizeAgentId(targetAgentId);
+    if (agentIdRef.current !== requestAgentId) {
+      if (kind === 'file') {
+        saveSelectedPath(requestAgentId, targetPath);
+      }
+      return;
+    }
+
+    const normalized = targetPath.replace(/^\.\//, '').replace(/^\/+|\/+$/g, '');
+    if (!normalized) return;
+
+    const segments = normalized.split('/').filter(Boolean);
+    const ancestors = kind === 'directory'
+      ? segments.map((_, index) => segments.slice(0, index + 1).join('/'))
+      : segments.slice(0, -1).map((_, index) => segments.slice(0, index + 1).join('/'));
+
+    for (const dirPath of ancestors) {
+      setExpandedPaths((prev) => {
+        if (prev.has(dirPath)) return prev;
+        const next = new Set(prev);
+        next.add(dirPath);
+        return next;
+      });
+      await ensureDirectoryLoaded(dirPath, requestAgentId);
+    }
+
+    if (kind === 'file') {
+      setSelectedPathState(normalized);
+    }
+  }, [ensureDirectoryLoaded, scopedAgentId]);
+
   return {
     entries: visibleEntries,
     loading: visibleLoading,
@@ -326,5 +391,6 @@ export function useFileTree(agentId = DEFAULT_AGENT_ID) {
     selectFile,
     refresh,
     handleFileChange,
+    revealPath,
   };
 }

--- a/src/features/markdown/MarkdownRenderer.test.tsx
+++ b/src/features/markdown/MarkdownRenderer.test.tsx
@@ -1,6 +1,6 @@
 /** Tests for the MarkdownRenderer component. */
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 // Mock highlight.js to avoid complex setup
 vi.mock('@/lib/highlight', () => ({
@@ -67,6 +67,26 @@ describe('MarkdownRenderer', () => {
     const link = document.querySelector('a');
     expect(link).toBeTruthy();
     expect(link?.getAttribute('href')).toBe('https://example.com');
+  });
+
+  it('opens workspace links in-app when a handler is provided', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(<MarkdownRenderer content="[notes](docs/todo.md)" onOpenWorkspacePath={onOpenWorkspacePath} />);
+
+    fireEvent.click(screen.getByRole('link', { name: 'notes' }));
+
+    expect(onOpenWorkspacePath).toHaveBeenCalledWith('docs/todo.md');
+  });
+
+  it('keeps external links as normal browser links when a handler is provided', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(<MarkdownRenderer content="[example](https://example.com)" onOpenWorkspacePath={onOpenWorkspacePath} />);
+
+    const link = screen.getByRole('link', { name: 'example' });
+    expect(link).toHaveAttribute('target', '_blank');
+
+    fireEvent.click(link);
+    expect(onOpenWorkspacePath).not.toHaveBeenCalled();
   });
 
   it('renders code blocks', () => {

--- a/src/features/markdown/MarkdownRenderer.tsx
+++ b/src/features/markdown/MarkdownRenderer.tsx
@@ -11,6 +11,7 @@ interface MarkdownRendererProps {
   className?: string;
   searchQuery?: string;
   suppressImages?: boolean;
+  onOpenWorkspacePath?: (path: string) => void | Promise<void>;
 }
 
 function highlightText(text: string, query: string): React.ReactNode {
@@ -47,6 +48,23 @@ function processChildren(children: React.ReactNode, searchQuery?: string): React
   });
 }
 
+function isWorkspacePathLink(href: string): boolean {
+  if (!href) return false;
+  const trimmed = href.trim();
+  if (!trimmed || trimmed.startsWith('#')) return false;
+  if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(trimmed)) return false;
+  if (trimmed.startsWith('//')) return false;
+  return true;
+}
+
+function decodeWorkspacePathLink(href: string): string {
+  try {
+    return decodeURIComponent(href);
+  } catch {
+    return href;
+  }
+}
+
 // ─── Code Block with actions ─────────────────────────────────────────────────
 
 function CodeBlock({ code, language, highlightedHtml }: {
@@ -71,7 +89,7 @@ function CodeBlock({ code, language, highlightedHtml }: {
 // ─── Main renderer ───────────────────────────────────────────────────────────
 
 /** Render markdown content with syntax highlighting, search-term highlighting, and inline charts. */
-export function MarkdownRenderer({ content, className = '', searchQuery, suppressImages }: MarkdownRendererProps) {
+export function MarkdownRenderer({ content, className = '', searchQuery, suppressImages, onOpenWorkspacePath }: MarkdownRendererProps) {
   // Memoize components object to avoid unnecessary ReactMarkdown re-renders.
   // Only recreated when searchQuery or suppressImages changes.
   const components = useMemo(() => ({
@@ -125,13 +143,34 @@ export function MarkdownRenderer({ content, className = '', searchQuery, suppres
         <table className="markdown-table">{children}</table>
       </div>
     ),
-    a: ({ children, href }: { children?: React.ReactNode; href?: string }) => (
-      <a href={href} target="_blank" rel="noopener noreferrer" className="markdown-link">
-        {children}
-      </a>
-    ),
+    a: ({ children, href }: { children?: React.ReactNode; href?: string }) => {
+      if (!href) {
+        return <span>{children}</span>;
+      }
+
+      if (onOpenWorkspacePath && isWorkspacePathLink(href)) {
+        return (
+          <a
+            href={href}
+            className="markdown-link"
+            onClick={(event) => {
+              event.preventDefault();
+              void onOpenWorkspacePath(decodeWorkspacePathLink(href));
+            }}
+          >
+            {children}
+          </a>
+        );
+      }
+
+      return (
+        <a href={href} target="_blank" rel="noopener noreferrer" className="markdown-link">
+          {children}
+        </a>
+      );
+    },
     ...(suppressImages ? { img: () => null } : {}), // When set, images handled by extractedImages + ImageLightbox
-  }), [searchQuery, suppressImages]);
+  }), [onOpenWorkspacePath, searchQuery, suppressImages]);
 
   return (
     <div className={`markdown-content ${className}`}>


### PR DESCRIPTION
## What

Add a small workspace path resolve API plus the minimum generic open/reveal flow needed to make workspace path references actionable inside Nerve.

## Why

Closes #147

Nerve already carries file/path references through several UI and agent-facing surfaces, but upstream does not currently expose a small dedicated API for turning a workspace-relative reference into a validated, normalized file-browser target. This change improves generic file-reference/path-resolution reliability and also makes path refs easier to hand off across agent/subagent/action flows without forcing immediate inline blob/base64 expansion.

## How

- add `GET /api/files/resolve` in `server/routes/file-browser.ts`
- validate and normalize workspace-relative paths and return `{ path, type, binary }`
- add the smallest generic client path needed to consume the endpoint:
  - open text/image files inside Nerve when resolvable
  - reveal directories or non-openable targets in the file tree
- add focused tests for the route plus reveal/open plumbing

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [x] New features include tests
- [ ] UI changes include a screenshot or screen recording

## Screenshots

Not applicable for this narrow route + minimal reveal/open flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * File browser can now reveal and navigate to workspace files and directories referenced in chat conversations
  * Workspace path links in chat messages now open relevant files directly in the editor
  * Enhanced file navigation capabilities for improved workspace file discovery and access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->