### PR TITLE
fix(kanban): add task lookup route by id

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1506,6 +1506,20 @@ List tasks with optional filters and pagination.
 
 Tasks are sorted by status order → column order → most recently updated.
 
+### `GET /api/kanban/tasks/:id`
+
+Fetch a single task by ID.
+
+**Rate Limit:** General (60/min)
+
+**Response:** The matching `KanbanTask` object.
+
+**Errors:**
+
+| Status | Body | Condition |
+|--------|------|-----------|
+| 404 | `{ "error": "not_found" }` | Task not found |
+
 ### `POST /api/kanban/tasks`
 
 Create a new task.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -371,7 +371,7 @@ Applied in order in `app.ts`:
 | `/api/claude-code-limits` | `routes/claude-code-limits.ts` | GET | Claude Code rate limits via PTY + CLI parsing |
 | `/api/codex-limits` | `routes/codex-limits.ts` | GET | Codex rate limits via OpenAI API with local file fallback |
 | `/api/kanban/tasks` | `routes/kanban.ts` | GET, POST | Task CRUD -- list (with filters/pagination) and create |
-| `/api/kanban/tasks/:id` | `routes/kanban.ts` | PATCH, DELETE | Update (CAS-versioned) and delete tasks |
+| `/api/kanban/tasks/:id` | `routes/kanban.ts` | GET, PATCH, DELETE | Get, update (CAS-versioned), and delete tasks |
 | `/api/kanban/tasks/:id/reorder` | `routes/kanban.ts` | POST | Reorder/move tasks across columns |
 | `/api/kanban/tasks/:id/execute` | `routes/kanban.ts` | POST | Spawn agent session for task |
 | `/api/kanban/tasks/:id/complete` | `routes/kanban.ts` | POST | Complete a running task (auto-called by poller) |

--- a/server/routes/kanban.test.ts
+++ b/server/routes/kanban.test.ts
@@ -208,6 +208,17 @@ describe('GET /api/kanban/tasks/:id', () => {
     const body = await res.json() as { error: string };
     expect(body.error).toBe('not_found');
   });
+
+  it('returns 500 when getTask throws a non-not-found error', async () => {
+    const app = await buildApp();
+    const storeModule = await import('../lib/kanban-store.js');
+    const store = storeModule.getKanbanStore();
+    vi.spyOn(store, 'getTask').mockRejectedValueOnce(new Error('boom'));
+
+    const res = await app.request('/api/kanban/tasks/exploded');
+    expect(res.status).toBe(500);
+    expect(await res.text()).toContain('Internal Server Error');
+  });
 });
 
 // ── POST /api/kanban/tasks ───────────────────────────────────────────

--- a/server/routes/kanban.ts
+++ b/server/routes/kanban.ts
@@ -3,6 +3,7 @@
  *
  * GET    /api/kanban/tasks          — List tasks (with filters + pagination)
  * POST   /api/kanban/tasks          — Create a task
+ * GET    /api/kanban/tasks/:id      — Get a task by id
  * PATCH  /api/kanban/tasks/:id      — Update a task (CAS versioned)
  * DELETE /api/kanban/tasks/:id      — Delete a task
  * POST   /api/kanban/tasks/:id/reorder — Reorder / move a task


### PR DESCRIPTION
Closes #170

## Summary
- add `GET /api/kanban/tasks/:id` so individual Kanban tasks can be fetched by path param
- cover success, not-found, and unexpected-error behavior in route tests
- update API and architecture docs to reflect the new endpoint

## Test Plan
- [x] `npx vitest run server/routes/kanban.test.ts -t "GET /api/kanban/tasks/:id"`
- [x] `npx vitest run server/routes/kanban.test.ts`
- [x] `npm run build`
- [x] `npm run build:server`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to retrieve individual Kanban tasks by ID with proper error handling for missing tasks.

* **Documentation**
  * Updated API reference and architecture documentation to reflect the new task retrieval functionality.

* **Tests**
  * Added comprehensive test coverage for the new task retrieval endpoint, including success and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->