### PR TITLE
fix(sessions): keep spawned child sessions visible after refresh

### DIFF
--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -394,6 +394,87 @@ describe('SessionContext', () => {
     expect(rpcMock).not.toHaveBeenCalledWith('sessions.list', expect.objectContaining({ activeMinutes: expect.any(Number) }));
   });
 
+  it('keeps a newly spawned active child session visible after the authoritative refresh omits it', async () => {
+    let subagentSpawnRequested = false;
+    rpcMock.mockImplementation(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'chat.send') {
+        subagentSpawnRequested = true;
+        return {};
+      }
+
+      if (method === 'sessions.list') {
+        if (params?.spawnedBy === 'agent:main:main') {
+          return {
+            sessions: subagentSpawnRequested
+              ? [
+                  { sessionKey: 'agent:main:main', label: 'Main' },
+                  { sessionKey: 'agent:main:subagent:new-child', label: 'New child', state: 'running' },
+                ]
+              : [
+                  { sessionKey: 'agent:main:main', label: 'Main' },
+                ],
+          };
+        }
+
+        if (params?.activeMinutes === 24 * 60) {
+          return {
+            sessions: subagentSpawnRequested
+              ? [
+                  { sessionKey: 'agent:main:main', label: 'Main' },
+                  { sessionKey: 'agent:main:subagent:new-child', label: 'New child', state: 'running' },
+                ]
+              : [
+                  { sessionKey: 'agent:main:main', label: 'Main' },
+                ],
+          };
+        }
+
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+          ],
+        };
+      }
+
+      return {};
+    });
+
+    function SpawnSubagent() {
+      const { spawnSession } = useSessionContext();
+      return (
+        <button
+          data-testid="spawn-subagent"
+          onClick={() => spawnSession({
+            kind: 'subagent',
+            task: 'Investigate issue',
+            parentSessionKey: 'agent:main:main',
+          })}
+        />
+      );
+    }
+
+    render(
+      <SessionProvider>
+        <SessionLabels />
+        <SpawnSubagent />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Main')).toBeInTheDocument();
+    });
+
+    screen.getByTestId('spawn-subagent').click();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-session').textContent).toBe('agent:main:subagent:new-child');
+      expect(screen.getByText('New child')).toBeInTheDocument();
+    });
+
+    expect(rpcMock).toHaveBeenCalledWith('sessions.list', { limit: 1000 });
+    expect(rpcMock).toHaveBeenCalledWith('sessions.list', { spawnedBy: 'agent:main:main', limit: 500 });
+  });
+
   it('marks background top-level roots unread on start and pings when chat reaches a terminal event', async () => {
     rpcMock.mockImplementation(async (method: string) => {
       if (method === 'sessions.list') {

--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -397,11 +397,6 @@ describe('SessionContext', () => {
   it('keeps a newly spawned active child session visible after the authoritative refresh omits it', async () => {
     let subagentSpawnRequested = false;
     rpcMock.mockImplementation(async (method: string, params?: Record<string, unknown>) => {
-      if (method === 'chat.send') {
-        subagentSpawnRequested = true;
-        return {};
-      }
-
       if (method === 'sessions.list') {
         if (params?.spawnedBy === 'agent:main:main') {
           return {
@@ -439,6 +434,26 @@ describe('SessionContext', () => {
       return {};
     });
 
+    globalThis.fetch = vi.fn((input: string | URL | Request) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+      if (url.includes('/api/sessions/spawn-subagent')) {
+        subagentSpawnRequested = true;
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ ok: true, sessionKey: 'agent:main:subagent:new-child' }),
+        } as Response);
+      }
+      if (url.includes('/api/server-info')) return Promise.resolve(jsonResponse({ agentName: 'Jen' }));
+      if (url.includes('/api/agentlog')) return Promise.resolve(jsonResponse([]));
+      if (url.includes('/api/sessions/hidden')) return Promise.resolve(jsonResponse({ ok: true, sessions: [] }));
+      return Promise.resolve(jsonResponse({}));
+    }) as typeof fetch;
+
     function SpawnSubagent() {
       const { spawnSession } = useSessionContext();
       return (
@@ -473,6 +488,110 @@ describe('SessionContext', () => {
 
     expect(rpcMock).toHaveBeenCalledWith('sessions.list', { limit: 1000 });
     expect(rpcMock).toHaveBeenCalledWith('sessions.list', { spawnedBy: 'agent:main:main', limit: 500 });
+  });
+
+  it('includes spawned children from non-main roots when refreshing the sessions sidebar', async () => {
+    let subagentSpawnRequested = false;
+    rpcMock.mockImplementation(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'sessions.list') {
+        if (params?.spawnedBy === 'agent:reviewer:main') {
+          return {
+            sessions: subagentSpawnRequested
+              ? [
+                  { sessionKey: 'agent:reviewer:main', label: 'Reviewer' },
+                  { sessionKey: 'agent:reviewer:subagent:new-child', label: 'Reviewer child', state: 'running' },
+                ]
+              : [
+                  { sessionKey: 'agent:reviewer:main', label: 'Reviewer' },
+                ],
+          };
+        }
+
+        if (params?.spawnedBy === 'agent:main:main') {
+          return {
+            sessions: [
+              { sessionKey: 'agent:main:main', label: 'Main' },
+            ],
+          };
+        }
+
+        if (params?.activeMinutes === 24 * 60) {
+          return {
+            sessions: subagentSpawnRequested
+              ? [
+                  { sessionKey: 'agent:reviewer:main', label: 'Reviewer' },
+                  { sessionKey: 'agent:reviewer:subagent:new-child', label: 'Reviewer child', state: 'running' },
+                ]
+              : [
+                  { sessionKey: 'agent:reviewer:main', label: 'Reviewer' },
+                ],
+          };
+        }
+
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            { sessionKey: 'agent:reviewer:main', label: 'Reviewer' },
+          ],
+        };
+      }
+
+      return {};
+    });
+
+    globalThis.fetch = vi.fn((input: string | URL | Request) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+      if (url.includes('/api/sessions/spawn-subagent')) {
+        subagentSpawnRequested = true;
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ ok: true, sessionKey: 'agent:reviewer:subagent:new-child' }),
+        } as Response);
+      }
+      if (url.includes('/api/server-info')) return Promise.resolve(jsonResponse({ agentName: 'Jen' }));
+      if (url.includes('/api/agentlog')) return Promise.resolve(jsonResponse([]));
+      if (url.includes('/api/sessions/hidden')) return Promise.resolve(jsonResponse({ ok: true, sessions: [] }));
+      return Promise.resolve(jsonResponse({}));
+    }) as typeof fetch;
+
+    function SpawnReviewerSubagent() {
+      const { spawnSession } = useSessionContext();
+      return (
+        <button
+          data-testid="spawn-reviewer-subagent"
+          onClick={() => spawnSession({
+            kind: 'subagent',
+            task: 'Investigate reviewer issue',
+            parentSessionKey: 'agent:reviewer:main',
+          })}
+        />
+      );
+    }
+
+    render(
+      <SessionProvider>
+        <SessionLabels />
+        <SpawnReviewerSubagent />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Reviewer')).toBeInTheDocument();
+    });
+
+    screen.getByTestId('spawn-reviewer-subagent').click();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('current-session').textContent).toBe('agent:reviewer:subagent:new-child');
+      expect(screen.getByText('Reviewer child')).toBeInTheDocument();
+    });
+
+    expect(rpcMock).toHaveBeenCalledWith('sessions.list', { spawnedBy: 'agent:reviewer:main', limit: 500 });
   });
 
   it('marks background top-level roots unread on start and pings when chat reaches a terminal event', async () => {

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -220,16 +220,34 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const listAuthoritativeSessions = useCallback(async () => {
     if (connectionState !== 'connected') return sessionsRef.current;
     try {
-      const [res, hiddenCronSessions, spawnedRes] = await Promise.all([
+      const [res, hiddenCronSessions] = await Promise.all([
         rpc('sessions.list', { limit: FULL_SESSIONS_LIMIT }) as Promise<SessionsListResponse>,
         fetchHiddenCronSessions(24 * 60, FULL_SESSIONS_LIMIT),
-        // Keep active child sessions visible even when the full sessions.list
-        // result lags behind the recent spawn/discovery flow.
-        rpc('sessions.list', { spawnedBy: MAIN_SESSION_KEY, limit: SESSIONS_SPAWNED_LIMIT }) as Promise<SessionsListResponse>,
       ]);
-      return mergeSessionLists(
-        mergeSessionLists(res?.sessions ?? [], hiddenCronSessions),
-        spawnedRes?.sessions ?? [],
+
+      const baseSessions = mergeSessionLists(res?.sessions ?? [], hiddenCronSessions);
+      const spawnedByRoots = new Set<string>([MAIN_SESSION_KEY]);
+      for (const rootSession of getTopLevelAgentSessions(baseSessions)) {
+        spawnedByRoots.add(getSessionKey(rootSession));
+      }
+
+      // Keep active child sessions visible even when the full sessions.list
+      // result lags behind the recent spawn/discovery flow.
+      const spawnedSessionLists = await Promise.all(
+        [...spawnedByRoots].map(async (rootSessionKey) => {
+          try {
+            const spawnedRes = await rpc('sessions.list', { spawnedBy: rootSessionKey, limit: SESSIONS_SPAWNED_LIMIT }) as SessionsListResponse;
+            return spawnedRes?.sessions ?? [];
+          } catch (err) {
+            console.debug('[SessionContext] Failed to fetch spawned sessions for root:', rootSessionKey, err);
+            return [];
+          }
+        }),
+      );
+
+      return spawnedSessionLists.reduce(
+        (acc, spawnedSessions) => mergeSessionLists(acc, spawnedSessions),
+        baseSessions,
       );
     } catch (err) {
       console.debug('[SessionContext] Failed to fetch authoritative session list:', err);

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -23,6 +23,8 @@ const IDLE_STATES = new Set(['idle', 'done', 'error', 'final', 'aborted', 'compl
 
 // Use the full session list for the sidebar so older root chats stay visible.
 const FULL_SESSIONS_LIMIT = 1000;
+const MAIN_SESSION_KEY = 'agent:main:main';
+const SESSIONS_SPAWNED_LIMIT = 500;
 
 export type SubagentCleanupMode = 'keep' | 'delete';
 
@@ -218,11 +220,17 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const listAuthoritativeSessions = useCallback(async () => {
     if (connectionState !== 'connected') return sessionsRef.current;
     try {
-      const [res, hiddenCronSessions] = await Promise.all([
+      const [res, hiddenCronSessions, spawnedRes] = await Promise.all([
         rpc('sessions.list', { limit: FULL_SESSIONS_LIMIT }) as Promise<SessionsListResponse>,
         fetchHiddenCronSessions(24 * 60, FULL_SESSIONS_LIMIT),
+        // Keep active child sessions visible even when the full sessions.list
+        // result lags behind the recent spawn/discovery flow.
+        rpc('sessions.list', { spawnedBy: MAIN_SESSION_KEY, limit: SESSIONS_SPAWNED_LIMIT }) as Promise<SessionsListResponse>,
       ]);
-      return mergeSessionLists(res?.sessions ?? [], hiddenCronSessions);
+      return mergeSessionLists(
+        mergeSessionLists(res?.sessions ?? [], hiddenCronSessions),
+        spawnedRes?.sessions ?? [],
+      );
     } catch (err) {
       console.debug('[SessionContext] Failed to fetch authoritative session list:', err);
       return sessionsRef.current;


### PR DESCRIPTION
## What

Fixes a Sessions-tab reliability bug where a newly spawned active subagent can become the current session while still being absent from the Sessions sidebar after the authoritative refresh.

## In Plain English
This PR fixes a confusing bug where Nerve could open a newly spawned subagent session but then fail to show that same session in the Sessions tab.

From the user’s perspective, it feels like the child session half-exists: you are inside it, but the sidebar does not show it. That makes the session list feel unreliable and makes spawned subagents harder to trust and manage.

This fix keeps freshly spawned child sessions visible through the refresh path so the sidebar stays consistent with the session the user is actually chatting with.

## Why

Closes #225

After `spawnSession()` discovers a new child session from the recent-window poll, it refreshes the Sessions list from the authoritative full-list path. On current `master`, that refresh can omit the just-spawned child, leaving the UI focused on a subagent session that does not appear in the Sessions tab.

## How

- supplement the authoritative Sessions refresh with a `spawnedBy: MAIN_SESSION_KEY` query
- merge those spawned-child sessions into the sidebar list before returning it
- add a focused `SessionContext` regression test for the reproduced missing-child case

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [ ] New features include tests
- [ ] UI changes include a screenshot or screen recording



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Spawned subagent child sessions now remain visible after authoritative refreshes and can become the active session for both main and non-main roots. Session discovery now includes an extra per-root refresh step and handles partial failures without dropping children.

* **Tests**
  * Added tests that simulate backend responses to validate visibility, selection, and resilience of newly spawned child sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->