### PR TITLE
fix(chat): advertise command palette in input helper

### DIFF
--- a/src/features/chat/InputBar.tsx
+++ b/src/features/chat/InputBar.tsx
@@ -489,7 +489,7 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
           : (
             <>
               <span className="sm:hidden">Enter to send · Shift+Enter newline · Double Shift voice</span>
-              <span className="hidden sm:inline">Enter or ⌘Enter to send · Shift+Enter for newline · Double Left Shift for voice · Ctrl+F search</span>
+              <span className="hidden sm:inline">Enter or ⌘Enter to send · Shift+Enter for newline · Double Left Shift for voice · ⌘K commands</span>
             </>
           )}
       </div>


### PR DESCRIPTION
## Summary
- replace the incorrect desktop input helper copy with `⌘K commands`
- keep this as a copy-only change with no shortcut behavior changes
- leave the mobile helper text unchanged

## Test Plan
- [x] `npm run build`
- [x] restart `nerve.service`
- [x] verify `/health` returns `200 OK`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the hint text displayed in the input bar when idle to reflect the command shortcut (⌘K).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->