### PR TITLE
Allow renaming more agent sessions in NERV

### DIFF
--- a/src/features/sessions/SessionList.test.tsx
+++ b/src/features/sessions/SessionList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { Session } from '@/types';
 import { SessionList } from './SessionList';
 
@@ -43,5 +43,35 @@ describe('SessionList empty state', () => {
 
     expect(screen.getByTestId('session-skeleton-group')).toBeInTheDocument();
     expect(screen.queryByText('No active sessions')).not.toBeInTheDocument();
+  });
+});
+
+describe('SessionList actions', () => {
+  it('allows renaming direct child sessions without enabling delete', () => {
+    const sessions: Session[] = [
+      { sessionKey: 'agent:reviewer:main', label: 'Reviewer' },
+      { sessionKey: 'agent:reviewer:telegram:direct:123', displayName: 'Telegram DM' },
+    ];
+
+    renderSessionList({ sessions, compact: true, onRename: vi.fn(), onDelete: vi.fn() });
+
+    fireEvent.click(screen.getAllByLabelText('Session actions')[1]!);
+
+    expect(screen.getByTitle('Rename session')).toBeInTheDocument();
+    expect(screen.queryByTitle('Delete session')).not.toBeInTheDocument();
+  });
+
+  it('allows renaming ACP child sessions without enabling delete', () => {
+    const sessions: Session[] = [
+      { sessionKey: 'agent:codex:main', label: 'Codex' },
+      { sessionKey: 'agent:codex:acp:123', displayName: 'ACP Session', parentId: 'agent:codex:main' },
+    ];
+
+    renderSessionList({ sessions, compact: true, onRename: vi.fn(), onDelete: vi.fn() });
+
+    fireEvent.click(screen.getAllByLabelText('Session actions')[1]!);
+
+    expect(screen.getByTitle('Rename session')).toBeInTheDocument();
+    expect(screen.queryByTitle('Delete session')).not.toBeInTheDocument();
   });
 });

--- a/src/features/sessions/SessionNode.tsx
+++ b/src/features/sessions/SessionNode.tsx
@@ -143,10 +143,11 @@ export const SessionNode = memo(function SessionNode({
   const [actionsOpen, setActionsOpen] = useState(false);
   const actionsRef = useRef<HTMLDivElement>(null);
 
-  const canRenameDelete = isRootAgent || isSubagent || isCron || isCronRun;
+  const canDelete = isRootAgent || isSubagent || isCron || isCronRun;
+  const canRename = Boolean(onStartRename);
   const hasAbortAction = Boolean(onAbort && running);
-  const hasRenameAction = Boolean(canRenameDelete && onStartRename && !isRenaming);
-  const hasDeleteAction = Boolean(canRenameDelete && onDelete);
+  const hasRenameAction = Boolean(canRename && onStartRename && !isRenaming);
+  const hasDeleteAction = Boolean(canDelete && onDelete);
   const hasActions = hasAbortAction || hasRenameAction || hasDeleteAction;
 
   useEffect(() => {
@@ -359,29 +360,25 @@ export const SessionNode = memo(function SessionNode({
               ⏹
             </button>
           )}
-          {canRenameDelete && (
-            <>
-              {hasRenameAction && (
-                <button
-                  type="button"
-                  onClick={handleRenameClick}
-                  title="Rename session"
-                  className="bg-card/90 border border-border/60 text-muted-foreground hover:text-foreground hover:border-muted-foreground cursor-pointer text-[0.667rem] w-5 h-5 flex items-center justify-center"
-                >
-                  <PenLine size={10} />
-                </button>
-              )}
-              {hasDeleteAction && (
-                <button
-                  type="button"
-                  onClick={handleDeleteClick}
-                  title="Delete session"
-                  className="bg-card/90 border border-border/60 text-muted-foreground hover:text-red hover:border-red/40 cursor-pointer text-[0.667rem] w-5 h-5 flex items-center justify-center"
-                >
-                  ✕
-                </button>
-              )}
-            </>
+          {hasRenameAction && (
+            <button
+              type="button"
+              onClick={handleRenameClick}
+              title="Rename session"
+              className="bg-card/90 border border-border/60 text-muted-foreground hover:text-foreground hover:border-muted-foreground cursor-pointer text-[0.667rem] w-5 h-5 flex items-center justify-center"
+            >
+              <PenLine size={10} />
+            </button>
+          )}
+          {hasDeleteAction && (
+            <button
+              type="button"
+              onClick={handleDeleteClick}
+              title="Delete session"
+              className="bg-card/90 border border-border/60 text-muted-foreground hover:text-red hover:border-red/40 cursor-pointer text-[0.667rem] w-5 h-5 flex items-center justify-center"
+            >
+              ✕
+            </button>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary
- allow rename actions for any session that exposes an `onStartRename` handler in the agent panel
- keep delete restricted to root agents, subagents, cron sessions, and cron runs
- add regression tests for Telegram direct sessions and ACP child sessions

## Why
Gateway label validation is generic (valid label + uniqueness), and does not appear to restrict renames by session type. The existing lockout was local NERV policy, which blocked visible agent-panel sessions like direct Telegram/Discord channels and ACP sessions from being renamed. This change makes NERV more permissive while still leaving delete scoped to the narrower set of session types it already supported.

## Verification
- `npm run build` ✅
- `npm test -- --run src/features/sessions/SessionList.test.tsx` ✅
- `npm test -- --run` ⚠️ existing unrelated failure in `server/lib/config.test.ts > defaults auth to false` (received `true`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases for session actions to verify rename functionality is available for direct and ACP child sessions while ensuring delete action availability is controlled independently.

* **Refactor**
  * Separated session action gating logic to independently control availability of rename and delete actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->