### PR TITLE
fix: harden skills API against stderr JSON output

### DIFF
--- a/server/routes/skills.test.ts
+++ b/server/routes/skills.test.ts
@@ -161,6 +161,19 @@ describe('GET /api/skills', () => {
     expect(skillsCall?.opts).toEqual(expect.objectContaining({ cwd: mainWorkspace }));
   });
 
+  it('falls back to stderr when skills JSON is emitted there on success', async () => {
+    setupExec('', GOOD_SKILLS_JSON);
+
+    const app = await buildApp();
+    const res = await app.request('/api/skills');
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean; skills: Array<{ name: string }> };
+    expect(json.ok).toBe(true);
+    expect(json.skills).toHaveLength(2);
+    expect(json.skills[0].name).toBe('weather');
+  });
+
   it('parses skills when warnings are printed before JSON', async () => {
     setupExec(`Config warnings: duplicate plugin id\n${GOOD_SKILLS_JSON}`);
 

--- a/server/routes/skills.ts
+++ b/server/routes/skills.ts
@@ -123,7 +123,10 @@ function formatExecError(err: ExecFileException, stderr: string, commandLabel: s
   return `${commandLabel} failed: ${err.message}`;
 }
 
-function execOpenclawCommand(args: string[], opts: { env?: NodeJS.ProcessEnv; cwd?: string } = {}): Promise<string> {
+function execOpenclawCommand(
+  args: string[],
+  opts: { env?: NodeJS.ProcessEnv; cwd?: string } = {},
+): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
     const openclawBin = resolveOpenclawBin();
     execFile(openclawBin, args, {
@@ -136,7 +139,7 @@ function execOpenclawCommand(args: string[], opts: { env?: NodeJS.ProcessEnv; cw
         const label = `openclaw ${args.join(' ')}`;
         return reject(new SkillsRouteError(formatExecError(err, stderr, label)));
       }
-      return resolve(stdout);
+      return resolve({ stdout, stderr });
     });
   });
 }
@@ -203,11 +206,12 @@ async function execOpenclawSkills(agentId?: string): Promise<RawSkill[]> {
   const scoped = await createScopedOpenclawEnv(workspace.workspaceRoot);
 
   try {
-    const stdout = await execOpenclawCommand(['skills', 'list', '--json'], {
+    const { stdout, stderr } = await execOpenclawCommand(['skills', 'list', '--json'], {
       env: scoped.env,
       cwd: await resolveWorkspaceCwd(workspace.workspaceRoot),
     });
-    return parseSkillsOutput(stdout);
+    const payload = stdout.trim() ? stdout : stderr;
+    return parseSkillsOutput(payload);
   } finally {
     await scoped.cleanup();
   }


### PR DESCRIPTION
## Summary
- make `/api/skills` fall back to stderr when `openclaw skills list --json` succeeds but emits the JSON payload there instead of stdout
- add a regression test covering that case

## Why
Issue #158 included a report that skills would not display in the UI because `openclaw skills list --json` was returning JSON on stderr.

I could not reproduce that exact CLI behavior locally, so this is framed as **hardening**, not a confirmed root-cause fix.

That said, the current route only parses stdout, so if a successful OpenClaw build/environment does emit the JSON payload on stderr, the skills page will fail even though the command itself succeeded.

This change keeps stdout as the canonical source and only falls back to stderr when stdout is empty.

## Verification
- `npx vitest run server/routes/skills.test.ts`
- `npm run build`

Refs #158


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced the skills API endpoint to reliably retrieve skill data across different output configurations.

* **Tests**
  * Added test coverage for the skills endpoint to ensure consistent data parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->