### PR TITLE
fix(stt): append api-version for Azure OpenAI Whisper endpoint

### DIFF
--- a/server/lib/config.ts
+++ b/server/lib/config.ts
@@ -50,6 +50,7 @@ export const config = {
   host: process.env.HOST || DEFAULT_HOST,
 
   openaiApiKey: process.env.OPENAI_API_KEY || '',
+  openaiApiVersion: process.env.OPENAI_API_VERSION || process.env.AZURE_OPENAI_API_VERSION || '',
   replicateApiToken: process.env.REPLICATE_API_TOKEN || '',
   mimoApiKey: process.env.MIMO_API_KEY || '',
 

--- a/server/services/openai-whisper.test.ts
+++ b/server/services/openai-whisper.test.ts
@@ -40,7 +40,8 @@ describe('openai-whisper transcribe URL building', () => {
     }));
 
     vi.doMock('../lib/constants.js', () => ({
-      OPENAI_WHISPER_URL: 'https://example.cognitiveservices.azure.com/openai/deployments/whisper/audio/transcriptions',
+      OPENAI_WHISPER_URL:
+        'https://example.cognitiveservices.azure.com/openai/deployments/whisper/audio/transcriptions',
     }));
 
     vi.mocked(fetch).mockResolvedValue(
@@ -77,6 +78,29 @@ describe('openai-whisper transcribe URL building', () => {
     expect(result).toEqual({ ok: true, text: 'ok' });
     expect(fetch).toHaveBeenCalledWith(
       'https://example.cognitiveservices.azure.com/openai/deployments/whisper/audio/transcriptions?api-version=2025-01-01',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('uses base whisper URL when API version is whitespace-only', async () => {
+    vi.doMock('../lib/config.js', () => ({
+      config: { openaiApiKey: 'sk-test', openaiApiVersion: '   ', language: 'en' },
+    }));
+
+    vi.doMock('../lib/constants.js', () => ({
+      OPENAI_WHISPER_URL: 'https://api.openai.com/v1/audio/transcriptions',
+    }));
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ text: 'ok' }), { status: 200 }),
+    );
+
+    const { transcribe } = await import('./openai-whisper.js');
+    const result = await transcribe(Buffer.from('abc'), 'sample.webm');
+
+    expect(result).toEqual({ ok: true, text: 'ok' });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/audio/transcriptions',
       expect.objectContaining({ method: 'POST' }),
     );
   });

--- a/server/services/openai-whisper.test.ts
+++ b/server/services/openai-whisper.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('openai-whisper transcribe URL building', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('uses base whisper URL when no API version is configured', async () => {
+    vi.doMock('../lib/config.js', () => ({
+      config: { openaiApiKey: 'sk-test', openaiApiVersion: '', language: 'en' },
+    }));
+
+    vi.doMock('../lib/constants.js', () => ({
+      OPENAI_WHISPER_URL: 'https://api.openai.com/v1/audio/transcriptions',
+    }));
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ text: 'ok' }), { status: 200 }),
+    );
+
+    const { transcribe } = await import('./openai-whisper.js');
+    const result = await transcribe(Buffer.from('abc'), 'sample.webm');
+
+    expect(result).toEqual({ ok: true, text: 'ok' });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/audio/transcriptions',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('appends api-version when OPENAI_API_VERSION/AZURE_OPENAI_API_VERSION is configured', async () => {
+    vi.doMock('../lib/config.js', () => ({
+      config: { openaiApiKey: 'sk-test', openaiApiVersion: '2024-06-01', language: 'en' },
+    }));
+
+    vi.doMock('../lib/constants.js', () => ({
+      OPENAI_WHISPER_URL: 'https://example.cognitiveservices.azure.com/openai/deployments/whisper/audio/transcriptions',
+    }));
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ text: 'ok' }), { status: 200 }),
+    );
+
+    const { transcribe } = await import('./openai-whisper.js');
+    const result = await transcribe(Buffer.from('abc'), 'sample.webm');
+
+    expect(result).toEqual({ ok: true, text: 'ok' });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://example.cognitiveservices.azure.com/openai/deployments/whisper/audio/transcriptions?api-version=2024-06-01',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('does not override existing api-version query parameter', async () => {
+    vi.doMock('../lib/config.js', () => ({
+      config: { openaiApiKey: 'sk-test', openaiApiVersion: '2024-06-01', language: 'en' },
+    }));
+
+    vi.doMock('../lib/constants.js', () => ({
+      OPENAI_WHISPER_URL:
+        'https://example.cognitiveservices.azure.com/openai/deployments/whisper/audio/transcriptions?api-version=2025-01-01',
+    }));
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ text: 'ok' }), { status: 200 }),
+    );
+
+    const { transcribe } = await import('./openai-whisper.js');
+    const result = await transcribe(Buffer.from('abc'), 'sample.webm');
+
+    expect(result).toEqual({ ok: true, text: 'ok' });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://example.cognitiveservices.azure.com/openai/deployments/whisper/audio/transcriptions?api-version=2025-01-01',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+});

--- a/server/services/openai-whisper.ts
+++ b/server/services/openai-whisper.ts
@@ -9,6 +9,18 @@
 import { config } from '../lib/config.js';
 import { OPENAI_WHISPER_URL } from '../lib/constants.js';
 
+function getWhisperUrl(): string {
+  const apiVersion = config.openaiApiVersion?.trim();
+  if (!apiVersion) return OPENAI_WHISPER_URL;
+
+  const url = new URL(OPENAI_WHISPER_URL);
+  if (!url.searchParams.has('api-version')) {
+    url.searchParams.set('api-version', apiVersion);
+  }
+
+  return url.toString();
+}
+
 export interface WhisperResult {
   ok: true;
   text: string;
@@ -55,7 +67,7 @@ export async function transcribe(
   footer += `--${boundary}--\r\n`;
   const payload = Buffer.concat([header, fileData, Buffer.from(footer)]);
 
-  const resp = await fetch(OPENAI_WHISPER_URL, {
+  const resp = await fetch(getWhisperUrl(), {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${config.openaiApiKey}`,


### PR DESCRIPTION
## Summary
Fixes Azure OpenAI Whisper transcription failures by appending `api-version` when configured.

## What changed
- Added `openaiApiVersion` config value from env:
  - `OPENAI_API_VERSION`
  - `AZURE_OPENAI_API_VERSION` (fallback alias)
- Updated `server/services/openai-whisper.ts` to build request URL dynamically:
  - uses existing `OPENAI_WHISPER_URL` by default
  - appends `?api-version=<value>` when version env is set
  - preserves existing `api-version` if already present in URL
- Added focused tests in `server/services/openai-whisper.test.ts` for all three URL behaviors.

## Verification
- `npx vitest run server/services/openai-whisper.test.ts server/routes/transcribe.test.ts`
- `npm run build:server`

Fixes #171


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server configuration now supports specifying an OpenAI API version.
  * Whisper transcription requests respect the configured API version and preserve existing URL parameters when present.

* **Tests**
  * Added test coverage for API-version handling in transcription request URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->