### PR TITLE
docs: remove stale architecture test counts

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -738,9 +738,9 @@ npm test              # Run all tests
 npm run test:coverage # With V8 coverage
 ```
 
-### Test Files
+### Test Coverage Areas
 
-48 test files, 692 tests. Key areas:
+The Vitest suite spans server code, client features, hooks, and shared utilities. Representative areas:
 
 | Area | Files | Coverage |
 |------|-------|----------|


### PR DESCRIPTION
## Summary

Remove the stale hardcoded test counts from `docs/ARCHITECTURE.md`.

## Why

The previous `48 test files, 692 tests` line is no longer accurate and is easy to let drift. This changes the section to describe the coverage areas without baking in a brittle point-in-time count.
