### PR TITLE
fix: parse OpenClaw config with JSON5 for model catalog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "dotenv": "^17.2.4",
         "highlight.js": "^11.11.1",
         "hono": "^4.11.7",
+        "json5": "^2.2.3",
         "lightweight-charts": "^5.1.0",
         "lucide-react": "^0.563.0",
         "node-pty": "^1.1.0",
@@ -9314,7 +9315,8 @@
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "dotenv": "^17.2.4",
     "highlight.js": "^11.11.1",
     "hono": "^4.11.7",
+    "json5": "^2.2.3",
     "lightweight-charts": "^5.1.0",
     "lucide-react": "^0.563.0",
     "node-pty": "^1.1.0",

--- a/server/routes/gateway.test.ts
+++ b/server/routes/gateway.test.ts
@@ -360,6 +360,55 @@ describe('gateway routes', () => {
       });
     });
 
+    it('returns configured models when the OpenClaw config uses JSON5 syntax', async () => {
+      setDefaults();
+      readFileImpl = async () => `
+        {
+          // OpenClaw config often includes comments and trailing commas
+          agents: {
+            defaults: {
+              model: {
+                primary: 'zai/glm-4.7',
+                fallbacks: [
+                  'openrouter/xiaomi/mimo-v2-pro',
+                ],
+              },
+              models: {
+                'zai/glm-4.7': { alias: 'glm-4.7' },
+                'openrouter/xiaomi/mimo-v2-pro': { alias: 'mimo-v2-pro' },
+              },
+            },
+          },
+        }
+      `;
+
+      const app = buildApp();
+      const res = await app.request('/api/gateway/models');
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        models: [
+          {
+            id: 'zai/glm-4.7',
+            label: 'glm-4.7',
+            provider: 'zai',
+            alias: 'glm-4.7',
+            configured: true,
+            role: 'primary',
+          },
+          {
+            id: 'openrouter/xiaomi/mimo-v2-pro',
+            label: 'mimo-v2-pro',
+            provider: 'openrouter',
+            alias: 'mimo-v2-pro',
+            configured: true,
+            role: 'fallback',
+          },
+        ],
+        error: null,
+        source: 'config',
+      });
+    });
+
     it('returns an explicit error when the config is unreadable', async () => {
       setDefaults();
       readFileImpl = async () => {

--- a/server/routes/gateway.ts
+++ b/server/routes/gateway.ts
@@ -13,6 +13,7 @@
  */
 
 import { Hono } from 'hono';
+import JSON5 from 'json5';
 import { execFile } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { Socket } from 'node:net';
@@ -159,7 +160,7 @@ async function getModelCatalog(): Promise<{ models: GatewayModelInfo[]; error: s
 
   try {
     const raw = await readFile(configPath, 'utf8');
-    const configData = JSON.parse(raw) as OpenClawConfig;
+    const configData = JSON5.parse(raw) as OpenClawConfig;
     const models = readConfiguredModels(configData);
 
     if (models.length === 0) {


### PR DESCRIPTION
## Summary

Fixes the false-positive header warning from #209.

Closes #209.

## What changed

- switched `/api/gateway/models` from `JSON.parse` to `JSON5.parse`
- added `json5` as a runtime dependency
- added a regression test for JSON5-style config syntax

## Why

Nerve v1.5.2 started reading configured models directly from the active OpenClaw config. If `openclaw.json` used JSON5-style syntax (comments, unquoted keys, trailing commas), Nerve could fail to parse it and show:

> ⚠ Could not read OpenClaw config.

even though OpenClaw itself was working normally.

## Verification

- `npm test -- server/routes/gateway.test.ts`
- `npm run build:server`

Also verified live:
- pre-fix instance showed the warning
- fixed instance no longer showed it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration files now support JSON5 format, enabling comments and trailing commas for improved readability and flexibility.

* **Tests**
  * Added test coverage for JSON5 configuration file parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->