### PR TITLE
fix: tighten file resolve and markdown path updates

### DIFF
--- a/server/routes/file-browser.test.ts
+++ b/server/routes/file-browser.test.ts
@@ -112,6 +112,12 @@ describe('file-browser routes', () => {
       expect(json).toEqual({ ok: true, path: 'docs', type: 'directory', binary: false });
     });
 
+    it('returns 404 for safe missing targets inside the workspace root', async () => {
+      const app = await buildApp();
+      const res = await app.request('/api/files/resolve?path=missing-note.md');
+      expect(res.status).toBe(404);
+    });
+
     it('returns 403 for invalid or excluded targets', async () => {
       const app = await buildApp();
       const res = await app.request('/api/files/resolve?path=../../etc');

--- a/server/routes/file-browser.ts
+++ b/server/routes/file-browser.ts
@@ -288,7 +288,11 @@ app.get('/api/files/resolve', async (c) => {
     return c.json({ ok: false, error: 'Not supported for remote workspaces', code: 'REMOTE_WORKSPACE' }, 501);
   }
 
-  const resolved = await resolveWorkspacePathForRoot(workspace.workspaceRoot, targetPath);
+  const resolved = await resolveWorkspacePathForRoot(
+    workspace.workspaceRoot,
+    targetPath,
+    { allowNonExistent: true },
+  );
   if (!resolved) {
     return c.json({ ok: false, error: 'Invalid or excluded path' }, 403);
   }

--- a/src/features/chat/MessageBubble.test.tsx
+++ b/src/features/chat/MessageBubble.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 
 vi.mock('@/features/markdown/MarkdownRenderer', () => ({
-  MarkdownRenderer: ({ content }: { content: string }) => <div>{content}</div>,
+  MarkdownRenderer: ({ content, onOpenWorkspacePath }: { content: string; onOpenWorkspacePath?: ((path: string) => void) & { handlerId?: string } }) => (
+    <div data-handler-id={onOpenWorkspacePath?.handlerId ?? ''}>{content}</div>
+  ),
 }));
 
 vi.mock('@/features/charts/InlineChart', () => ({
@@ -43,5 +45,42 @@ describe('MessageBubble', () => {
     expect(bubble?.className).toContain('w-fit');
     expect(body).toBeTruthy();
     expect(body?.className).toContain('text-left');
+  });
+
+  it('re-renders when onOpenWorkspacePath changes', async () => {
+    const handlerOne = Object.assign(() => {}, { handlerId: 'one' });
+    const handlerTwo = Object.assign(() => {}, { handlerId: 'two' });
+
+    const { container, rerender } = render(
+      <MessageBubble
+        msg={makeMessage({ role: 'assistant', rawText: '[notes](docs/todo.md)' })}
+        index={0}
+        isCollapsed={false}
+        isMemoryCollapsed={false}
+        onToggleCollapse={() => {}}
+        onToggleMemory={() => {}}
+        onOpenWorkspacePath={handlerOne}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-handler-id="one"]')).toBeTruthy();
+    });
+
+    rerender(
+      <MessageBubble
+        msg={makeMessage({ role: 'assistant', rawText: '[notes](docs/todo.md)' })}
+        index={0}
+        isCollapsed={false}
+        isMemoryCollapsed={false}
+        onToggleCollapse={() => {}}
+        onToggleMemory={() => {}}
+        onOpenWorkspacePath={handlerTwo}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-handler-id="two"]')).toBeTruthy();
+    });
   });
 });

--- a/src/features/chat/MessageBubble.tsx
+++ b/src/features/chat/MessageBubble.tsx
@@ -378,6 +378,7 @@ export const MessageBubble = memo(MessageBubbleInner, (prev, next) => {
   
   // Agent name (rare change but must re-render when it does)
   if (prev.agentName !== next.agentName) return false;
+  if (prev.onOpenWorkspacePath !== next.onOpenWorkspacePath) return false;
   
   // All relevant props are equal, skip re-render
   return true;


### PR DESCRIPTION
Follow-up to #148.

This patches the two legit findings we reviewed:

- return 404 for safe missing workspace paths in /api/files/resolve instead of collapsing them into 403
- ensure MessageBubble re-renders when onOpenWorkspacePath changes so markdown file-link handlers do not go stale

Validation:
- touched regressions reproduced before the fix
- touched test suites passed after patch
- build passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing message bubble updates when workspace path handler changes.
  * API now correctly returns 404 status for non-existent workspace files.

* **Tests**
  * Added test coverage for resolve endpoint behavior with non-existent files.
  * Added test coverage for MessageBubble re-rendering with callback changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->