### PR TITLE
feat(setup): infer agent name from local identity metadata

### DIFF
--- a/scripts/lib/agent-name-default.test.ts
+++ b/scripts/lib/agent-name-default.test.ts
@@ -1,0 +1,42 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it } from 'vitest';
+
+import { detectAgentDisplayNameDefault } from './agent-name-default.js';
+
+describe('detectAgentDisplayNameDefault', () => {
+  it('prefers existing AGENT_NAME when present', () => {
+    const result = detectAgentDisplayNameDefault('  Existing Agent  ', 'Agent', []);
+    expect(result).toBe('Existing Agent');
+  });
+
+  it('detects Name from IDENTITY.md metadata', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'nerve-agent-name-'));
+    const identityPath = join(tempDir, 'IDENTITY.md');
+    writeFileSync(identityPath, '# IDENTITY\n- **Name:** Chip\n', 'utf8');
+
+    const result = detectAgentDisplayNameDefault(undefined, 'Agent', [identityPath]);
+    expect(result).toBe('Chip');
+  });
+
+  it('falls back to second identity candidate if first is missing/invalid', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'nerve-agent-name-'));
+    const firstPath = join(tempDir, 'missing.md');
+    const secondPath = join(tempDir, 'nested', 'IDENTITY.md');
+    mkdirSync(join(tempDir, 'nested'), { recursive: true });
+    writeFileSync(secondPath, 'Notes\n- **Name:** Cookie\n', 'utf8');
+
+    const result = detectAgentDisplayNameDefault(undefined, 'Agent', [firstPath, secondPath]);
+    expect(result).toBe('Cookie');
+  });
+
+  it('falls back to literal default when metadata is unavailable or malformed', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'nerve-agent-name-'));
+    const identityPath = join(tempDir, 'IDENTITY.md');
+    writeFileSync(identityPath, '# IDENTITY\nNo name field here\n', 'utf8');
+
+    const result = detectAgentDisplayNameDefault(undefined, 'Agent', [identityPath]);
+    expect(result).toBe('Agent');
+  });
+});

--- a/scripts/lib/agent-name-default.ts
+++ b/scripts/lib/agent-name-default.ts
@@ -1,0 +1,34 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
+
+function defaultIdentityPaths(): string[] {
+  const home = homedir();
+  return [
+    resolve(home, '.openclaw', 'workspace', 'IDENTITY.md'),
+    resolve(home, '.openclaw', 'workspace', 'projects', 'openclaw-agent', 'IDENTITY.md'),
+  ];
+}
+
+export function detectAgentDisplayNameDefault(
+  existingName: string | undefined,
+  fallbackName: string,
+  identityPaths: string[] = defaultIdentityPaths(),
+): string {
+  if (existingName?.trim()) return existingName.trim();
+
+  for (const identityPath of identityPaths) {
+    if (!existsSync(identityPath)) continue;
+
+    try {
+      const raw = readFileSync(identityPath, 'utf-8');
+      const match = raw.match(/^-[ \t]*\*\*Name:\*\*[ \t]*(.+)$/m);
+      const detected = match?.[1]?.trim();
+      if (detected) return detected;
+    } catch {
+      // Non-fatal — keep falling back.
+    }
+  }
+
+  return fallbackName;
+}

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -39,6 +39,7 @@ import { generateSelfSignedCert } from './lib/cert-gen.js';
 import { detectGatewayConfig, getEnvGatewayToken, chooseSetupGatewayToken, restartGateway, approvePendingNerveDevice, detectNeededConfigChanges, type ConfigChange } from './lib/gateway-detect.js';
 import { applyAccessPlanToConfig, buildAccessPlan, type InstallerAccessProfile } from './lib/access-plan.js';
 import { getTailscaleState, type TailscaleState } from './lib/tailscale.js';
+import { detectAgentDisplayNameDefault } from './lib/agent-name-default.js';
 
 const PROJECT_ROOT = resolve(process.cwd());
 const ENV_PATH = resolve(PROJECT_ROOT, '.env');
@@ -434,7 +435,7 @@ async function collectInteractive(
   config.AGENT_NAME = await input({
     theme: promptTheme,
     message: 'Agent display name',
-    default: existing.AGENT_NAME || DEFAULTS.AGENT_NAME,
+    default: detectAgentDisplayNameDefault(existing.AGENT_NAME, DEFAULTS.AGENT_NAME),
   });
 
   // ── 3/5: Access Mode ──────────────────────────────────────────────
@@ -1148,7 +1149,7 @@ async function runDefaults(existing: EnvConfig, prereqs: PrereqResult): Promise<
   }
 
   if (!config.GATEWAY_URL) config.GATEWAY_URL = DEFAULTS.GATEWAY_URL;
-  if (!config.AGENT_NAME) config.AGENT_NAME = DEFAULTS.AGENT_NAME;
+  if (!config.AGENT_NAME) config.AGENT_NAME = detectAgentDisplayNameDefault(undefined, DEFAULTS.AGENT_NAME);
   if (!config.PORT) config.PORT = DEFAULTS.PORT;
   if (!config.HOST) config.HOST = DEFAULTS.HOST;
 


### PR DESCRIPTION
## What

Teach setup to infer a better default `AGENT_NAME` from existing local OpenClaw identity metadata instead of always falling back to the literal `Agent`.

## Why

Closes #150

When local OpenClaw identity metadata already exists, setup can usually infer the intended display name up front. That makes both interactive setup and `--defaults` mode less generic on first run while preserving the existing fallback behavior when metadata is missing or unreadable.

## How

- add a small helper that reads existing identity metadata from the standard OpenClaw identity files
- extract the configured name when present
- use that helper in both interactive setup defaults and `--defaults` mode
- fall back to the existing literal default when detection fails
- add focused tests for the helper

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist

- [ ] `npm run lint` passes
- [ ] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [x] New features include tests
- [ ] UI changes include a screenshot or screen recording

## Screenshots

Not applicable for this setup-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic agent display name detection from configuration files during setup. The system now probes predefined locations for identity information before applying default values.

* **Tests**
  * Added test coverage for the new agent display name detection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->