### PR TITLE
fix(sessions): keep main root label canonical

### DIFF
--- a/src/features/sessions/sessionKeys.test.ts
+++ b/src/features/sessions/sessionKeys.test.ts
@@ -88,6 +88,11 @@ describe('sessionKeys', () => {
     expect(getSessionDisplayLabel(session('agent:main:main'), 'Nerve')).toBe('Nerve (main)');
   });
 
+  it('keeps the main root label canonical even if gateway metadata says heartbeat', () => {
+    expect(getSessionDisplayLabel(session('agent:main:main', { label: 'heartbeat' }), 'Nerve')).toBe('Nerve (main)');
+    expect(getSessionDisplayLabel(session('agent:main:main', { displayName: 'heartbeat' }), 'Nerve')).toBe('Nerve (main)');
+  });
+
   it('falls back to inferred parent when explicit parentId is outside the current window', () => {
     const knownKeys = new Set(['agent:reviewer:main', 'agent:reviewer:subagent:child']);
     const child = session('agent:reviewer:subagent:child', { parentId: 'agent:missing:main' });

--- a/src/features/sessions/sessionKeys.ts
+++ b/src/features/sessions/sessionKeys.ts
@@ -126,12 +126,15 @@ export function getTopLevelAgentSessions(sessions: Session[]): Session[] {
 export function getSessionDisplayLabel(session: Session, agentName = 'Agent'): string {
   const sessionKey = getSessionKey(session);
 
+  if (sessionKey === 'agent:main:main') {
+    return `${agentName} (main)`;
+  }
+
   if (session.label?.trim()) return session.label.trim();
   if (session.displayName?.trim()) return session.displayName.trim();
 
   if (isTopLevelAgentSessionKey(sessionKey)) {
     const rootId = getRootAgentId(sessionKey);
-    if (rootId === 'main') return `${agentName} (main)`;
     if (rootId) return `Agent ${rootId}`;
   }
 


### PR DESCRIPTION
## Summary
- render `agent:main:main` as the canonical `${agentName} (main)` label even if gateway metadata provides a different `label` or `displayName`
- add a regression test covering the reported `"heartbeat"` root-label case
- keep existing label behavior unchanged for other session types and other top-level agents

## Why
Issue #195 reports a label-spoofing problem.

The root session was still `agent:main:main`, but Nerve trusted gateway-provided `label` / `displayName` first, so the root could render as `"heartbeat"` and make the sidebar look incorrectly nested.

This change makes the main root identity canonical in the UI.

## Tradeoff
- `agent:main:main` no longer visually honors arbitrary custom labels
- this is intentional, so the main root always renders consistently

## Testing
- `npm test -- --run src/features/sessions/sessionKeys.test.ts src/features/sessions/sessionTree.test.ts`
- `npm run build`

Fixes #195


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Session display labels now correctly display canonical naming regardless of conflicting or overriding metadata from external sources. This ensures consistent labeling across the application.

* **Tests**
  * Added test coverage to ensure session display labels maintain consistent, correct formatting even when gateway metadata provides conflicting values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->