### PR TITLE
chore(release): prepare 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-03-25
+
+### Fixed
+- Restored the browser websocket auth identity to `webchat-ui` so remote deployments do not trip the gateway's stricter Control UI device-identity requirement on non-secure page origins. This fixes the 1.5.0 login failure reported by users connecting to remote gateway endpoints from plain remote HTTP Nerve pages.
+
 ## [1.5.0] - 2026-03-25
 
 ### Highlights

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-nerve",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-nerve",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-nerve",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Web interface for OpenClaw — chat, voice input, TTS, and agent monitoring in the browser",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Prepare the 1.5.1 hotfix release.

Includes:
- bump package version to 1.5.1
- sync package-lock version metadata
- add 1.5.1 changelog entry for the auth regression hotfix

Validation:
- targeted auth tests passed on the hotfix branch
- npm run build passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed login authentication failures occurring in remote deployments by restoring proper browser websocket authentication identity handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->