### PR TITLE
fix(setup): allow sessions_spawn for kanban task execution

### DIFF
--- a/docs/DEPLOYMENT-C.md
+++ b/docs/DEPLOYMENT-C.md
@@ -94,7 +94,7 @@ https://nerve.example.com
 ```json
 "gateway": {
   "tools": {
-    "allow": ["cron", "gateway"]
+    "allow": ["cron", "gateway", "sessions_spawn"]
   }
 }
 ```

--- a/docs/INSTALLER-STEPS.md
+++ b/docs/INSTALLER-STEPS.md
@@ -276,7 +276,7 @@ After `.env` is written, the setup wizard detects and applies pending OpenClaw g
 #### Possible changes detected:
 1. **Device scopes** — bootstraps `~/.openclaw/devices/paired.json` with full operator scopes if missing or incomplete
 2. **Pre-pair Nerve device** — registers Nerve's Ed25519 identity in `paired.json` so it can connect without manual `openclaw devices approve`
-3. **Tools allow** — adds `"cron"` and `"gateway"` to `gateway.tools.allow` in `~/.openclaw/openclaw.json` (required for OpenClaw ≥2026.2.23 which denies these tools on `/tools/invoke` by default)
+3. **Tools allow** — adds `"cron"`, `"gateway"`, and `"sessions_spawn"` to `gateway.tools.allow` in `~/.openclaw/openclaw.json` (required for OpenClaw ≥2026.2.23, which denies these tools on `/tools/invoke` by default; `sessions_spawn` is required for Kanban task execution)
 4. **Allowed origins** — adds all required Nerve browser origins to `gateway.controlUi.allowedOrigins`
    - LAN or tailnet-IP mode: `http://<ip>:<port>`
    - Tailscale Serve mode: `https://<node>.tail<id>.ts.net`

--- a/scripts/lib/gateway-detect.test.ts
+++ b/scripts/lib/gateway-detect.test.ts
@@ -143,6 +143,28 @@ describe('gateway detection and repair', () => {
     expect(updated.gateway.controlUi.allowedOrigins).not.toContain(`  http://${EXAMPLE_TS_IPV4}:3080  `);
   });
 
+  it('detects missing sessions_spawn in gateway.tools.allow and patches it for kanban execution', async () => {
+    const { mod } = await importGatewayDetect();
+
+    const changes = mod.detectNeededConfigChanges({
+      gatewayToken: 'test-token',
+    });
+    const toolsAllowChange = changes.find((change) => change.id === 'tools-allow');
+
+    expect(toolsAllowChange).toBeDefined();
+    expect(toolsAllowChange?.description).toContain('sessions_spawn');
+
+    const result = toolsAllowChange!.apply();
+    expect(result.ok).toBe(true);
+
+    const updated = JSON.parse(readFileSync(path.join(tempHome, '.openclaw', 'openclaw.json'), 'utf8'));
+    expect(updated.gateway.tools.allow).toEqual(expect.arrayContaining([
+      'cron',
+      'gateway',
+      'sessions_spawn',
+    ]));
+  });
+
   it('prefers a detected config token over a stale shell env token during setup', async () => {
     process.env.OPENCLAW_GATEWAY_TOKEN = 'stale-shell-token';
 

--- a/scripts/lib/gateway-detect.ts
+++ b/scripts/lib/gateway-detect.ts
@@ -172,7 +172,7 @@ export function patchGatewayAllowedOrigins(origin: string): GatewayPatchResult {
   }
 }
 
-const REQUIRED_HTTP_TOOLS = ['cron', 'gateway'] as const;
+const REQUIRED_HTTP_TOOLS = ['cron', 'gateway', 'sessions_spawn'] as const;
 
 // Must match the connect metadata sent by Nerve's browser WS client
 // (src/hooks/useWebSocket.ts) to avoid OpenClaw 2026.2.26+ metadata-repair prompts.
@@ -914,7 +914,7 @@ export function detectNeededConfigChanges(opts: {
   if (needsToolsAllow()) {
     changes.push({
       id: 'tools-allow',
-      description: 'Allow cron + gateway tools on /tools/invoke (needed for cron and gateway management)',
+      description: 'Allow cron + gateway + sessions_spawn tools on /tools/invoke (needed for cron, gateway management, and kanban task execution)',
       apply: () => {
         const r = patchGatewayToolsAllow();
         return { ok: r.ok, message: r.message, needsRestart: r.ok };

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -767,7 +767,7 @@ async function collectInteractive(
         } else if (change.id === 'pre-pair') {
           dim('  • Pre-pair: run `openclaw devices approve` after starting Nerve');
         } else if (change.id === 'tools-allow') {
-          dim('  • HTTP tools: add "cron" and "gateway" to gateway.tools.allow in ~/.openclaw/openclaw.json');
+          dim('  • HTTP tools: add "cron", "gateway", and "sessions_spawn" to gateway.tools.allow in ~/.openclaw/openclaw.json');
         } else if (change.id.startsWith('allowed-origins')) {
           dim('  • Origins: add the required origin(s) to gateway.controlUi.allowedOrigins in ~/.openclaw/openclaw.json');
         }


### PR DESCRIPTION
## Summary
- add `sessions_spawn` to the required Gateway HTTP tool allowlist patched by Nerve setup
- cover the regression with a gateway-detect test
- update setup/deployment docs and manual fix text to include `sessions_spawn`

## Why
Fresh-box repro showed that Nerve `v1.5.1` installs with:

```json
"gateway": {
  "tools": {
    "allow": ["cron", "gateway"]
  }
}
```

Kanban task execution uses `sessions_spawn` over `POST /tools/invoke`, so a fresh install failed after clicking **Run** with:

```text
Spawn failed: Gateway tool invoke failed: 404 {"ok":false,"error":{"type":"not_found","message":"Tool not available: sessions_spawn"}}
```

Also confirmed the direct Gateway repro:
- `POST /tools/invoke` with tool `sessions_spawn` returned `404 Not Found`
- adding only `sessions_spawn` to `gateway.tools.allow` and restarting the Gateway changed that same call to `200 OK`
- after that, Kanban execution spawned a real child session and recorded `childSessionKey` / `runId`

## Changes
- `scripts/lib/gateway-detect.ts`
  - treat `sessions_spawn` as a required HTTP tool alongside `cron` and `gateway`
  - update the setup change description to mention Kanban execution
- `scripts/setup.ts`
  - update the manual remediation text shown when config patching is skipped
- `scripts/lib/gateway-detect.test.ts`
  - add a regression test proving `detectNeededConfigChanges()` flags the missing `sessions_spawn` entry and patches it into `gateway.tools.allow`
- docs
  - update installer/deployment docs to show `sessions_spawn` in the required allowlist

## Verification
- `npx vitest run scripts/lib/gateway-detect.test.ts server/routes/kanban.test.ts`
- `npm run build`

Refs #158


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment and installer guidance to include `sessions_spawn` in the required Gateway tools allowlist configuration alongside `cron` and `gateway`.
  * Updated setup wizard instructions for configuring Gateway tool permissions.

* **Tests**
  * Added test coverage to verify proper detection and application of updated Gateway configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->