### PR TITLE
feat(settings): add optional hidden workspace entries toggle

### DIFF
--- a/server/routes/file-browser.test.ts
+++ b/server/routes/file-browser.test.ts
@@ -89,6 +89,34 @@ describe('file-browser routes', () => {
       expect(names).not.toContain('node_modules');
       expect(names).not.toContain('.git');
     });
+
+    it('hides hidden workspace entries by default', async () => {
+      await fs.writeFile(path.join(tmpDir, '.hidden.md'), 'secret');
+      await fs.writeFile(path.join(tmpDir, 'visible.md'), 'hello');
+
+      const app = await buildApp();
+      const res = await app.request('/api/files/tree');
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { ok: boolean; entries: Array<{ name: string }> };
+      const names = json.entries.map(e => e.name);
+
+      expect(names).toContain('visible.md');
+      expect(names).not.toContain('.hidden.md');
+    });
+
+    it('includes hidden workspace entries when showHidden=true', async () => {
+      await fs.writeFile(path.join(tmpDir, '.hidden.md'), 'secret');
+      await fs.mkdir(path.join(tmpDir, '.plans'));
+
+      const app = await buildApp();
+      const res = await app.request('/api/files/tree?showHidden=true');
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { ok: boolean; entries: Array<{ name: string }> };
+      const names = json.entries.map(e => e.name);
+
+      expect(names).toContain('.hidden.md');
+      expect(names).toContain('.plans');
+    });
   });
 
   describe('GET /api/files/resolve', () => {

--- a/server/routes/file-browser.test.ts
+++ b/server/routes/file-browser.test.ts
@@ -9,12 +9,16 @@ describe('file-browser routes', () => {
   let homeDir: string;
   let tmpDir: string;
   let researchWorkspace: string;
+  let remoteHomeDir: string;
+  let remoteWorkspace: string;
 
   beforeEach(async () => {
     vi.resetModules();
     homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'fbrowser-test-'));
     tmpDir = path.join(homeDir, '.openclaw', 'workspace');
     researchWorkspace = path.join(homeDir, '.openclaw', 'workspace-research');
+    remoteHomeDir = path.join(homeDir, 'remote-nonexistent');
+    remoteWorkspace = path.join(remoteHomeDir, '.openclaw', 'workspace');
     await fs.mkdir(tmpDir, { recursive: true });
     // Create a MEMORY.md in the tmpDir so getWorkspaceRoot returns tmpDir
     await fs.writeFile(path.join(tmpDir, 'MEMORY.md'), '# Memories\n');
@@ -25,21 +29,43 @@ describe('file-browser routes', () => {
     await fs.rm(homeDir, { recursive: true, force: true });
   });
 
-  async function buildApp(opts?: { fileBrowserRoot?: string }) {
+  async function buildApp(opts?: {
+    fileBrowserRoot?: string;
+    remote?: boolean;
+    gatewayFilesListResult?: Array<{ name: string; missing?: boolean; size?: number; updatedAtMs?: number }>;
+  }) {
     vi.resetModules();
+    vi.doUnmock('../lib/gateway-rpc.js');
+
+    const useRemote = opts?.remote ?? false;
+    const configuredHomeDir = useRemote ? remoteHomeDir : homeDir;
+    const configuredWorkspace = useRemote ? remoteWorkspace : tmpDir;
+
     vi.doMock('../lib/config.js', () => ({
       config: {
         auth: false,
         port: 3000,
         host: '127.0.0.1',
         sslPort: 3443,
-        home: homeDir,
-        memoryPath: path.join(tmpDir, 'MEMORY.md'),
-        memoryDir: path.join(tmpDir, 'memory'),
+        home: configuredHomeDir,
+        memoryPath: path.join(configuredWorkspace, 'MEMORY.md'),
+        memoryDir: path.join(configuredWorkspace, 'memory'),
         fileBrowserRoot: opts?.fileBrowserRoot ?? '',
+        workspaceRemote: false,
       },
       SESSION_COOKIE_NAME: 'nerve_session_3000',
     }));
+
+    if (useRemote) {
+      vi.doMock('../lib/gateway-rpc.js', () => ({
+        gatewayFilesList: vi.fn().mockResolvedValue(opts?.gatewayFilesListResult ?? []),
+        gatewayFilesGet: vi.fn(),
+        gatewayFilesSet: vi.fn(),
+      }));
+
+      const detectMod = await import('../lib/workspace-detect.js');
+      detectMod.clearWorkspaceDetectCache();
+    }
 
     const mod = await import('./file-browser.js');
     const app = new Hono();
@@ -116,6 +142,28 @@ describe('file-browser routes', () => {
 
       expect(names).toContain('.hidden.md');
       expect(names).toContain('.plans');
+    });
+
+    it('includes hidden workspace entries when showHidden=true via remote gateway fallback', async () => {
+      const app = await buildApp({
+        remote: true,
+        gatewayFilesListResult: [
+          { name: '.hidden.md', missing: false, size: 6, updatedAtMs: 1000 },
+          { name: '.plans', missing: false, size: 0, updatedAtMs: 1001 },
+          { name: 'visible.md', missing: false, size: 5, updatedAtMs: 1002 },
+        ],
+      });
+
+      const res = await app.request('/api/files/tree?showHidden=true');
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { ok: boolean; entries: Array<{ name: string }>; remoteWorkspace?: boolean };
+      const names = json.entries.map((e) => e.name);
+
+      expect(json.ok).toBe(true);
+      expect(json.remoteWorkspace).toBe(true);
+      expect(names).toContain('.hidden.md');
+      expect(names).toContain('.plans');
+      expect(names).toContain('visible.md');
     });
   });
 

--- a/server/routes/file-browser.ts
+++ b/server/routes/file-browser.ts
@@ -89,6 +89,7 @@ async function listDirectory(
   dirPath: string,
   basePath: string,
   depth: number,
+  showHidden: boolean,
 ): Promise<TreeEntry[]> {
   const entries: TreeEntry[] = [];
 
@@ -114,7 +115,7 @@ async function listDirectory(
       // Internal metadata file for restore bookkeeping.
       if (item.name === '.index.json') continue;
     // FILE_BROWSER_ROOT: Show all files when custom root is set, but always hide .trash folder
-    } else if (!config.fileBrowserRoot && item.name.startsWith('.') && item.name !== '.nerveignore' && item.name !== '.trash') {
+    } else if (!showHidden && item.name.startsWith('.') && item.name !== '.nerveignore' && item.name !== '.trash') {
       continue;
     } else if (config.fileBrowserRoot && item.name === '.trash') {
       continue;
@@ -129,7 +130,7 @@ async function listDirectory(
         path: relativePath,
         type: 'directory',
         children: depth > 1
-          ? await listDirectory(fullPath, relativePath, depth - 1)
+          ? await listDirectory(fullPath, relativePath, depth - 1, showHidden)
           : null,
       });
     } else if (item.isFile()) {
@@ -186,6 +187,7 @@ app.get('/api/files/tree', async (c) => {
   const root = workspace.workspaceRoot;
   const subPath = c.req.query('path') || '';
   const depth = Math.min(Math.max(Number(c.req.query('depth')) || 1, 1), 5);
+  const showHidden = c.req.query('showHidden') === 'true';
 
   // Check if workspace is local
   const isLocal = await isWorkspaceLocal(root);
@@ -213,7 +215,7 @@ app.get('/api/files/tree', async (c) => {
       targetDir = root;
     }
 
-    const entries = await listDirectory(targetDir, subPath, depth);
+    const entries = await listDirectory(targetDir, subPath, depth, showHidden);
 
     return c.json({
       ok: true,

--- a/server/routes/file-browser.ts
+++ b/server/routes/file-browser.ts
@@ -114,7 +114,7 @@ async function listDirectory(
     if (inTrash) {
       // Internal metadata file for restore bookkeeping.
       if (item.name === '.index.json') continue;
-    // FILE_BROWSER_ROOT: Show all files when custom root is set, but always hide .trash folder
+    // Hide dotfiles unless showHidden=true, except for .nerveignore and .trash; custom roots still hide .trash.
     } else if (!showHidden && item.name.startsWith('.') && item.name !== '.nerveignore' && item.name !== '.trash') {
       continue;
     } else if (config.fileBrowserRoot && item.name === '.trash') {
@@ -162,9 +162,13 @@ function handleFileOpError(c: Context, err: unknown) {
 }
 
 /** Convert gateway file list to TreeEntry format for the UI. */
-function gatewayFilesToTree(files: Awaited<ReturnType<typeof gatewayFilesList>>): TreeEntry[] {
+function gatewayFilesToTree(
+  files: Awaited<ReturnType<typeof gatewayFilesList>>,
+  showHidden: boolean,
+): TreeEntry[] {
   return files
     .filter((f) => !f.missing)
+    .filter((f) => showHidden || !f.name.startsWith('.') || f.name === '.nerveignore' || f.name === '.trash')
     .map((f) => ({
       name: f.name,
       path: f.name,
@@ -245,7 +249,7 @@ app.get('/api/files/tree', async (c) => {
 
   try {
     const remoteFiles = await gatewayFilesList(workspace.agentId);
-    const entries = gatewayFilesToTree(remoteFiles);
+    const entries = gatewayFilesToTree(remoteFiles, showHidden);
     return c.json({
       ok: true,
       root: '.',

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -36,6 +36,8 @@ interface SettingsContextValue {
   toggleEvents: () => void;
   logVisible: boolean;
   toggleLog: () => void;
+  showHiddenWorkspaceEntries: boolean;
+  toggleShowHiddenWorkspaceEntries: () => void;
   theme: ThemeName;
   setTheme: (theme: ThemeName) => void;
   font: FontName;
@@ -117,6 +119,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   });
   const [logVisible, setLogVisible] = useState(() => {
     return localStorage.getItem('nerve:showLog') === 'true'; // Default to false (hidden)
+  });
+  const [showHiddenWorkspaceEntries, setShowHiddenWorkspaceEntries] = useState(() => {
+    return localStorage.getItem('nerve:showHiddenWorkspaceEntries') === 'true';
   });
   const [theme, setThemeState] = useState<ThemeName>(() => {
     const saved = localStorage.getItem('oc-theme') as ThemeName | null;
@@ -288,6 +293,14 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
+  const toggleShowHiddenWorkspaceEntries = useCallback(() => {
+    setShowHiddenWorkspaceEntries(prev => {
+      const next = !prev;
+      localStorage.setItem('nerve:showHiddenWorkspaceEntries', String(next));
+      return next;
+    });
+  }, []);
+
   const setTheme = useCallback((newTheme: ThemeName) => {
     setThemeState(newTheme);
     localStorage.setItem('oc-theme', newTheme);
@@ -339,6 +352,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     toggleEvents,
     logVisible,
     toggleLog,
+    showHiddenWorkspaceEntries,
+    toggleShowHiddenWorkspaceEntries,
     theme,
     setTheme,
     font,
@@ -353,7 +368,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     wakeWordEnabled, handleToggleWakeWord, handleWakeWordState,
     liveTranscriptionPreview, toggleLiveTranscriptionPreview,
     speak, panelRatio, setPanelRatio, telemetryVisible, toggleTelemetry,
-    eventsVisible, toggleEvents, logVisible, toggleLog, theme, setTheme, font, setFont,
+    eventsVisible, toggleEvents, logVisible, toggleLog, showHiddenWorkspaceEntries, toggleShowHiddenWorkspaceEntries, theme, setTheme, font, setFont,
     fontSize, setFontSize, editorFontSize, setEditorFontSize,
   ]);
 

--- a/src/features/file-browser/FileTreePanel.test.tsx
+++ b/src/features/file-browser/FileTreePanel.test.tsx
@@ -9,6 +9,13 @@ vi.mock('./hooks/useFileTree', () => ({
   useFileTree: vi.fn(),
 }));
 
+// Mock settings context
+vi.mock('@/contexts/SettingsContext', () => ({
+  useSettings: () => ({
+    showHiddenWorkspaceEntries: false,
+  }),
+}));
+
 // Mock the ConfirmDialog component
 vi.mock('../../components/ConfirmDialog', () => ({
   ConfirmDialog: ({ open, title, message, onConfirm, onCancel }: {

--- a/src/features/file-browser/FileTreePanel.tsx
+++ b/src/features/file-browser/FileTreePanel.tsx
@@ -10,6 +10,7 @@ import { PanelLeftClose, RefreshCw, Pencil, Trash2, RotateCcw, X } from 'lucide-
 import { FileTreeNode } from './FileTreeNode';
 import { useFileTree } from './hooks/useFileTree';
 import { ConfirmDialog } from '../../components/ConfirmDialog';
+import { useSettings } from '@/contexts/SettingsContext';
 import type { TreeEntry } from './types';
 
 const MIN_WIDTH = 160;
@@ -107,10 +108,11 @@ export function FileTreePanel({
   onCollapseChange,
   collapsed,
 }: FileTreePanelProps) {
+  const { showHiddenWorkspaceEntries } = useSettings();
   const {
     entries, loading, error, expandedPaths, selectedPath,
     loadingPaths, workspaceInfo, toggleDirectory, selectFile, refresh, handleFileChange, revealPath,
-  } = useFileTree(workspaceAgentId);
+  } = useFileTree(workspaceAgentId, showHiddenWorkspaceEntries);
 
   // React to external file changes. Sequence keeps repeated same-path events distinct,
   // and agentId prevents a stale event from one workspace from replaying in another.

--- a/src/features/file-browser/hooks/useFileTree.test.ts
+++ b/src/features/file-browser/hooks/useFileTree.test.ts
@@ -419,6 +419,93 @@ describe('useFileTree', () => {
 
       expect(mockLocalStorage.getItem).toHaveBeenCalledWith(getWorkspaceStorageKey('file-tree-expanded', 'main'));
     });
+
+    it('includes showHidden in tree requests when enabled', async () => {
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          entries: [],
+          workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+        }),
+      } as Response);
+
+      renderHook(() => useFileTree('main', true));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalled();
+      });
+
+      const requestUrl = getRequestUrl(mockFetch.mock.calls[0]![0]);
+      expect(requestUrl.searchParams.get('showHidden')).toBe('true');
+    });
+
+    it('reloads the tree when hidden entry visibility changes', async () => {
+      const mockFetch = vi.mocked(fetch);
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            entries: [
+              { name: 'src', path: 'src', type: 'directory' as const, children: null },
+            ],
+            workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+          }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            entries: [
+              { name: '.plans', path: '.plans', type: 'directory' as const, children: null },
+              { name: 'src', path: 'src', type: 'directory' as const, children: null },
+            ],
+            workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+          }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            entries: [
+              { name: 'demo.md', path: '.plans/demo.md', type: 'file' as const, children: null },
+            ],
+          }),
+        } as Response);
+
+      const { result, rerender } = renderHook(
+        ({ showHidden }: { showHidden: boolean }) => useFileTree('main', showHidden),
+        { initialProps: { showHidden: false } },
+      );
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+        expect(result.current.entries.map((entry) => entry.path)).toEqual(['src']);
+      });
+
+      rerender({ showHidden: true });
+
+      await waitFor(() => {
+        expect(result.current.entries.map((entry) => entry.path)).toEqual(['.plans', 'src']);
+      });
+
+      await act(async () => {
+        await result.current.revealPath('.plans/demo.md', 'file');
+      });
+
+      await waitFor(() => {
+        expect(result.current.expandedPaths.has('.plans')).toBe(true);
+        expect(result.current.selectedPath).toBe('.plans/demo.md');
+      });
+
+      const reloadedRootUrl = getRequestUrl(mockFetch.mock.calls[1]![0]);
+      const revealUrl = getRequestUrl(mockFetch.mock.calls[2]![0]);
+      expect(reloadedRootUrl.searchParams.get('showHidden')).toBe('true');
+      expect(revealUrl.searchParams.get('showHidden')).toBe('true');
+      expect(revealUrl.searchParams.get('path')).toBe('.plans');
+    });
   });
 
   describe('return object includes workspaceInfo', () => {

--- a/src/features/file-browser/hooks/useFileTree.ts
+++ b/src/features/file-browser/hooks/useFileTree.ts
@@ -98,14 +98,15 @@ function findEntry(entries: TreeEntry[], targetPath: string): TreeEntry | null {
   return null;
 }
 
-function buildTreeUrl(dirPath: string, agentId: string): string {
+function buildTreeUrl(dirPath: string, agentId: string, showHiddenEntries: boolean): string {
   const params = new URLSearchParams({ depth: '1', agentId });
+  if (showHiddenEntries) params.set('showHidden', 'true');
   if (dirPath) params.set('path', dirPath);
   return `/api/files/tree?${params.toString()}`;
 }
 
 /** Hook for managing file tree state with workspace info and persistence. */
-export function useFileTree(agentId = DEFAULT_AGENT_ID) {
+export function useFileTree(agentId = DEFAULT_AGENT_ID, showHiddenEntries = false) {
   const scopedAgentId = normalizeAgentId(agentId);
   const [entries, setEntries] = useState<TreeEntry[]>([]);
   const entriesRef = useRef<TreeEntry[]>([]);
@@ -158,7 +159,7 @@ export function useFileTree(agentId = DEFAULT_AGENT_ID) {
     requestAgentId = agentIdRef.current,
   ): Promise<TreeEntry[] | null> => {
     try {
-      const res = await fetch(buildTreeUrl(dirPath, requestAgentId));
+      const res = await fetch(buildTreeUrl(dirPath, requestAgentId, showHiddenEntries));
       if (!res.ok) {
         if (dirPath && (res.status === 400 || res.status === 404) && agentIdRef.current === requestAgentId) {
           setExpandedPaths((prev) => {
@@ -184,7 +185,7 @@ export function useFileTree(agentId = DEFAULT_AGENT_ID) {
     } catch {
       return null;
     }
-  }, []);
+  }, [showHiddenEntries]);
 
   // Initial load and agent changes
   const loadRoot = useCallback(async (targetAgentId = scopedAgentId) => {

--- a/src/features/settings/AppearanceSettings.tsx
+++ b/src/features/settings/AppearanceSettings.tsx
@@ -42,7 +42,22 @@ const FONT_SIZE_OPTIONS = [
 
 /** Settings section for theme, font, font size, and panel visibility. */
 export function AppearanceSettings() {
-  const { eventsVisible, toggleEvents, logVisible, toggleLog, theme, setTheme, font, setFont, fontSize, setFontSize, editorFontSize, setEditorFontSize } = useSettings();
+  const {
+    eventsVisible,
+    toggleEvents,
+    logVisible,
+    toggleLog,
+    showHiddenWorkspaceEntries,
+    toggleShowHiddenWorkspaceEntries,
+    theme,
+    setTheme,
+    font,
+    setFont,
+    fontSize,
+    setFontSize,
+    editorFontSize,
+    setEditorFontSize,
+  } = useSettings();
 
   const handleThemeChange = (next: string) => {
     setTheme(next as ThemeName);
@@ -174,6 +189,22 @@ export function AppearanceSettings() {
           checked={logVisible}
           onCheckedChange={toggleLog}
           aria-label="Toggle log panel visibility"
+        />
+      </div>
+
+      {/* Hidden workspace entries visibility */}
+      <div className="cockpit-row items-start justify-between">
+        <div className="flex items-center gap-3">
+          <Eye size={14} className={showHiddenWorkspaceEntries ? 'text-primary' : 'text-muted-foreground'} aria-hidden="true" />
+          <div className="flex flex-col">
+            <span className="text-sm font-medium text-foreground" id="hidden-workspace-entries-label">Show hidden workspace entries</span>
+            <span className="text-xs text-muted-foreground">Reveal dotfiles and dotfolders in the workspace browser when you need them.</span>
+          </div>
+        </div>
+        <Switch
+          checked={showHiddenWorkspaceEntries}
+          onCheckedChange={toggleShowHiddenWorkspaceEntries}
+          aria-label="Toggle hidden workspace entries visibility"
         />
       </div>
 


### PR DESCRIPTION
## What

Adds an optional hidden-workspace-entries toggle for the Nerve workspace browser.

## In Plain English
This PR gives advanced users a simple way to see hidden files and folders in the workspace browser without changing the default experience for everyone else.

For most people, hiding dotfiles and other hidden entries keeps the UI cleaner. But for developer-heavy workflows, those hidden entries often contain important repo metadata, config files, and documentation that users do need to reach sometimes.

This adds an opt-in toggle so hidden entries stay out of the way by default, but become available when someone explicitly wants deeper workspace access.

- introduces a user-facing setting for showing hidden workspace files/folders
- defaults it to **off** so existing users see no UI change
- includes hidden entries in workspace tree loading when enabled
- keeps normal open/reveal flows working for hidden entries while enabled

Closes #245.

## Why

Nerve's default hidden-entry behavior is reasonable for most users, but some developer workflows need access to dotfiles, hidden documentation folders, repo metadata, and other hidden workspace artifacts.

This slice adds that capability in a generalized, opt-in way instead of baking special handling for any one hidden path. That preserves the uncluttered default UI while giving advanced users a way to opt into deeper workspace browsing.

## How

- added `showHiddenWorkspaceEntries` state to settings with localStorage persistence
- exposed the setting in Appearance settings as **Show hidden workspace entries**
- threaded the setting through workspace tree loading
- updated server-side file-tree listing to respect the hidden-entry flag
- ensured reveal/open flows stay coherent for hidden entries when the setting is enabled
- added focused tests for tree loading, panel behavior, and server-side hidden-entry handling

## Validation

- `npx vitest run server/routes/file-browser.test.ts src/features/file-browser/hooks/useFileTree.test.ts src/features/file-browser/FileTreePanel.test.tsx`
- `npm run build`
- local dogfood:
  - hidden entries stay hidden by default
  - enabling the toggle shows hidden entries in the workspace tree
  - disabling it hides them again
  - persisted behavior works across restart/reopen

## Notes / out of scope

- This PR does not redesign broader permissions or search/index behavior for hidden entries.

## Type of change

- ✨ New feature


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new setting to control visibility of hidden workspace entries (dotfiles) in the file browser
  * A toggle switch is now available in Appearance Settings to manage hidden file visibility

* **Tests**
  * Added tests covering hidden file filtering behavior and visibility toggle scenarios across local and remote file access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->