### PR TITLE
feat: add Mistral Voxtral TTS provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ server/data/kanban/audit.log
 server-dist/data/kanban/tasks.json
 server-dist/data/kanban/audit.log
 node_modules
+
+.worktrees/

--- a/docs/API.md
+++ b/docs/API.md
@@ -289,7 +289,7 @@ Synthesizes speech from text. Returns raw audio binary.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `text` | `string` | Yes | Text to synthesize (1–5000 chars, non-empty after trim) |
-| `provider` | `"openai" \| "replicate" \| "edge" \| "qwen" \| "xiaomi"` | No | TTS provider. `"qwen"` is a legacy alias for `"replicate"` + model `"qwen-tts"` |
+| `provider` | `"openai" \| "mistral" \| "replicate" \| "edge" \| "qwen" \| "xiaomi"` | No | TTS provider. `"qwen"` is a legacy alias for `"replicate"` + model `"qwen-tts"` |
 | `voice` | `string` | No | Provider-specific voice name |
 | `model` | `string` | No | Provider-specific model ID |
 
@@ -299,9 +299,11 @@ Synthesizes speech from text. Returns raw audio binary.
 2. Replicate, if `REPLICATE_API_TOKEN` is set
 3. Edge TTS, always available (free, no API key)
 
+Mistral Voxtral is available when `provider: "mistral"` is requested and `MISTRAL_API_KEY` is configured. It is not part of the automatic fallback chain.
+
 Xiaomi MiMo is available when `provider: "xiaomi"` is requested and `MIMO_API_KEY` is configured. It is not part of the automatic fallback chain.
 
-**Response:** `audio/mpeg` binary for OpenAI, Replicate, and Edge, or `audio/wav` for Xiaomi MiMo (200)
+**Response:** `audio/mpeg` binary for OpenAI, Mistral, Replicate, and Edge, or `audio/wav` for Xiaomi MiMo (200)
 
 **Errors:**
 
@@ -334,6 +336,7 @@ Returns the current TTS voice configuration.
     "instructions": "Speak naturally and conversationally, like a real person. Warm, friendly tone with a slight British accent. Keep it casual and relaxed, not robotic or overly formal."
   },
   "edge": { "voice": "en-US-AriaNeural" },
+  "mistral": { "model": "voxtral-mini-tts-2603", "voice": "" },
   "xiaomi": { "model": "mimo-v2-tts", "voice": "mimo_default", "style": "" }
 }
 ```
@@ -348,6 +351,7 @@ Partially updates the TTS voice configuration. Only known keys are accepted.
 {
   "openai": { "voice": "nova", "instructions": "Speak cheerfully" },
   "edge": { "voice": "en-GB-SoniaNeural" },
+  "mistral": { "model": "voxtral-tts-26-03", "voice": "alloy_voice" },
   "xiaomi": { "voice": "default_en", "style": "Happy" }
 }
 ```
@@ -359,6 +363,7 @@ Partially updates the TTS voice configuration. Only known keys are accepted.
 | `qwen` | `mode`, `language`, `speaker`, `voiceDescription`, `styleInstruction` |
 | `openai` | `model`, `voice`, `instructions` |
 | `edge` | `voice` |
+| `mistral` | `model`, `voice` |
 | `xiaomi` | `model`, `voice`, `style` |
 
 All values must be strings, max 2000 characters each.
@@ -373,6 +378,7 @@ Returns whether optional provider keys are configured. Key values are never retu
 {
   "openaiKeySet": true,
   "replicateKeySet": false,
+  "mistralKeySet": true,
   "xiaomiKeySet": true
 }
 ```
@@ -387,6 +393,7 @@ Writes optional provider keys to `.env` and hot-reloads the in-memory config.
 {
   "openaiKey": "sk-...",
   "replicateToken": "r8_...",
+  "mistralApiKey": "sk-mistral-...",
   "mimoApiKey": "sk-mimo-..."
 }
 ```
@@ -398,9 +405,10 @@ Any subset of fields may be provided. Sending an empty string clears that key.
 ```json
 {
   "ok": true,
-  "message": "OPENAI_API_KEY saved, MIMO_API_KEY saved",
+  "message": "OPENAI_API_KEY saved, MISTRAL_API_KEY saved, MIMO_API_KEY saved",
   "openaiKeySet": true,
   "replicateKeySet": false,
+  "mistralKeySet": true,
   "xiaomiKeySet": true
 }
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -409,6 +409,7 @@ Applied in order in `app.ts`:
 | File | Purpose |
 |------|---------|
 | `services/openai-tts.ts` | OpenAI TTS API client (gpt-4o-mini-tts, tts-1, tts-1-hd) |
+| `services/mistral-tts.ts` | Mistral Voxtral TTS API client (`/v1/audio/speech`, base64 audio decode) |
 | `services/replicate-tts.ts` | Replicate API client for hosted TTS models (Qwen3-TTS). WAV→MP3 via ffmpeg |
 | `services/edge-tts.ts` | Microsoft Edge Read-Aloud TTS via WebSocket protocol. Free, zero-config. Includes Sec-MS-GEC token generation |
 | `services/tts-cache.ts` | LRU in-memory TTS cache with TTL expiry (100 MB budget) |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -64,7 +64,7 @@ Prompts for optional API keys:
 - `OPENAI_API_KEY`, enables OpenAI TTS + Whisper transcription
 - `REPLICATE_API_TOKEN`, enables Qwen TTS via Replicate (warns if `ffmpeg` is missing)
 
-Edge TTS always works without any keys. Xiaomi MiMo can be enabled later by setting `MIMO_API_KEY` manually or saving it from Settings, Audio.
+Edge TTS always works without any keys. Mistral Voxtral and Xiaomi MiMo can be enabled later by setting `MISTRAL_API_KEY` / `MIMO_API_KEY` manually or saving them from Settings, Audio.
 
 #### 6. Advanced Settings (Optional)
 
@@ -151,11 +151,13 @@ AGENT_NAME=Friday
 |----------|-------------|
 | `OPENAI_API_KEY` | Enables OpenAI TTS (multiple voices) and Whisper audio transcription |
 | `REPLICATE_API_TOKEN` | Enables Replicate-hosted TTS models (e.g. Qwen TTS). Requires `ffmpeg` for WAV→MP3 |
+| `MISTRAL_API_KEY` | Enables Mistral Voxtral TTS when the Mistral provider is selected in Settings, Audio |
 | `MIMO_API_KEY` | Enables Xiaomi MiMo TTS when the Xiaomi provider is selected in Settings, Audio |
 
 ```bash
 OPENAI_API_KEY=sk-...
 REPLICATE_API_TOKEN=r8_...
+MISTRAL_API_KEY=sk-mistral-...
 MIMO_API_KEY=sk-mimo-...
 ```
 
@@ -163,6 +165,8 @@ TTS provider fallback chain (when no explicit provider is requested):
 1. **OpenAI** — if `OPENAI_API_KEY` is set
 2. **Replicate** — if `REPLICATE_API_TOKEN` is set
 3. **Edge TTS** — always available, no API key needed (default for new installs)
+
+Mistral Voxtral is available as an explicit provider option when `MISTRAL_API_KEY` is set. It is not part of the automatic fallback chain.
 
 Xiaomi MiMo is available as an explicit provider option when `MIMO_API_KEY` is set. It is not part of the automatic fallback chain.
 
@@ -434,6 +438,7 @@ NERVE_SESSION_TTL=2592000000
 # API Keys
 OPENAI_API_KEY=sk-...
 REPLICATE_API_TOKEN=r8_...
+MISTRAL_API_KEY=sk-mistral-...
 MIMO_API_KEY=sk-mimo-...
 
 # Speech / Language

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -379,6 +379,7 @@ HSTS is always sent (`max-age=31536000; includeSubDomains`), even over HTTP. Bro
 | `GATEWAY_TOKEN` | `.env` file (chmod 600) | Used server-side for trusted official-gateway connections. `/api/connect-defaults` returns `token: null`. Never logged. |
 | `OPENAI_API_KEY` | `.env` file | Used server-side only. Never sent to clients. |
 | `REPLICATE_API_TOKEN` | `.env` file | Used server-side only. Never sent to clients. |
+| `MISTRAL_API_KEY` | `.env` file | Used server-side only. Never sent to clients. |
 | Gateway URL + optional manual token | `localStorage` (`oc-config`) | Used for reconnects. Trusted official-gateway flows usually keep the token empty; manually entered custom-gateway tokens persist until cleared. |
 
 The setup wizard applies `chmod 600` to `.env` and backup files, restricting read access to the file owner.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -257,6 +257,7 @@ After approval, reconnect from the browser (refresh the page or click reconnect)
 2. **TTS provider configured?** Check Settings → Audio → TTS Provider
 3. **API key present?**
    - OpenAI: requires `OPENAI_API_KEY`
+   - Mistral Voxtral: requires `MISTRAL_API_KEY`
    - Replicate: requires `REPLICATE_API_TOKEN`
    - Xiaomi MiMo: requires `MIMO_API_KEY`
    - Edge: no key needed (free)

--- a/server/lib/config.ts
+++ b/server/lib/config.ts
@@ -51,6 +51,7 @@ export const config = {
 
   openaiApiKey: process.env.OPENAI_API_KEY || '',
   replicateApiToken: process.env.REPLICATE_API_TOKEN || '',
+  mistralApiKey: process.env.MISTRAL_API_KEY || '',
   mimoApiKey: process.env.MIMO_API_KEY || '',
 
   // Speech-to-text
@@ -174,10 +175,14 @@ export const WS_ALLOWED_HOSTS = new Set([
 
 /** Resolve the TTS provider label for the startup banner. */
 function ttsProviderLabel(): string {
-  if (config.openaiApiKey && config.replicateApiToken) return 'OpenAI + Replicate + Edge';
-  if (config.openaiApiKey) return 'OpenAI + Edge';
-  if (config.replicateApiToken) return 'Replicate + Edge';
-  return 'Edge (free)';
+  const providers = [
+    config.openaiApiKey ? 'OpenAI' : null,
+    config.mistralApiKey ? 'Mistral' : null,
+    config.replicateApiToken ? 'Replicate' : null,
+    'Edge',
+  ].filter(Boolean);
+
+  return providers.join(' + ') + (providers.length === 1 ? ' (free)' : '');
 }
 
 /** Resolve the STT provider label for the startup banner. */
@@ -264,6 +269,9 @@ export function validateConfig(): void {
   }
   if (!config.replicateApiToken) {
     console.warn('[config] ⚠ REPLICATE_API_TOKEN not set — Qwen TTS unavailable');
+  }
+  if (!config.mistralApiKey) {
+    console.warn('[config] ⚠ MISTRAL_API_KEY not set — Mistral Voxtral TTS unavailable');
   }
   if (!process.env.NERVE_LANGUAGE && process.env.LANGUAGE) {
     console.warn('[config] ⚠ LANGUAGE is deprecated — use NERVE_LANGUAGE instead');

--- a/server/lib/constants.ts
+++ b/server/lib/constants.ts
@@ -9,12 +9,14 @@
 
 export const OPENAI_BASE_URL = process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1';
 export const REPLICATE_BASE_URL = process.env.REPLICATE_BASE_URL || 'https://api.replicate.com/v1';
+export const MISTRAL_BASE_URL = process.env.MISTRAL_BASE_URL || 'https://api.mistral.ai/v1';
 
 // ─── API endpoints (derived from base URLs) ──────────────────────────────────
 
 export const OPENAI_TTS_URL = `${OPENAI_BASE_URL}/audio/speech`;
 export const OPENAI_WHISPER_URL = `${OPENAI_BASE_URL}/audio/transcriptions`;
 export const REPLICATE_QWEN_TTS_URL = `${REPLICATE_BASE_URL}/models/qwen/qwen3-tts/predictions`;
+export const MISTRAL_TTS_URL = `${MISTRAL_BASE_URL}/audio/speech`;
 
 // ─── Default connection ──────────────────────────────────────────────────────
 

--- a/server/lib/tts-config.test.ts
+++ b/server/lib/tts-config.test.ts
@@ -57,7 +57,7 @@ async function loadTtsModule(opts: {
 }
 
 describe('getTTSConfig', () => {
-  it('returns Xiaomi defaults when config file is missing', async () => {
+  it('returns Mistral and Xiaomi defaults when config file is missing', async () => {
     const mod = await loadTtsModule({
       language: 'en',
       edgeVoiceGender: 'female',
@@ -65,19 +65,23 @@ describe('getTTSConfig', () => {
     });
 
     const cfg = mod.getTTSConfig();
+    expect(cfg.mistral.model).toBe('voxtral-mini-tts-2603');
+    expect(cfg.mistral.voice).toBe('82c99ee6-f932-423f-a4a3-d403c8914b8d');
     expect(cfg.xiaomi.model).toBe('mimo-v2-tts');
     expect(cfg.xiaomi.voice).toBe('mimo_default');
     expect(cfg.xiaomi.style).toBe('');
   });
 
-  it('deep-merges Xiaomi patches without dropping defaults', async () => {
+  it('deep-merges Mistral and Xiaomi patches without dropping defaults', async () => {
     const mod = await loadTtsModule({
       language: 'en',
       edgeVoiceGender: 'female',
       storedVoice: 'en-US-JennyNeural',
     });
 
-    const cfg = mod.updateTTSConfig({ xiaomi: { style: 'Happy' } });
+    const cfg = mod.updateTTSConfig({ mistral: { voice: 'alloy_voice' }, xiaomi: { style: 'Happy' } });
+    expect(cfg.mistral.model).toBe('voxtral-mini-tts-2603');
+    expect(cfg.mistral.voice).toBe('alloy_voice');
     expect(cfg.xiaomi.style).toBe('Happy');
     expect(cfg.xiaomi.model).toBe('mimo-v2-tts');
     expect(cfg.xiaomi.voice).toBe('mimo_default');

--- a/server/lib/tts-config.ts
+++ b/server/lib/tts-config.ts
@@ -1,7 +1,7 @@
 /**
  * TTS voice configuration — reads/writes a JSON config file.
  *
- * All voice-related settings (OpenAI, Qwen/Replicate, Edge) live here
+ * All voice-related settings (OpenAI, Mistral, Qwen/Replicate, Edge) live here
  * instead of env vars or hardcoded values. On first run, default settings
  * are written to `<PROJECT_ROOT>/tts-config.json`. Subsequent reads merge
  * the on-disk config with defaults so new fields are always present.
@@ -46,6 +46,13 @@ export interface TTSVoiceConfig {
     /** Voice name (e.g. en-US-AriaNeural, en-GB-SoniaNeural) */
     voice: string;
   };
+  /** Mistral Voxtral TTS settings */
+  mistral: {
+    /** Mistral model name */
+    model: string;
+    /** Preset or custom Mistral voice ID */
+    voice: string;
+  };
   /** Xiaomi MiMo TTS settings */
   xiaomi: {
     /** Xiaomi model name */
@@ -73,6 +80,10 @@ const DEFAULTS: TTSVoiceConfig = {
   },
   edge: {
     voice: 'en-US-AriaNeural',
+  },
+  mistral: {
+    model: 'voxtral-mini-tts-2603',
+    voice: '82c99ee6-f932-423f-a4a3-d403c8914b8d',
   },
   xiaomi: {
     model: 'mimo-v2-tts',

--- a/server/routes/api-keys.test.ts
+++ b/server/routes/api-keys.test.ts
@@ -11,10 +11,11 @@ describe('api-keys routes', () => {
     vi.restoreAllMocks();
   });
 
-  function mockDeps(overrides: { mimoKey?: string } = {}) {
+  function mockDeps(overrides: { mistralKey?: string; mimoKey?: string } = {}) {
     const mockConfig: Record<string, unknown> = {
       openaiApiKey: '',
       replicateApiToken: '',
+      mistralApiKey: overrides.mistralKey || '',
       mimoApiKey: overrides.mimoKey || '',
     };
 
@@ -38,6 +39,17 @@ describe('api-keys routes', () => {
     return app;
   }
 
+  it('reports mistralKeySet from config', async () => {
+    mockDeps({ mistralKey: 'sk-mistral' });
+    const app = await buildApp();
+
+    const res = await app.request('/api/keys');
+    expect(res.status).toBe(200);
+
+    const json = await res.json() as Record<string, unknown>;
+    expect(json.mistralKeySet).toBe(true);
+  });
+
   it('reports xiaomiKeySet from config', async () => {
     mockDeps({ mimoKey: 'sk-mimo' });
     const app = await buildApp();
@@ -47,6 +59,23 @@ describe('api-keys routes', () => {
 
     const json = await res.json() as Record<string, unknown>;
     expect(json.xiaomiKeySet).toBe(true);
+  });
+
+  it('writes MISTRAL_API_KEY from mistralApiKey input', async () => {
+    mockDeps();
+    const app = await buildApp();
+
+    const res = await app.request('/api/keys', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mistralApiKey: 'sk-mistral' }),
+    });
+
+    expect(res.status).toBe(200);
+
+    const json = await res.json() as Record<string, unknown>;
+    expect(json.ok).toBe(true);
+    expect(json.mistralKeySet).toBe(true);
   });
 
   it('writes MIMO_API_KEY from mimoApiKey input', async () => {

--- a/server/routes/api-keys.ts
+++ b/server/routes/api-keys.ts
@@ -18,6 +18,7 @@ app.get('/api/keys', rateLimitGeneral, (c) => {
   return c.json({
     openaiKeySet: !!config.openaiApiKey,
     replicateKeySet: !!config.replicateApiToken,
+    mistralKeySet: !!config.mistralApiKey,
     xiaomiKeySet: !!config.mimoApiKey,
   });
 });
@@ -43,6 +44,13 @@ app.put('/api/keys', rateLimitGeneral, async (c) => {
       results.push(val ? 'REPLICATE_API_TOKEN saved' : 'REPLICATE_API_TOKEN cleared');
     }
 
+    if (body.mistralApiKey !== undefined) {
+      const val = body.mistralApiKey.trim();
+      await writeEnvKey('MISTRAL_API_KEY', val);
+      (config as Record<string, unknown>).mistralApiKey = val;
+      results.push(val ? 'MISTRAL_API_KEY saved' : 'MISTRAL_API_KEY cleared');
+    }
+
     if (body.mimoApiKey !== undefined) {
       const val = body.mimoApiKey.trim();
       await writeEnvKey('MIMO_API_KEY', val);
@@ -55,6 +63,7 @@ app.put('/api/keys', rateLimitGeneral, async (c) => {
       message: results.join(', ') || 'No changes',
       openaiKeySet: !!config.openaiApiKey,
       replicateKeySet: !!config.replicateApiToken,
+      mistralKeySet: !!config.mistralApiKey,
       xiaomiKeySet: !!config.mimoApiKey,
     });
   } catch {

--- a/server/routes/tts.test.ts
+++ b/server/routes/tts.test.ts
@@ -13,10 +13,12 @@ describe('TTS routes', () => {
 
   function mockDeps(overrides: {
     openaiKey?: string;
+    mistralKey?: string;
     replicateToken?: string;
     mimoKey?: string;
     edgeResult?: { ok: boolean; buf?: Buffer; message?: string; status?: number; contentType?: string };
     openaiResult?: { ok: boolean; buf?: Buffer; message?: string; status?: number };
+    mistralResult?: { ok: boolean; buf?: Buffer; message?: string; status?: number; contentType?: string };
     replicateResult?: { ok: boolean; buf?: Buffer; message?: string; status?: number };
     xiaomiResult?: { ok: boolean; buf?: Buffer; message?: string; status?: number; contentType?: string };
   } = {}) {
@@ -24,6 +26,7 @@ describe('TTS routes', () => {
       config: {
         auth: false, port: 3000, host: '127.0.0.1', sslPort: 3443,
         openaiApiKey: overrides.openaiKey || '',
+        mistralApiKey: overrides.mistralKey || '',
         replicateApiToken: overrides.replicateToken || '',
         mimoApiKey: overrides.mimoKey || '',
       },
@@ -52,6 +55,11 @@ describe('TTS routes', () => {
         overrides.replicateResult || { ok: true, buf: Buffer.from('fake-replicate-audio') }
       ),
     }));
+    vi.doMock('../services/mistral-tts.js', () => ({
+      synthesizeMistral: vi.fn(async () =>
+        overrides.mistralResult || { ok: true, buf: Buffer.from('fake-mistral-audio'), contentType: 'audio/mpeg' }
+      ),
+    }));
     vi.doMock('../services/xiaomi-tts.js', () => ({
       synthesizeXiaomi: vi.fn(async () =>
         overrides.xiaomiResult || { ok: true, buf: Buffer.from('RIFFdemo'), contentType: 'audio/wav' }
@@ -62,6 +70,7 @@ describe('TTS routes', () => {
         openai: { voice: 'alloy', model: 'tts-1', instructions: '' },
         edge: { voice: 'en-US-JennyNeural' },
         qwen: {},
+        mistral: { model: 'voxtral-mini-tts-2603', voice: '' },
         xiaomi: { model: 'mimo-v2-tts', voice: 'mimo_default', style: 'Happy' },
       })),
       updateTTSConfig: vi.fn((patch: unknown) => patch),
@@ -121,6 +130,18 @@ describe('TTS routes', () => {
       expect(res.status).toBe(200);
     });
 
+    it('uses explicit mistral provider when requested', async () => {
+      mockDeps({ mistralKey: 'sk-mistral' });
+      const app = await buildApp();
+      const res = await app.request('/api/tts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: 'Hello', provider: 'mistral' }),
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Content-Type')).toBe('audio/mpeg');
+    });
+
     it('uses explicit edge provider even when OpenAI key exists', async () => {
       mockDeps({ openaiKey: 'sk-test' });
       const app = await buildApp();
@@ -154,6 +175,17 @@ describe('TTS routes', () => {
       });
       expect(res.status).toBe(200);
       expect(res.headers.get('Content-Type')).toBe('audio/wav');
+    });
+
+    it('returns Mistral provider errors', async () => {
+      mockDeps({ mistralResult: { ok: false, message: 'Mistral failed', status: 502 } });
+      const app = await buildApp();
+      const res = await app.request('/api/tts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: 'Hello', provider: 'mistral' }),
+      });
+      expect(res.status).toBe(502);
     });
 
     it('returns Xiaomi provider errors', async () => {
@@ -221,6 +253,17 @@ describe('TTS routes', () => {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ edge: { voice: 'en-US-GuyNeural' } }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts valid Mistral config patch', async () => {
+      mockDeps();
+      const app = await buildApp();
+      const res = await app.request('/api/tts/config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mistral: { model: 'voxtral-tts-26-03', voice: 'alloy_voice' } }),
       });
       expect(res.status).toBe(200);
     });

--- a/server/routes/tts.ts
+++ b/server/routes/tts.ts
@@ -1,13 +1,14 @@
 /**
  * POST /api/tts — Text-to-speech synthesis.
  *
- * Supports OpenAI TTS, Replicate (Qwen, etc.), and Edge TTS (free, zero-config).
+ * Supports OpenAI TTS, Mistral Voxtral, Replicate (Qwen, etc.), and Edge TTS (free, zero-config).
  * Body: { text: string, provider?: string, model?: string, voice?: string }
  * Response: audio/mpeg binary
  *
  * Provider selection priority:
  *  - Explicit provider choice is always honoured
  *  - "openai" → OpenAI TTS (requires OPENAI_API_KEY)
+ *  - "mistral" → Mistral Voxtral TTS (requires MISTRAL_API_KEY)
  *  - "replicate" → Replicate-hosted models (requires REPLICATE_API_TOKEN)
  *  - "edge" → Microsoft Edge Read-Aloud TTS (free, no key needed)
  *  - Auto fallback: openai (if key) → replicate (if key) → edge (always available)
@@ -25,6 +26,7 @@ import { getTtsCache, setTtsCache } from '../services/tts-cache.js';
 import { synthesizeOpenAI } from '../services/openai-tts.js';
 import { synthesizeReplicate } from '../services/replicate-tts.js';
 import { synthesizeEdge } from '../services/edge-tts.js';
+import { synthesizeMistral } from '../services/mistral-tts.js';
 import { synthesizeXiaomi } from '../services/xiaomi-tts.js';
 import { rateLimitTTS, rateLimitGeneral } from '../middleware/rate-limit.js';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
@@ -41,7 +43,7 @@ const ttsSchema = z.object({
     .refine((s) => s.trim().length > 0, 'Text cannot be empty or whitespace'),
   voice: z.string().optional(),
   // Accept both old ("qwen") and new ("replicate") values
-  provider: z.enum(['openai', 'replicate', 'qwen', 'edge', 'xiaomi']).optional(),
+  provider: z.enum(['openai', 'mistral', 'replicate', 'qwen', 'edge', 'xiaomi']).optional(),
   model: z.string().optional(),
 });
 
@@ -74,6 +76,7 @@ app.post(
 
       // Resolve effective provider: explicit > openai (if key) > replicate (if key) > edge
       const useXiaomi = provider === 'xiaomi';
+      const useMistral = provider === 'mistral';
       const useReplicate =
         provider === 'replicate' ||
         (!provider && !config.openaiApiKey && !!config.replicateApiToken);
@@ -82,11 +85,13 @@ app.post(
         (!provider && !config.openaiApiKey && !config.replicateApiToken);
       const effectiveProvider = useXiaomi
         ? 'xiaomi'
-        : useEdge
-          ? 'edge'
-          : useReplicate
-            ? 'replicate'
-            : 'openai';
+        : useMistral
+          ? 'mistral'
+          : useEdge
+            ? 'edge'
+            : useReplicate
+              ? 'replicate'
+              : 'openai';
       console.log(`[tts] provider=${effectiveProvider} voice=${voice} text="${text.slice(0, 50)}..."`);
 
       const xiaomiStyle = effectiveProvider === 'xiaomi' ? getTTSConfig().xiaomi.style : '';
@@ -107,6 +112,8 @@ app.post(
       let result;
       if (effectiveProvider === 'xiaomi') {
         result = await synthesizeXiaomi(text, { model, voice });
+      } else if (effectiveProvider === 'mistral') {
+        result = await synthesizeMistral(text, { model, voice });
       } else if (effectiveProvider === 'edge') {
         result = await synthesizeEdge(text, voice);
       } else if (effectiveProvider === 'replicate') {
@@ -143,6 +150,7 @@ const TTS_CONFIG_SCHEMA: Record<string, string[]> = {
   qwen: ['mode', 'language', 'speaker', 'voiceDescription', 'styleInstruction'],
   openai: ['model', 'voice', 'instructions'],
   edge: ['voice'],
+  mistral: ['model', 'voice'],
   xiaomi: ['model', 'voice', 'style'],
 };
 

--- a/server/services/mistral-tts.test.ts
+++ b/server/services/mistral-tts.test.ts
@@ -1,0 +1,113 @@
+/** Tests for the Mistral Voxtral TTS provider service. */
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('synthesizeMistral', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns a clear error when the Mistral key is missing', async () => {
+    vi.doMock('../lib/config.js', () => ({
+      config: { mistralApiKey: '' },
+    }));
+
+    vi.doMock('../lib/tts-config.js', () => ({
+      getTTSConfig: () => ({ mistral: { model: 'voxtral-mini-tts-2603', voice: '' } }),
+    }));
+
+    const { synthesizeMistral } = await import('./mistral-tts.js');
+    await expect(synthesizeMistral('Hello')).resolves.toMatchObject({
+      ok: false,
+      status: 500,
+      message: expect.stringContaining('Mistral'),
+    });
+  });
+
+  it('posts Voxtral speech requests and decodes MP3 audio', async () => {
+    vi.doMock('../lib/config.js', () => ({
+      config: { mistralApiKey: 'sk-mistral' },
+    }));
+
+    vi.doMock('../lib/tts-config.js', () => ({
+      getTTSConfig: () => ({ mistral: { model: 'voxtral-mini-tts-2603', voice: 'alloy_voice' } }),
+    }));
+
+    const mp3 = Buffer.from('ID3demo');
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ audio_data: mp3.toString('base64') }), { status: 200 }),
+    );
+
+    const { synthesizeMistral } = await import('./mistral-tts.js');
+    const result = await synthesizeMistral('Hello there');
+
+    expect(result).toMatchObject({ ok: true, contentType: 'audio/mpeg' });
+    if (!result.ok) throw new Error('Expected Mistral synthesis to succeed');
+    expect(result.buf.equals(mp3)).toBe(true);
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.mistral.ai/v1/audio/speech',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer sk-mistral',
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+
+    const [, init] = vi.mocked(fetch).mock.calls[0] ?? [];
+    const body = JSON.parse(String(init?.body));
+    expect(body.model).toBe('voxtral-mini-tts-2603');
+    expect(body.input).toBe('Hello there');
+    expect(body.response_format).toBe('mp3');
+    expect(body.voice_id).toBe('alloy_voice');
+  });
+
+  it('omits voice_id when no voice is configured', async () => {
+    vi.doMock('../lib/config.js', () => ({
+      config: { mistralApiKey: 'sk-mistral' },
+    }));
+
+    vi.doMock('../lib/tts-config.js', () => ({
+      getTTSConfig: () => ({ mistral: { model: 'voxtral-mini-tts-2603', voice: '' } }),
+    }));
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ audio_data: Buffer.from('ID3demo').toString('base64') }), { status: 200 }),
+    );
+
+    const { synthesizeMistral } = await import('./mistral-tts.js');
+    await synthesizeMistral('Hello');
+
+    const [, init] = vi.mocked(fetch).mock.calls[0] ?? [];
+    const body = JSON.parse(String(init?.body));
+    expect(body.voice_id).toBeUndefined();
+  });
+
+  it('returns a provider error when Mistral payload is malformed', async () => {
+    vi.doMock('../lib/config.js', () => ({
+      config: { mistralApiKey: 'sk-mistral' },
+    }));
+
+    vi.doMock('../lib/tts-config.js', () => ({
+      getTTSConfig: () => ({ mistral: { model: 'voxtral-mini-tts-2603', voice: '' } }),
+    }));
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+
+    const { synthesizeMistral } = await import('./mistral-tts.js');
+    await expect(synthesizeMistral('Hello')).resolves.toMatchObject({
+      ok: false,
+      status: 502,
+      message: expect.stringContaining('audio'),
+    });
+  });
+});

--- a/server/services/mistral-tts.ts
+++ b/server/services/mistral-tts.ts
@@ -1,0 +1,78 @@
+/**
+ * Mistral Voxtral TTS provider.
+ *
+ * Uses Mistral's audio speech API and decodes the returned base64 audio payload.
+ * Maps Nerve's generic `voice` setting to Mistral `voice_id`.
+ * @module
+ */
+
+import { config } from '../lib/config.js';
+import { getTTSConfig } from '../lib/tts-config.js';
+import { MISTRAL_TTS_URL } from '../lib/constants.js';
+
+export interface MistralTTSResult {
+  ok: true;
+  buf: Buffer;
+  contentType: 'audio/mpeg';
+}
+
+export interface MistralTTSError {
+  ok: false;
+  status: number;
+  message: string;
+}
+
+export async function synthesizeMistral(
+  text: string,
+  opts?: { voice?: string; model?: string },
+): Promise<MistralTTSResult | MistralTTSError> {
+  if (!config.mistralApiKey) {
+    return { ok: false, status: 500, message: 'Mistral API key not configured' };
+  }
+
+  const mistral = getTTSConfig().mistral;
+  const effectiveModel = opts?.model || mistral.model;
+  const effectiveVoice = opts?.voice || mistral.voice;
+
+  const resp = await fetch(MISTRAL_TTS_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${config.mistralApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: effectiveModel,
+      input: text,
+      response_format: 'mp3',
+      ...(effectiveVoice.trim() && { voice_id: effectiveVoice.trim() }),
+    }),
+  });
+
+  if (!resp.ok) {
+    const errBody = await resp.text();
+    console.error('[tts:mistral] API error:', resp.status, errBody);
+    return { ok: false, status: resp.status, message: errBody || 'Mistral TTS failed' };
+  }
+
+  let payload: unknown;
+  try {
+    payload = await resp.json();
+  } catch (err) {
+    console.error('[tts:mistral] Failed to parse JSON:', (err as Error).message);
+    return { ok: false, status: 502, message: 'Mistral returned invalid JSON' };
+  }
+
+  const audioData = (payload as { audio_data?: string }).audio_data;
+  if (!audioData) {
+    console.error('[tts:mistral] Missing audio data in response:', JSON.stringify(payload));
+    return { ok: false, status: 502, message: 'Mistral response missing audio data' };
+  }
+
+  try {
+    const buf = Buffer.from(audioData, 'base64');
+    return { ok: true, buf, contentType: 'audio/mpeg' };
+  } catch (err) {
+    console.error('[tts:mistral] Failed to decode audio:', (err as Error).message);
+    return { ok: false, status: 502, message: 'Mistral returned invalid audio data' };
+  }
+}

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -243,7 +243,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   const toggleTtsProvider = useCallback(() => {
     setTtsProvider(prev => {
-      const order: TTSProvider[] = ['openai', 'replicate', 'xiaomi', 'edge'];
+      const order: TTSProvider[] = ['openai', 'mistral', 'replicate', 'xiaomi', 'edge'];
       const next = order[(order.indexOf(prev) + 1) % order.length]!;
       localStorage.setItem('oc-tts-provider', next);
       return next;

--- a/src/features/command-palette/commands.ts
+++ b/src/features/command-palette/commands.ts
@@ -162,6 +162,13 @@ export function createCommands(actions: CommandActions): Command[] {
       keywords: ['tts', 'voice', 'speech', 'openai'],
     },
     {
+      id: 'tts-mistral',
+      label: 'TTS: Switch to Mistral Voxtral',
+      action: () => actions.onTtsProviderChange('mistral' as TTSProvider),
+      category: 'voice',
+      keywords: ['tts', 'voice', 'speech', 'mistral', 'voxtral'],
+    },
+    {
       id: 'tts-replicate',
       label: 'TTS: Switch to Replicate',
       action: () => actions.onTtsProviderChange('replicate' as TTSProvider),

--- a/src/features/settings/AudioSettings.component.test.tsx
+++ b/src/features/settings/AudioSettings.component.test.tsx
@@ -17,6 +17,7 @@ vi.mock('@/features/tts/useTTSConfig', () => ({
       edge: { voice: 'en-US-AriaNeural' },
       openai: { model: 'tts-1', voice: 'alloy', instructions: '' },
       qwen: { mode: 'voice_design', language: 'English', speaker: 'Serena', voiceDescription: '', styleInstruction: '' },
+      mistral: { model: 'voxtral-mini-tts-2603', voice: '' },
       xiaomi: { model: 'mimo-v2-tts', voice: 'mimo_default', style: '' },
     },
     saved: true,
@@ -72,9 +73,10 @@ function mockWakeWordSupport(result: { supported: boolean; reason: 'mobile-web' 
   (wakeWordSupport.isWakeWordSupportedEnvironment as Mock).mockReturnValue(result.supported);
 }
 
-type ApiKeyState = { openaiKeySet: boolean; replicateKeySet: boolean; xiaomiKeySet: boolean; hasGpu: boolean };
+type ApiKeyState = { openaiKeySet: boolean; mistralKeySet: boolean; replicateKeySet: boolean; xiaomiKeySet: boolean; hasGpu: boolean };
 let apiKeyState: ApiKeyState = {
   openaiKeySet: true,
+  mistralKeySet: false,
   replicateKeySet: true,
   xiaomiKeySet: false,
   hasGpu: false,
@@ -86,6 +88,7 @@ describe('AudioSettings', () => {
     mockWakeWordSupport({ supported: true, reason: null });
     apiKeyState = {
       openaiKeySet: true,
+      mistralKeySet: false,
       replicateKeySet: true,
       xiaomiKeySet: false,
       hasGpu: false,
@@ -169,6 +172,36 @@ describe('AudioSettings', () => {
 
       expect(await screen.findByText(/wake word isn't supported on mobile web/i)).toBeInTheDocument();
       expect(screen.getByText(/use the manual mic trigger instead/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Mistral Voxtral output settings', () => {
+    it('renders a Mistral Voxtral provider button', async () => {
+      render(<AudioSettings {...baseProps} section="output" ttsProvider="mistral" ttsModel="" />);
+      expect(await screen.findByRole('button', { name: 'Mistral Voxtral' })).toBeInTheDocument();
+    });
+
+    it('shows the Mistral API key prompt when selected and the key is missing', async () => {
+      apiKeyState.mistralKeySet = false;
+      render(<AudioSettings {...baseProps} section="output" ttsProvider="mistral" ttsModel="" />);
+
+      expect(await screen.findByText(/MISTRAL_API_KEY required for Mistral Voxtral/i)).toBeInTheDocument();
+    });
+
+    it('renders Mistral model and voice controls', async () => {
+      render(<AudioSettings {...baseProps} section="output" ttsProvider="mistral" ttsModel="" />);
+
+      expect(await screen.findByLabelText('TTS Model')).toHaveValue('');
+      expect(screen.getByLabelText('Mistral Voice ID')).toHaveValue('');
+      expect(screen.getByRole('option', { name: 'voxtral-mini-tts-2603 (default)' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'voxtral-tts-26-03' })).toBeInTheDocument();
+    });
+
+    it('updates Mistral voice ID when the field changes', async () => {
+      render(<AudioSettings {...baseProps} section="output" ttsProvider="mistral" ttsModel="voxtral-mini-tts-2603" />);
+
+      fireEvent.change(await screen.findByLabelText('Mistral Voice ID'), { target: { value: 'alloy_voice' } });
+      expect(updateField).toHaveBeenCalledWith('mistral', 'voice', 'alloy_voice');
     });
   });
 

--- a/src/features/settings/AudioSettings.tsx
+++ b/src/features/settings/AudioSettings.tsx
@@ -352,7 +352,7 @@ function ApiKeyInput({
 }: {
   keyName: string;
   provider: string;
-  fieldName: 'openaiKey' | 'replicateToken' | 'mimoApiKey';
+  fieldName: 'openaiKey' | 'mistralApiKey' | 'replicateToken' | 'mimoApiKey';
   onSaved: () => void;
 }) {
   const [value, setValue] = useState('');
@@ -419,6 +419,10 @@ const PROVIDER_MODELS: Record<TTSProvider, { value: string; label: string }[]> =
     { value: 'tts-1', label: 'tts-1' },
     { value: 'tts-1-hd', label: 'tts-1-hd' },
   ],
+  mistral: [
+    { value: '', label: 'voxtral-mini-tts-2603 (default)' },
+    { value: 'voxtral-tts-26-03', label: 'voxtral-tts-26-03' },
+  ],
   replicate: [
     { value: '', label: 'qwen-tts (default)' },
   ],
@@ -465,13 +469,19 @@ export function AudioSettings({
   const { state: langState, support, isMultilingual, setLanguage } = useLanguage();
 
   // Fetch API key status once on mount
-  const [apiKeys, setApiKeys] = useState<{ openai: boolean; replicate: boolean; xiaomi: boolean }>({ openai: true, replicate: true, xiaomi: true });
+  const [apiKeys, setApiKeys] = useState<{ openai: boolean; mistral: boolean; replicate: boolean; xiaomi: boolean }>({
+    openai: true,
+    mistral: true,
+    replicate: true,
+    xiaomi: true,
+  });
   useEffect(() => {
     fetch('/api/keys')
       .then((r) => r.json())
       .then((data) => {
         setApiKeys({
           openai: !!data.openaiKeySet,
+          mistral: !!data.mistralKeySet,
           replicate: !!data.replicateKeySet,
           xiaomi: !!data.xiaomiKeySet,
         });
@@ -723,7 +733,7 @@ export function AudioSettings({
       {showOutput && (
         <div className="space-y-2">
           <span className="cockpit-field-label">TTS Provider</span>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             <button
               type="button"
               onClick={() => onTtsProviderChange('openai')}
@@ -731,6 +741,14 @@ export function AudioSettings({
               className="shell-chip min-h-11 flex-1 justify-center rounded-2xl px-3 py-2 text-sm font-medium"
             >
               OpenAI
+            </button>
+            <button
+              type="button"
+              onClick={() => onTtsProviderChange('mistral')}
+              data-active={ttsProvider === 'mistral'}
+              className="shell-chip min-h-11 flex-1 justify-center rounded-2xl px-3 py-2 text-sm font-medium"
+            >
+              Mistral Voxtral
             </button>
             <button
               type="button"
@@ -777,6 +795,9 @@ export function AudioSettings({
       {showOutput && ttsProvider === 'openai' && !apiKeys.openai && (
         <ApiKeyInput keyName="OPENAI_API_KEY" provider="OpenAI TTS" fieldName="openaiKey" onSaved={() => setApiKeys(k => ({ ...k, openai: true }))} />
       )}
+      {showOutput && ttsProvider === 'mistral' && !apiKeys.mistral && (
+        <ApiKeyInput keyName="MISTRAL_API_KEY" provider="Mistral Voxtral" fieldName="mistralApiKey" onSaved={() => setApiKeys(k => ({ ...k, mistral: true }))} />
+      )}
       {showOutput && ttsProvider === 'replicate' && !apiKeys.replicate && (
         <ApiKeyInput keyName="REPLICATE_API_TOKEN" provider="Replicate TTS" fieldName="replicateToken" onSaved={() => setApiKeys(k => ({ ...k, replicate: true }))} />
       )}
@@ -792,10 +813,15 @@ export function AudioSettings({
             <p className="mt-1 text-xs text-muted-foreground">Select the synthesis model exposed by the active provider.</p>
           </div>
           <InlineSelect
-            value={ttsProvider === 'xiaomi' ? (ttsModel || config?.xiaomi.model || '') : ttsModel}
+            value={ttsProvider === 'xiaomi'
+              ? (ttsModel || config?.xiaomi.model || '')
+              : ttsProvider === 'mistral'
+                ? (ttsModel || (config?.mistral.model === 'voxtral-mini-tts-2603' ? '' : config?.mistral.model || ''))
+                : ttsModel}
             onChange={(value) => {
               onTtsModelChange(value);
               if (ttsProvider === 'xiaomi') updateField('xiaomi', 'model', value);
+              if (ttsProvider === 'mistral') updateField('mistral', 'model', value || 'voxtral-mini-tts-2603');
             }}
             options={models}
             ariaLabel="TTS Model"
@@ -837,6 +863,23 @@ export function AudioSettings({
                 placeholder="Describe how the voice should sound..."
               />
             </>
+          )}
+
+          {ttsProvider === 'mistral' && (
+            <div className="cockpit-row items-start justify-between gap-4">
+              <div className="min-w-0 flex-1">
+                <span className="text-sm font-medium text-foreground">Voice ID</span>
+                <p className="mt-1 text-xs text-muted-foreground">Optional preset or custom Mistral voice ID. Leave blank to use the provider default.</p>
+              </div>
+              <input
+                type="text"
+                value={config.mistral.voice}
+                onChange={(e) => updateField('mistral', 'voice', e.target.value)}
+                placeholder="alloy_voice"
+                className="cockpit-input cockpit-input-mono h-11 min-w-[188px]"
+                aria-label="Mistral Voice ID"
+              />
+            </div>
           )}
 
           {ttsProvider === 'edge' && (

--- a/src/features/tts/useTTS.test.ts
+++ b/src/features/tts/useTTS.test.ts
@@ -78,6 +78,10 @@ describe('migrateTTSProvider', () => {
     expect(migrateTTSProvider('replicate')).toBe('replicate');
   });
 
+  it('should keep "mistral" as-is', () => {
+    expect(migrateTTSProvider('mistral')).toBe('mistral');
+  });
+
   it('should keep "edge" as-is', () => {
     expect(migrateTTSProvider('edge')).toBe('edge');
   });

--- a/src/features/tts/useTTS.ts
+++ b/src/features/tts/useTTS.ts
@@ -14,7 +14,7 @@ if (typeof document !== 'undefined') {
   events.forEach(e => document.addEventListener(e, handler, { capture: true, once: false }));
 }
 
-export type TTSProvider = 'openai' | 'replicate' | 'edge' | 'xiaomi';
+export type TTSProvider = 'openai' | 'mistral' | 'replicate' | 'edge' | 'xiaomi';
 
 /** @deprecated Use 'replicate' instead. Kept for migration. */
 export type LegacyTTSProvider = 'qwen';
@@ -22,7 +22,7 @@ export type LegacyTTSProvider = 'qwen';
 /** Migrate legacy provider names to current ones. */
 export function migrateTTSProvider(provider: string): TTSProvider {
   if (provider === 'qwen') return 'replicate';
-  if (provider === 'openai' || provider === 'replicate' || provider === 'edge' || provider === 'xiaomi') return provider;
+  if (provider === 'openai' || provider === 'mistral' || provider === 'replicate' || provider === 'edge' || provider === 'xiaomi') return provider;
   return 'openai';
 }
 

--- a/src/features/tts/useTTSConfig.ts
+++ b/src/features/tts/useTTSConfig.ts
@@ -16,6 +16,10 @@ export interface TTSVoiceConfig {
   edge: {
     voice: string;
   };
+  mistral: {
+    model: string;
+    voice: string;
+  };
   xiaomi: {
     model: string;
     voice: string;


### PR DESCRIPTION
## Summary
- add a new explicit `mistral` TTS provider in Nerve wired through backend routes, provider config, API key management, settings UI, and command palette
- add a Mistral Voxtral service client plus tests/docs updates, with the current default Mistral voice set to Jane - Neutral for this branch
- validate the integration with targeted tests and live smoke testing against Mistral voices

## Test Plan
- [x] `npx vitest --run server/lib/tts-config.test.ts server/services/mistral-tts.test.ts server/routes/api-keys.test.ts server/routes/tts.test.ts src/features/tts/useTTS.test.ts src/features/settings/AudioSettings.component.test.tsx`
- [x] `npm run build`
- [x] manual smoke test in Nerve using Mistral voice playback

## Notes
- the full repo test suite is currently baseline-red on unrelated existing failures outside this change set, so this PR uses targeted verification + full build
- Mistral TTS appears intermittently flaky upstream (`500 Service unavailable`) during testing; explicit saved voice IDs work, but provider reliability is not perfect right now

## Follow-ups
- add a Mistral voice dropdown populated from `/v1/audio/voices`
- add retry logic / graceful handling for transient Mistral 500s
