### PR TITLE
Fix #171: [Bug] STT: Azure OpenAI (Whisper) transcription returns 404...

### DIFF
--- a/server/lib/constants.test.ts
+++ b/server/lib/constants.test.ts
@@ -1,0 +1,38 @@
+/** Tests for server/lib/constants.ts — URL construction with env overrides. */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+describe('constants module', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.resetModules();
+  });
+
+  describe('OPENAI_WHISPER_URL', () => {
+    it('omits api-version when OPENAI_API_VERSION is not set', async () => {
+      delete process.env.OPENAI_API_VERSION;
+      vi.resetModules();
+      const { OPENAI_WHISPER_URL } = await import('./constants.js');
+      expect(OPENAI_WHISPER_URL).not.toContain('api-version');
+      expect(OPENAI_WHISPER_URL).toMatch(/\/audio\/transcriptions$/);
+    });
+
+    it('appends api-version when OPENAI_API_VERSION is set', async () => {
+      process.env.OPENAI_API_VERSION = '2024-06-01';
+      vi.resetModules();
+      const { OPENAI_WHISPER_URL } = await import('./constants.js');
+      expect(OPENAI_WHISPER_URL).toContain('?api-version=2024-06-01');
+    });
+
+    it('uses custom base URL with api-version for Azure endpoints', async () => {
+      process.env.OPENAI_BASE_URL = 'https://myresource.cognitiveservices.azure.com/openai/deployments/whisper';
+      process.env.OPENAI_API_VERSION = '2024-06-01';
+      vi.resetModules();
+      const { OPENAI_WHISPER_URL } = await import('./constants.js');
+      expect(OPENAI_WHISPER_URL).toBe(
+        'https://myresource.cognitiveservices.azure.com/openai/deployments/whisper/audio/transcriptions?api-version=2024-06-01',
+      );
+    });
+  });
+});

--- a/server/lib/constants.ts
+++ b/server/lib/constants.ts
@@ -9,11 +9,14 @@
 
 export const OPENAI_BASE_URL = process.env.OPENAI_BASE_URL || 'https://api.openai.com/v1';
 export const REPLICATE_BASE_URL = process.env.REPLICATE_BASE_URL || 'https://api.replicate.com/v1';
+export const OPENAI_API_VERSION = process.env.OPENAI_API_VERSION || '';
 
 // ─── API endpoints (derived from base URLs) ──────────────────────────────────
 
 export const OPENAI_TTS_URL = `${OPENAI_BASE_URL}/audio/speech`;
-export const OPENAI_WHISPER_URL = `${OPENAI_BASE_URL}/audio/transcriptions`;
+export const OPENAI_WHISPER_URL = OPENAI_API_VERSION
+  ? `${OPENAI_BASE_URL}/audio/transcriptions?api-version=${OPENAI_API_VERSION}`
+  : `${OPENAI_BASE_URL}/audio/transcriptions`;
 export const REPLICATE_QWEN_TTS_URL = `${REPLICATE_BASE_URL}/models/qwen/qwen3-tts/predictions`;
 
 // ─── Default connection ──────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #171

## What

Appends `?api-version=<version>` to the Whisper transcription URL when the `OPENAI_API_VERSION` environment variable is set. No behavior change for standard OpenAI usage where this var is unset.

## Why

Azure OpenAI endpoints require an `api-version` query parameter on every request. Without it, `POST /api/transcribe` returns `404 Resource not found`. Previously, `server/lib/constants.ts` built `OPENAI_WHISPER_URL` as a bare string with no mechanism to append query params.

## How

- **`server/lib/constants.ts`**: Exports a new `OPENAI_API_VERSION` constant read from `process.env.OPENAI_API_VERSION`. `OPENAI_WHISPER_URL` is now conditionally constructed: if `OPENAI_API_VERSION` is non-empty, the URL becomes `${OPENAI_BASE_URL}/audio/transcriptions?api-version=${OPENAI_API_VERSION}`; otherwise it falls back to the existing bare path. `OPENAI_TTS_URL` is unchanged as Azure TTS is not affected.
- **`server/lib/constants.test.ts`** (new file): Three Vitest cases cover the three relevant states — var unset (no query string), var set (query string appended), and Azure base URL with version (full URL shape verified).

No changes to `server/services/openai-whisper.ts` were needed since it already imports `OPENAI_WHISPER_URL` directly from `constants.ts`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [x] New features include tests
- [ ] UI changes include a screenshot or screen recording

## Screenshots

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced transcription service configuration by adding support for customizable OpenAI API versions through environment variables, enabling flexible endpoint setup for various service deployments

* **Tests**
  * Added comprehensive test coverage validating transcription URL construction across multiple configuration scenarios, including different API versions and base URL combinations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->