### PR TITLE
feat(workspace): enable recursive watch by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,7 @@ GATEWAY_URL=http://127.0.0.1:18789
 # MEMORY_DIR=~/.openclaw/workspace/memory
 # SESSIONS_DIR=~/.openclaw/agents/main/sessions
 # USAGE_FILE=~/.openclaw/token-usage.json
+# NERVE_WATCH_WORKSPACE_RECURSIVE=false   # Disable full-workspace live file watching (default: enabled)
 
 # ─── API Keys (optional — Edge TTS is always available as a free fallback) ───
 OPENAI_API_KEY=

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -291,7 +291,7 @@ REPLICATE_BASE_URL=https://api.replicate.com/v1
 | `SESSIONS_DIR` | `~/.openclaw/agents/main/sessions/` | Session transcript directory (scanned for token usage) |
 | `USAGE_FILE` | `~/.openclaw/token-usage.json` | Persistent cumulative token usage data |
 | `NERVE_VOICE_PHRASES_PATH` | `~/.nerve/voice-phrases.json` | Override location for per-language voice phrase overrides |
-| `NERVE_WATCH_WORKSPACE_RECURSIVE` | `false` | Re-enables recursive `fs.watch` for full workspace `file.changed` SSE events outside `MEMORY.md` and `memory/`. Disabled by default to prevent Linux inotify `ENOSPC` watcher exhaustion. Memory watchers stay enabled for discovered agent workspaces even when this is `false`. |
+| `NERVE_WATCH_WORKSPACE_RECURSIVE` | `true` | Enables recursive `fs.watch` for full workspace `file.changed` SSE events outside `MEMORY.md` and `memory/`. Set this to `false` to disable full-workspace watching if you hit Linux inotify `ENOSPC` watcher exhaustion. Memory watchers stay enabled for discovered agent workspaces even when this is `false`. |
 
 ```bash
 FILE_BROWSER_ROOT=/home/user

--- a/server/lib/config.test.ts
+++ b/server/lib/config.test.ts
@@ -58,6 +58,32 @@ describe('config module', () => {
     });
   });
 
+  describe('workspaceWatchRecursive', () => {
+    it('defaults to true when env var is unset', async () => {
+      vi.resetModules();
+      delete process.env.NERVE_WATCH_WORKSPACE_RECURSIVE;
+
+      const { config } = await import('./config.js');
+      expect(config.workspaceWatchRecursive).toBe(true);
+    });
+
+    it('can be disabled explicitly with false', async () => {
+      vi.resetModules();
+      process.env.NERVE_WATCH_WORKSPACE_RECURSIVE = 'false';
+
+      const { config } = await import('./config.js');
+      expect(config.workspaceWatchRecursive).toBe(false);
+    });
+
+    it('stays enabled when set to true', async () => {
+      vi.resetModules();
+      process.env.NERVE_WATCH_WORKSPACE_RECURSIVE = 'true';
+
+      const { config } = await import('./config.js');
+      expect(config.workspaceWatchRecursive).toBe(true);
+    });
+  });
+
   describe('SESSION_COOKIE_NAME', () => {
     it('includes the port number', async () => {
       const { SESSION_COOKIE_NAME, config } = await import('./config.js');

--- a/server/lib/config.ts
+++ b/server/lib/config.ts
@@ -84,7 +84,7 @@ export const config = {
   memoryDir: process.env.MEMORY_DIR || path.join(HOME, '.openclaw', 'workspace', 'memory'),
   sessionsDir: process.env.SESSIONS_DIR || path.join(HOME, '.openclaw', 'agents', 'main', 'sessions'),
   usageFile: process.env.USAGE_FILE || path.join(HOME, '.openclaw', 'token-usage.json'),
-  workspaceWatchRecursive: process.env.NERVE_WATCH_WORKSPACE_RECURSIVE === 'true',
+  workspaceWatchRecursive: process.env.NERVE_WATCH_WORKSPACE_RECURSIVE !== 'false',
   workspaceRemote: process.env.NERVE_WORKSPACE_REMOTE === 'true',
   certPath: path.join(PROJECT_ROOT, 'certs', 'cert.pem'),
   keyPath: path.join(PROJECT_ROOT, 'certs', 'key.pem'),

--- a/server/lib/file-watcher.ts
+++ b/server/lib/file-watcher.ts
@@ -229,7 +229,7 @@ export async function startFileWatcher(): Promise<void> {
   startRootWorkspaceWatcher();
 
   if (!config.workspaceWatchRecursive) {
-    console.log('[file-watcher] Workspace recursive watch disabled (default). Set NERVE_WATCH_WORKSPACE_RECURSIVE=true to re-enable SSE file.changed events outside memory/.');
+    console.log('[file-watcher] Workspace recursive watch disabled via NERVE_WATCH_WORKSPACE_RECURSIVE=false. SSE file.changed events outside memory/ are off.');
   }
 }
 


### PR DESCRIPTION
## What
- make recursive workspace watching opt-out instead of opt-in
- keep `NERVE_WATCH_WORKSPACE_RECURSIVE=false` as the escape hatch for installs that hit watcher exhaustion
- update config tests and docs to match the new default
- add the flag to `.env.example` so the opt-out is discoverable

## Why
Right now fresh installs do not auto-detect non-memory workspace file changes unless the user discovers and enables `NERVE_WATCH_WORKSPACE_RECURSIVE=true`.

That feels backwards for the default UX. People expect workspace edits to live-update out of the box.

This flips the default while preserving an explicit off switch for environments that hit Linux inotify `ENOSPC` limits.

## Implementation
- `server/lib/config.ts`: default to `true` unless the env var is explicitly `false`
- `server/lib/file-watcher.ts`: update startup log message for the new opt-out behavior
- `server/lib/config.test.ts`: cover default-on, explicit false, and explicit true
- `docs/CONFIGURATION.md` + `.env.example`: document the new default and disable path

## Testing
- `npm run lint`
- `npm test -- server/lib/config.test.ts`
- `npm run build:server`

Note: `npm run lint` still reports pre-existing React hook dependency warnings unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recursive workspace file watching is now enabled by default, improving file change event detection across the entire workspace.

* **Documentation**
  * Updated configuration documentation; recursive watching is enabled by default and can be disabled if Linux inotify watcher resource limits are encountered.

* **Tests**
  * Added test coverage for workspace watching configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->