### PR TITLE
fix: use pointer cursor on session names in agents tab

### DIFF
--- a/src/features/sessions/SessionNode.tsx
+++ b/src/features/sessions/SessionNode.tsx
@@ -257,7 +257,7 @@ export const SessionNode = memo(function SessionNode({
         ) : (
           <SessionInfoPanel session={node.session} running={running}>
             <span className={cn(
-              "text-[0.667rem] font-bold flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap cursor-help",
+              "text-[0.667rem] font-bold flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap cursor-pointer",
               isCronRun ? "text-muted-foreground font-normal" : "text-foreground"
             )}>
               {isCron && <Timer size={11} className="text-purple mr-1 inline shrink-0" aria-label="Cron job" />}


### PR DESCRIPTION
## What
Changes the cursor from `cursor-help` (question-mark arrow) to `cursor-pointer` (click hand) when hovering over session names in the Agents tab.

This is a stylistic change so take it or leave it.  But now with the delayed hover, the cusor difference between `cursor-help` when hovering the session name, versus `cursor-pointer` when hovering the rest of the row is a bit unusual of a UI pattern.

## Why
The `cursor-help` icon appears when hovering over session names because the `<span>` is wrapped in a `<SessionInfoPanel>` tooltip trigger. However, since clicking the row selects the session, the help cursor is misleading — users expect a pointer to indicate clickability.

## How
Single class change in `src/features/sessions/SessionNode.tsx` (~line 260): `cursor-help` → `cursor-pointer` on the session name `<span>`.

No tests affected — this is a CSS-only change. Build and all existing tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the cursor appearance when hovering over session labels to better indicate they are interactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->