### PR TITLE
feat: add Beads viewer UI and explicit bead:// link support

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -47,6 +47,7 @@ import voicePhrasesRoutes from './routes/voice-phrases.js';
 import fileBrowserRoutes from './routes/file-browser.js';
 import uploadReferenceRoutes from './routes/upload-reference.js';
 import kanbanRoutes from './routes/kanban.js';
+import beadsRoutes from './routes/beads.js';
 // activity routes removed — tab dropped from workspace panel
 
 const app = new Hono();
@@ -89,7 +90,7 @@ const routes = [
   codexLimitsRoutes, claudeCodeLimitsRoutes, versionRoutes, versionCheckRoutes,
   gatewayRoutes, connectDefaultsRoutes,
   workspaceRoutes, cronsRoutes, sessionsRoutes, skillsRoutes, filesRoutes, apiKeysRoutes,
-  voicePhrasesRoutes, fileBrowserRoutes, uploadReferenceRoutes, channelsRoutes, kanbanRoutes,
+  voicePhrasesRoutes, fileBrowserRoutes, uploadReferenceRoutes, channelsRoutes, kanbanRoutes, beadsRoutes,
 ];
 for (const route of routes) app.route('/', route);
 

--- a/server/lib/beads.test.ts
+++ b/server/lib/beads.test.ts
@@ -1,0 +1,58 @@
+import path from 'node:path';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('./plans.js', () => ({
+  findRepoPlanByBeadId: vi.fn(),
+}));
+
+vi.mock('./agent-workspace.js', () => ({
+  resolveAgentWorkspace: vi.fn((agentId?: string) => ({
+    agentId: agentId?.trim() || 'main',
+    workspaceRoot: agentId?.trim() === 'research'
+      ? '/workspace-research'
+      : '/workspace',
+    memoryPath: '/workspace/MEMORY.md',
+    memoryDir: '/workspace/memory',
+  })),
+}));
+
+import { BeadAdapterError, resolveBeadLookupRepoRoot } from './beads.js';
+
+describe('resolveBeadLookupRepoRoot', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('defaults legacy lookup to process cwd', () => {
+    const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/repo/nerve');
+    expect(resolveBeadLookupRepoRoot()).toBe('/repo/nerve');
+    cwdSpy.mockRestore();
+  });
+
+  it('uses explicit absolute repo roots directly', () => {
+    expect(resolveBeadLookupRepoRoot({ targetPath: '/repos/demo' })).toBe('/repos/demo');
+  });
+
+  it('normalizes explicit .beads targets to the owning repo root', () => {
+    expect(resolveBeadLookupRepoRoot({ targetPath: '/repos/demo/.beads' })).toBe('/repos/demo');
+  });
+
+  it('resolves relative explicit targets against the current markdown document directory', () => {
+    expect(resolveBeadLookupRepoRoot({
+      targetPath: '../projects/demo/.beads',
+      currentDocumentPath: 'docs/specs/links.md',
+    })).toBe(path.resolve('/workspace', 'docs/projects/demo'));
+  });
+
+  it('uses the scoped workspace root when resolving relative explicit targets', () => {
+    expect(resolveBeadLookupRepoRoot({
+      targetPath: './repos/demo',
+      currentDocumentPath: 'notes/beads.md',
+      workspaceAgentId: 'research',
+    })).toBe(path.resolve('/workspace-research', 'notes/repos/demo'));
+  });
+
+  it('rejects relative explicit targets when no current document path is available', () => {
+    expect(() => resolveBeadLookupRepoRoot({ targetPath: '../projects/demo' })).toThrow(BeadAdapterError);
+  });
+});

--- a/server/lib/beads.ts
+++ b/server/lib/beads.ts
@@ -1,0 +1,274 @@
+import { execFile as execFileCallback } from 'node:child_process';
+import { accessSync, constants } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { findRepoPlanByBeadId } from './plans.js';
+import { resolveAgentWorkspace } from './agent-workspace.js';
+
+const execFile = promisify(execFileCallback);
+const BD_TIMEOUT_MS = 15_000;
+const BD_MAX_BUFFER_BYTES = 4 * 1024 * 1024;
+
+export class BeadNotFoundError extends Error {
+  constructor(beadId: string) {
+    super(`Bead not found: ${beadId}`);
+    this.name = 'BeadNotFoundError';
+  }
+}
+
+export class BeadAdapterError extends Error {
+  stderr: string;
+
+  constructor(message: string, stderr = '') {
+    super(message);
+    this.name = 'BeadAdapterError';
+    this.stderr = stderr;
+  }
+}
+
+export interface BeadRelationSummary {
+  id: string;
+  title: string | null;
+  status: string | null;
+  dependencyType: string | null;
+}
+
+export interface BeadLinkedPlanSummary {
+  path: string;
+  title: string;
+  planId: string | null;
+  archived: boolean;
+  status: string | null;
+  updatedAt: number;
+}
+
+export interface BeadDetail {
+  id: string;
+  title: string;
+  notes: string | null;
+  status: string | null;
+  priority: number | null;
+  issueType: string | null;
+  owner: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+  closedAt: string | null;
+  closeReason: string | null;
+  dependencies: BeadRelationSummary[];
+  dependents: BeadRelationSummary[];
+  linkedPlan: BeadLinkedPlanSummary | null;
+}
+
+export interface BeadLookupOptions {
+  targetPath?: string;
+  currentDocumentPath?: string;
+  workspaceAgentId?: string;
+}
+
+interface RawBeadRelation {
+  id?: unknown;
+  title?: unknown;
+  status?: unknown;
+  dependency_type?: unknown;
+}
+
+interface RawBeadRecord {
+  id?: unknown;
+  title?: unknown;
+  notes?: unknown;
+  status?: unknown;
+  priority?: unknown;
+  issue_type?: unknown;
+  owner?: unknown;
+  created_at?: unknown;
+  updated_at?: unknown;
+  closed_at?: unknown;
+  close_reason?: unknown;
+  dependencies?: RawBeadRelation[];
+  dependents?: RawBeadRelation[];
+}
+
+function normalizeString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function normalizeNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function getPreferredLocalBinDirs(): string[] {
+  const home = process.env.HOME || os.homedir();
+  return [
+    path.join(home, '.local', 'bin'),
+    path.join(home, '.npm-global', 'bin'),
+    path.join(home, '.volta', 'bin'),
+    path.join(home, '.bun', 'bin'),
+  ];
+}
+
+function buildRuntimePath(basePath?: string): string {
+  const segments = [...getPreferredLocalBinDirs(), ...(basePath || '').split(':').filter(Boolean)];
+  return [...new Set(segments)].join(':');
+}
+
+function resolveBdBin(): string {
+  if (process.env.BD_BIN?.trim()) return process.env.BD_BIN.trim();
+
+  for (const dir of getPreferredLocalBinDirs()) {
+    const candidate = path.join(dir, 'bd');
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // continue
+    }
+  }
+
+  return 'bd';
+}
+
+function parseJsonPayload(stdout: string): unknown {
+  const trimmed = stdout.trim();
+  if (!trimmed) return [];
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    // Fall through to warning-tolerant parsing.
+  }
+
+  for (let index = 0; index < trimmed.length; index += 1) {
+    const ch = trimmed[index];
+    if (ch !== '{' && ch !== '[') continue;
+    try {
+      return JSON.parse(trimmed.slice(index));
+    } catch {
+      // continue
+    }
+  }
+
+  throw new BeadAdapterError('Failed to parse bd JSON output');
+}
+
+function normalizeRelations(value: unknown): BeadRelationSummary[] {
+  if (!Array.isArray(value)) return [];
+
+  return value.flatMap((entry) => {
+    const relation = entry as RawBeadRelation;
+    const id = normalizeString(relation.id);
+    if (!id) return [];
+    return [{
+      id,
+      title: normalizeString(relation.title),
+      status: normalizeString(relation.status),
+      dependencyType: normalizeString(relation.dependency_type),
+    } satisfies BeadRelationSummary];
+  });
+}
+
+function normalizeBeadRepoRoot(repoRoot: string): string {
+  const trimmed = repoRoot.trim();
+  if (!trimmed) return trimmed;
+  return path.basename(trimmed) === '.beads' ? path.dirname(trimmed) : trimmed;
+}
+
+export function resolveBeadLookupRepoRoot(options: BeadLookupOptions = {}): string {
+  if (!options.targetPath?.trim()) {
+    return process.cwd();
+  }
+
+  const targetPath = options.targetPath.trim();
+  if (path.isAbsolute(targetPath)) {
+    return normalizeBeadRepoRoot(path.normalize(targetPath));
+  }
+
+  const currentDocumentPath = options.currentDocumentPath?.trim();
+  if (!currentDocumentPath) {
+    throw new BeadAdapterError('Relative explicit bead URIs require a current document path');
+  }
+
+  const workspaceRoot = resolveAgentWorkspace(options.workspaceAgentId).workspaceRoot;
+  const absoluteDocumentPath = path.isAbsolute(currentDocumentPath)
+    ? currentDocumentPath
+    : path.resolve(workspaceRoot, currentDocumentPath);
+
+  return normalizeBeadRepoRoot(path.resolve(path.dirname(absoluteDocumentPath), targetPath));
+}
+
+export async function getBeadDetail(beadId: string, options: BeadLookupOptions = {}): Promise<BeadDetail> {
+  const normalizedBeadId = beadId.trim();
+  if (!normalizedBeadId) {
+    throw new BeadNotFoundError(beadId);
+  }
+
+  const repoRoot = resolveBeadLookupRepoRoot(options);
+
+  let stdout = '';
+  let stderr = '';
+
+  try {
+    const result = await execFile(resolveBdBin(), ['show', normalizedBeadId, '--json'], {
+      cwd: repoRoot,
+      timeout: BD_TIMEOUT_MS,
+      maxBuffer: BD_MAX_BUFFER_BYTES,
+      env: {
+        ...process.env,
+        PATH: buildRuntimePath(process.env.PATH),
+      },
+    });
+    stdout = result.stdout;
+    stderr = result.stderr;
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException & { stderr?: string; code?: string; killed?: boolean; signal?: string };
+    const stderrLine = (err.stderr || '').trim().split('\n').find(Boolean) || '';
+
+    if (err.code === 'ENOENT') {
+      throw new BeadAdapterError('bd CLI not found in PATH', stderrLine);
+    }
+
+    if (err.killed && err.signal === 'SIGTERM') {
+      throw new BeadAdapterError(`bd show timed out after ${BD_TIMEOUT_MS}ms`, stderrLine);
+    }
+
+    if (stderrLine.toLowerCase().includes('not found') || stderrLine.toLowerCase().includes('no issue')) {
+      throw new BeadNotFoundError(normalizedBeadId);
+    }
+
+    throw new BeadAdapterError(stderrLine || err.message || 'Failed to read bead', stderrLine);
+  }
+
+  const payload = parseJsonPayload(stdout || stderr);
+  const records = Array.isArray(payload) ? payload : [payload];
+  const raw = records.find((entry) => normalizeString((entry as RawBeadRecord)?.id) === normalizedBeadId) as RawBeadRecord | undefined;
+
+  if (!raw || !normalizeString(raw.id) || !normalizeString(raw.title)) {
+    throw new BeadNotFoundError(normalizedBeadId);
+  }
+
+  const linkedPlan = await findRepoPlanByBeadId(normalizedBeadId, repoRoot);
+
+  return {
+    id: normalizeString(raw.id) ?? normalizedBeadId,
+    title: normalizeString(raw.title) ?? normalizedBeadId,
+    notes: normalizeString(raw.notes),
+    status: normalizeString(raw.status),
+    priority: normalizeNumber(raw.priority),
+    issueType: normalizeString(raw.issue_type),
+    owner: normalizeString(raw.owner),
+    createdAt: normalizeString(raw.created_at),
+    updatedAt: normalizeString(raw.updated_at),
+    closedAt: normalizeString(raw.closed_at),
+    closeReason: normalizeString(raw.close_reason),
+    dependencies: normalizeRelations(raw.dependencies),
+    dependents: normalizeRelations(raw.dependents),
+    linkedPlan: linkedPlan ? {
+      path: linkedPlan.path,
+      title: linkedPlan.title,
+      planId: linkedPlan.planId,
+      archived: linkedPlan.archived,
+      status: linkedPlan.status,
+      updatedAt: linkedPlan.updatedAt,
+    } : null,
+  };
+}

--- a/server/lib/plans.ts
+++ b/server/lib/plans.ts
@@ -1,0 +1,186 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const PLAN_ROOT_NAME = '.plans';
+
+function normalizeRepoRoot(repoRoot?: string): string {
+  return path.resolve(repoRoot || process.cwd());
+}
+
+export function getPlansRoot(repoRoot?: string): string {
+  return path.resolve(normalizeRepoRoot(repoRoot), PLAN_ROOT_NAME);
+}
+
+function isMarkdownFile(name: string): boolean {
+  return name.toLowerCase().endsWith('.md');
+}
+
+export function isArchivedPlanPath(relativePath: string): boolean {
+  return relativePath.split(/[\\/]+/).filter(Boolean).includes('archive');
+}
+
+function stripWrappingQuotes(value: string): string {
+  const trimmed = value.trim();
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parsePlanContent(content: string): {
+  frontmatter: {
+    plan_id?: string;
+    plan_title?: string;
+    status?: string;
+    bead_ids?: string[];
+  };
+  body: string;
+} {
+  if (!content.startsWith('---\n')) {
+    return { frontmatter: {}, body: content };
+  }
+
+  const end = content.indexOf('\n---\n', 4);
+  if (end === -1) {
+    return { frontmatter: {}, body: content };
+  }
+
+  const rawFrontmatter = content.slice(4, end);
+  const body = content.slice(end + 5);
+  const frontmatter: {
+    plan_id?: string;
+    plan_title?: string;
+    status?: string;
+    bead_ids?: string[];
+  } = {};
+  let activeArrayKey: 'bead_ids' | null = null;
+
+  for (const line of rawFrontmatter.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+
+    const arrayMatch = line.match(/^\s+-\s+(.*)$/);
+    if (arrayMatch && activeArrayKey === 'bead_ids') {
+      const next = stripWrappingQuotes(arrayMatch[1] ?? '');
+      if (!frontmatter.bead_ids) frontmatter.bead_ids = [];
+      if (next) frontmatter.bead_ids.push(next);
+      continue;
+    }
+
+    const keyValueMatch = line.match(/^([A-Za-z0-9_]+):\s*(.*)$/);
+    if (!keyValueMatch) {
+      activeArrayKey = null;
+      continue;
+    }
+
+    const [, key, rawValue] = keyValueMatch;
+    const value = rawValue.trim();
+    if (key === 'bead_ids') {
+      activeArrayKey = 'bead_ids';
+      if (!value) {
+        frontmatter.bead_ids = [];
+      } else if (value.startsWith('[') && value.endsWith(']')) {
+        frontmatter.bead_ids = value.slice(1, -1)
+          .split(',')
+          .map((item) => stripWrappingQuotes(item))
+          .filter(Boolean);
+      } else {
+        frontmatter.bead_ids = [stripWrappingQuotes(value)].filter(Boolean);
+      }
+      continue;
+    }
+
+    activeArrayKey = null;
+    if (key === 'plan_id' || key === 'plan_title' || key === 'status') {
+      frontmatter[key] = stripWrappingQuotes(value);
+    }
+  }
+
+  return { frontmatter, body };
+}
+
+function extractPlanTitle(content: string, frontmatter: { plan_title?: string }): string {
+  if (frontmatter.plan_title?.trim()) return frontmatter.plan_title.trim();
+
+  const { body } = parsePlanContent(content);
+  for (const line of body.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (trimmed.startsWith('# ')) return trimmed.slice(2).trim();
+  }
+
+  return 'Untitled plan';
+}
+
+async function collectPlanFiles(dirPath: string, relativeDir = ''): Promise<string[]> {
+  const items = await fs.readdir(dirPath, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const item of items) {
+    const childRelative = relativeDir ? path.posix.join(relativeDir, item.name) : item.name;
+    const childAbsolute = path.join(dirPath, item.name);
+
+    if (item.isDirectory()) {
+      files.push(...await collectPlanFiles(childAbsolute, childRelative));
+      continue;
+    }
+
+    if (item.isFile() && isMarkdownFile(item.name)) {
+      files.push(path.posix.join(PLAN_ROOT_NAME, childRelative));
+    }
+  }
+
+  return files;
+}
+
+export interface RepoPlanSummary {
+  path: string;
+  title: string;
+  status: string | null;
+  planId: string | null;
+  beadIds: string[];
+  archived: boolean;
+  updatedAt: number;
+}
+
+export async function listRepoPlans(repoRoot?: string): Promise<RepoPlanSummary[]> {
+  const plansRoot = getPlansRoot(repoRoot);
+
+  try {
+    const stat = await fs.stat(plansRoot);
+    if (!stat.isDirectory()) return [];
+  } catch {
+    return [];
+  }
+
+  const relativePaths = await collectPlanFiles(plansRoot);
+  const plans = await Promise.all(relativePaths.map(async (relativePath) => {
+    const absolutePath = path.resolve(normalizeRepoRoot(repoRoot), relativePath);
+    const [content, stat] = await Promise.all([
+      fs.readFile(absolutePath, 'utf-8'),
+      fs.stat(absolutePath),
+    ]);
+    const parsed = parsePlanContent(content);
+    return {
+      path: relativePath,
+      title: extractPlanTitle(content, parsed.frontmatter),
+      status: parsed.frontmatter.status?.trim() || null,
+      planId: parsed.frontmatter.plan_id?.trim() || null,
+      beadIds: parsed.frontmatter.bead_ids ?? [],
+      archived: isArchivedPlanPath(relativePath),
+      updatedAt: Math.floor(stat.mtimeMs),
+    } satisfies RepoPlanSummary;
+  }));
+
+  return plans.sort((left, right) => {
+    if (left.archived !== right.archived) return left.archived ? 1 : -1;
+    return right.updatedAt - left.updatedAt;
+  });
+}
+
+export async function findRepoPlanByBeadId(beadId: string, repoRoot?: string): Promise<RepoPlanSummary | null> {
+  const normalizedBeadId = beadId.trim();
+  if (!normalizedBeadId) return null;
+
+  const plans = await listRepoPlans(repoRoot);
+  return plans.find((plan) => plan.beadIds.includes(normalizedBeadId)) ?? null;
+}

--- a/server/routes/beads.test.ts
+++ b/server/routes/beads.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+
+const getBeadDetailMock = vi.fn();
+
+vi.mock('../lib/beads.js', () => ({
+  getBeadDetail: (...args: unknown[]) => getBeadDetailMock(...args),
+  BeadNotFoundError: class BeadNotFoundError extends Error {},
+  BeadAdapterError: class BeadAdapterError extends Error {},
+}));
+
+describe('beads routes', () => {
+  beforeEach(() => {
+    getBeadDetailMock.mockReset();
+  });
+
+  async function buildApp() {
+    vi.resetModules();
+    const mod = await import('./beads.js');
+    const app = new Hono();
+    app.route('/', mod.default);
+    return app;
+  }
+
+  it('returns bead detail for a known bead id', async () => {
+    getBeadDetailMock.mockResolvedValue({
+      id: 'nerve-fms2',
+      title: 'Implement read-only bead viewer tab foundation',
+      notes: 'Open a bead viewer tab.',
+      status: 'in_progress',
+      priority: 1,
+      issueType: 'task',
+      owner: 'Derrick',
+      createdAt: '2026-04-06T13:23:33Z',
+      updatedAt: '2026-04-06T13:26:10Z',
+      closedAt: null,
+      closeReason: null,
+      dependencies: [{ id: 'nerve-qkdo', title: 'Create branch', status: 'closed', dependencyType: 'blocks' }],
+      dependents: [],
+      linkedPlan: {
+        path: '.plans/2026-04-06-bead-viewer-tab-foundation-execution.md',
+        title: 'Bead viewer tab foundation',
+        planId: 'plan-bead-viewer-tab-foundation-execution',
+        archived: false,
+        status: 'In Progress',
+        updatedAt: 123,
+      },
+    });
+
+    const app = await buildApp();
+    const res = await app.request('/api/beads/nerve-fms2');
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      ok: true,
+      bead: expect.objectContaining({
+        id: 'nerve-fms2',
+        dependencies: [expect.objectContaining({ id: 'nerve-qkdo' })],
+        linkedPlan: expect.objectContaining({
+          path: '.plans/2026-04-06-bead-viewer-tab-foundation-execution.md',
+        }),
+      }),
+    });
+    expect(getBeadDetailMock).toHaveBeenCalledWith('nerve-fms2', {
+      targetPath: undefined,
+      currentDocumentPath: undefined,
+      workspaceAgentId: undefined,
+    });
+  });
+
+  it('passes explicit lookup context through to the bead lookup', async () => {
+    getBeadDetailMock.mockResolvedValue({
+      id: 'virtra-apex-docs-id2',
+      title: 'Demo',
+      notes: null,
+      status: null,
+      priority: null,
+      issueType: null,
+      owner: null,
+      createdAt: null,
+      updatedAt: null,
+      closedAt: null,
+      closeReason: null,
+      dependencies: [],
+      dependents: [],
+      linkedPlan: null,
+    });
+
+    const app = await buildApp();
+    const res = await app.request('/api/beads/virtra-apex-docs-id2?targetPath=../projects/virtra-apex-docs/.beads&currentDocumentPath=bead-link-dogfood.md&workspaceAgentId=main');
+
+    expect(res.status).toBe(200);
+    expect(getBeadDetailMock).toHaveBeenCalledWith('virtra-apex-docs-id2', {
+      targetPath: '../projects/virtra-apex-docs/.beads',
+      currentDocumentPath: 'bead-link-dogfood.md',
+      workspaceAgentId: 'main',
+    });
+  });
+
+  it('returns 404 when the bead is missing', async () => {
+    const { BeadNotFoundError } = await import('../lib/beads.js');
+    getBeadDetailMock.mockRejectedValue(new BeadNotFoundError('nerve-miss'));
+
+    const app = await buildApp();
+    const res = await app.request('/api/beads/nerve-miss');
+
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toEqual({
+      error: 'not_found',
+      details: 'nerve-miss',
+    });
+  });
+
+  it('returns 502 when the bd adapter fails', async () => {
+    const { BeadAdapterError } = await import('../lib/beads.js');
+    getBeadDetailMock.mockRejectedValue(new BeadAdapterError('bd failed'));
+
+    const app = await buildApp();
+    const res = await app.request('/api/beads/nerve-fms2');
+
+    expect(res.status).toBe(502);
+    await expect(res.json()).resolves.toEqual({
+      error: 'beads_adapter_error',
+      details: 'bd failed',
+    });
+  });
+});

--- a/server/routes/beads.ts
+++ b/server/routes/beads.ts
@@ -1,0 +1,35 @@
+import { Hono } from 'hono';
+import { rateLimitGeneral } from '../middleware/rate-limit.js';
+import { BeadAdapterError, BeadNotFoundError, getBeadDetail } from '../lib/beads.js';
+
+const app = new Hono();
+
+app.get('/api/beads/:id', rateLimitGeneral, async (c) => {
+  const beadId = c.req.param('id')?.trim();
+  if (!beadId) {
+    return c.json({ error: 'invalid_request', details: 'bead id is required' }, 400);
+  }
+
+  const targetPath = c.req.query('targetPath')?.trim() || undefined;
+  const currentDocumentPath = c.req.query('currentDocumentPath')?.trim() || undefined;
+  const workspaceAgentId = c.req.query('workspaceAgentId')?.trim() || undefined;
+
+  try {
+    const bead = await getBeadDetail(beadId, {
+      targetPath,
+      currentDocumentPath,
+      workspaceAgentId,
+    });
+    return c.json({ ok: true, bead });
+  } catch (error) {
+    if (error instanceof BeadNotFoundError) {
+      return c.json({ error: 'not_found', details: error.message }, 404);
+    }
+    if (error instanceof BeadAdapterError) {
+      return c.json({ error: 'beads_adapter_error', details: error.message }, 502);
+    }
+    throw error;
+  }
+});
+
+export default app;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import { PanelErrorBoundary } from '@/components/PanelErrorBoundary';
 import { SpawnAgentDialog } from '@/features/sessions/SpawnAgentDialog';
 import { DEFAULT_CHAT_PATH_LINKS_CONFIG, parseChatPathLinksConfig } from '@/features/chat/chatPathLinks';
 import { FileTreePanel, TabbedContentArea, useOpenFiles, type FileTreeChangeEvent } from '@/features/file-browser';
+import { type BeadLinkTarget, type OpenBeadTab, buildBeadTabId } from '@/features/beads';
 import { isImageFile } from '@/features/file-browser/utils/fileTypes';
 import { buildAgentRootSessionKey, getSessionDisplayLabel } from '@/features/sessions/sessionKeys';
 import { shouldGuardWorkspaceSwitch } from '@/features/workspace/workspaceSwitchGuard';
@@ -321,6 +322,7 @@ export default function App({ onLogout }: AppProps) {
   // View mode state (chat | kanban), persisted to localStorage
   const [viewMode, setViewModeRaw] = useState<ViewMode>(() => getInitialViewMode(kanbanVisible));
   const [pendingTaskId, setPendingTaskId] = useState<string | null>(null);
+  const [openBeads, setOpenBeads] = useState<OpenBeadTab[]>([]);
   const setViewMode = useCallback((mode: ViewMode) => {
     const nextMode = mode === 'kanban' && !kanbanVisible ? 'chat' : mode;
     setViewModeRaw(nextMode);
@@ -370,6 +372,44 @@ export default function App({ onLogout }: AppProps) {
     if (kanbanVisible || viewMode !== 'kanban') return;
     setViewMode('chat');
   }, [kanbanVisible, setViewMode, viewMode]);
+
+  const openBeadId = useCallback((target: BeadLinkTarget) => {
+    const normalizedBeadId = target.beadId.trim();
+    if (!normalizedBeadId) return;
+
+    const normalizedTarget: BeadLinkTarget = {
+      beadId: normalizedBeadId,
+      explicitTargetPath: target.explicitTargetPath?.trim() || undefined,
+      currentDocumentPath: target.currentDocumentPath?.trim() || undefined,
+      workspaceAgentId: target.workspaceAgentId?.trim() || workspaceAgentId,
+    };
+
+    const tabId = buildBeadTabId(normalizedTarget);
+    setOpenBeads((prev) => {
+      if (prev.some((bead) => bead.id === tabId)) return prev;
+      return [...prev, {
+        id: tabId,
+        beadId: normalizedBeadId,
+        name: normalizedBeadId,
+        explicitTargetPath: normalizedTarget.explicitTargetPath,
+        currentDocumentPath: normalizedTarget.currentDocumentPath,
+        workspaceAgentId: normalizedTarget.workspaceAgentId,
+      }];
+    });
+    setActiveTab(tabId);
+  }, [setActiveTab, workspaceAgentId]);
+
+  const closeWorkspaceTab = useCallback((tabId: string) => {
+    if (tabId.startsWith('bead:')) {
+      setOpenBeads((prev) => prev.filter((bead) => bead.id !== tabId));
+      if (activeTab === tabId) {
+        setActiveTab('chat');
+      }
+      return;
+    }
+
+    closeFile(tabId);
+  }, [activeTab, closeFile, setActiveTab]);
 
   const openWorkspacePath = useCallback(async (targetPath: string, basePath?: string) => {
     const params = new URLSearchParams({ path: targetPath, agentId: workspaceAgentId });
@@ -667,9 +707,10 @@ export default function App({ onLogout }: AppProps) {
     <TabbedContentArea
       activeTab={activeTab}
       openFiles={openFiles}
+      openBeads={openBeads}
       workspaceAgentId={workspaceAgentId}
       onSelectTab={setActiveTab}
-      onCloseTab={closeFile}
+      onCloseTab={closeWorkspaceTab}
       onContentChange={updateContent}
       onSaveFile={handleSaveFile}
       saveToast={visibleSaveToast}
@@ -677,6 +718,7 @@ export default function App({ onLogout }: AppProps) {
       onReloadFile={reloadFile}
       onRetryFile={reloadFile}
       onOpenWorkspacePath={openWorkspacePath}
+      onOpenBeadId={openBeadId}
       chatPanel={
         <PanelErrorBoundary name="Chat">
           <ChatPanel
@@ -704,6 +746,7 @@ export default function App({ onLogout }: AppProps) {
             isMobileTopBarHidden={isMobileTopBarHidden}
             onOpenWorkspacePath={openWorkspacePath}
             pathLinkPrefixes={chatPathLinkPrefixes}
+            onOpenBeadId={openBeadId}
           />
         </PanelErrorBoundary>
       }

--- a/src/features/beads/BeadViewerTab.tsx
+++ b/src/features/beads/BeadViewerTab.tsx
@@ -1,0 +1,166 @@
+import { AlertTriangle, ArrowUpRight, CircleDot, FileText, GitBranch, Loader2 } from 'lucide-react';
+import { MarkdownRenderer } from '@/features/markdown/MarkdownRenderer';
+import { useBeadDetail } from './useBeadDetail';
+import type { BeadLinkTarget } from './links';
+
+interface BeadViewerTabProps {
+  beadTarget: BeadLinkTarget;
+  onOpenBeadId?: (target: BeadLinkTarget) => void;
+  onOpenWorkspacePath?: (path: string, basePath?: string) => void | Promise<void>;
+}
+
+function formatTimestamp(value: string | null): string | null {
+  if (!value) return null;
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  return date.toLocaleString();
+}
+
+function RelationList({
+  title,
+  items,
+  onOpenBeadId,
+}: {
+  title: string;
+  items: Array<{ id: string; title: string | null; status: string | null; dependencyType: string | null }>;
+  onOpenBeadId?: (target: BeadLinkTarget) => void;
+}) {
+  if (items.length === 0) return null;
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2 text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+        <GitBranch size={13} />
+        <span>{title}</span>
+      </div>
+      <div className="space-y-2">
+        {items.map((item) => (
+          <button
+            key={item.id}
+            type="button"
+            className="flex w-full items-start justify-between gap-3 rounded-2xl border border-border/60 bg-card/60 px-3 py-3 text-left transition-colors hover:border-primary/40 hover:bg-card disabled:cursor-default disabled:opacity-75"
+            onClick={() => onOpenBeadId?.({ beadId: item.id })}
+            disabled={!onOpenBeadId}
+          >
+            <div className="min-w-0 space-y-1">
+              <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                <span className="truncate">{item.title || item.id}</span>
+              </div>
+              <div className="text-xs text-muted-foreground">
+                <span className="font-mono">{item.id}</span>
+                {item.status ? <span> · {item.status}</span> : null}
+                {item.dependencyType ? <span> · {item.dependencyType}</span> : null}
+              </div>
+            </div>
+            <ArrowUpRight size={14} className="mt-0.5 shrink-0 text-muted-foreground" />
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function BeadViewerTab({ beadTarget, onOpenBeadId, onOpenWorkspacePath }: BeadViewerTabProps) {
+  const { bead, loading, error } = useBeadDetail(beadTarget);
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center gap-2 text-sm text-muted-foreground">
+        <Loader2 size={16} className="animate-spin" />
+        <span>Loading bead…</span>
+      </div>
+    );
+  }
+
+  if (error || !bead) {
+    return (
+      <div className="flex h-full items-center justify-center px-6">
+        <div className="max-w-md rounded-3xl border border-destructive/30 bg-destructive/5 p-5 text-sm text-destructive">
+          <div className="mb-2 flex items-center gap-2 font-medium">
+            <AlertTriangle size={15} />
+            <span>Could not load bead {beadTarget.beadId}</span>
+          </div>
+          <p className="text-destructive/80">{error || 'Unknown error'}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto bg-background">
+      <div className="mx-auto flex max-w-4xl flex-col gap-6 px-5 py-5 sm:px-6 sm:py-6">
+        <section className="shell-panel rounded-[28px] border border-border/60 p-5 sm:p-6">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="space-y-3">
+              <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                <span className="cockpit-badge">Bead Viewer</span>
+                <span className="font-mono">{bead.id}</span>
+                {bead.status ? <span className="cockpit-badge">{bead.status}</span> : null}
+              </div>
+              <div>
+                <h1 className="text-2xl font-semibold tracking-tight text-foreground">{bead.title}</h1>
+                <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                  {bead.issueType ? <span>Type: {bead.issueType}</span> : null}
+                  {bead.priority !== null ? <span>Priority: {bead.priority}</span> : null}
+                  {bead.owner ? <span>Owner: {bead.owner}</span> : null}
+                  {bead.updatedAt ? <span>Updated: {formatTimestamp(bead.updatedAt)}</span> : null}
+                  {bead.closedAt ? <span>Closed: {formatTimestamp(bead.closedAt)}</span> : null}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {bead.notes ? (
+            <div className="mt-5 border-t border-border/50 pt-5">
+              <div className="mb-3 flex items-center gap-2 text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+                <CircleDot size={13} />
+                <span>Notes</span>
+              </div>
+              <MarkdownRenderer
+                content={bead.notes}
+                onOpenBeadId={onOpenBeadId}
+                onOpenWorkspacePath={onOpenWorkspacePath}
+              />
+            </div>
+          ) : null}
+
+          {bead.closeReason ? (
+            <div className="mt-5 rounded-2xl border border-border/60 bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
+              <span className="font-medium text-foreground">Close reason:</span> {bead.closeReason}
+            </div>
+          ) : null}
+        </section>
+
+        {bead.linkedPlan ? (
+          <section className="shell-panel rounded-[28px] border border-border/60 p-5 sm:p-6">
+            <div className="mb-3 flex items-center gap-2 text-[0.72rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+              <FileText size={13} />
+              <span>Linked plan</span>
+            </div>
+            <button
+              type="button"
+              className="flex w-full items-start justify-between gap-3 rounded-2xl border border-border/60 bg-card/60 px-4 py-4 text-left transition-colors hover:border-primary/40 hover:bg-card disabled:cursor-default disabled:opacity-75"
+              onClick={() => { void onOpenWorkspacePath?.(bead.linkedPlan!.path); }}
+              disabled={!onOpenWorkspacePath}
+            >
+              <div className="min-w-0 space-y-1">
+                <div className="truncate text-sm font-medium text-foreground">{bead.linkedPlan.title}</div>
+                <div className="text-xs text-muted-foreground">
+                  <span className="font-mono">{bead.linkedPlan.path}</span>
+                  {bead.linkedPlan.status ? <span> · {bead.linkedPlan.status}</span> : null}
+                  {bead.linkedPlan.archived ? <span> · archived</span> : null}
+                </div>
+              </div>
+              <ArrowUpRight size={14} className="mt-0.5 shrink-0 text-muted-foreground" />
+            </button>
+          </section>
+        ) : null}
+
+        <RelationList title="Dependencies" items={bead.dependencies} onOpenBeadId={onOpenBeadId} />
+        <RelationList title="Dependents" items={bead.dependents} onOpenBeadId={onOpenBeadId} />
+      </div>
+    </div>
+  );
+}

--- a/src/features/beads/index.ts
+++ b/src/features/beads/index.ts
@@ -1,0 +1,11 @@
+export {
+  buildBeadTabId,
+  decodeBeadLinkHref,
+  isBeadId,
+  isBeadLinkHref,
+  isSyntacticallyValidExplicitBeadHref,
+  parseBeadLinkHref,
+} from './links';
+export { BeadViewerTab } from './BeadViewerTab';
+export type { BeadDetail, BeadRelationSummary, BeadLinkedPlanSummary, OpenBeadTab } from './types';
+export type { BeadLinkTarget } from './links';

--- a/src/features/beads/links.test.ts
+++ b/src/features/beads/links.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { buildBeadTabId, decodeBeadLinkHref, isBeadId, isBeadLinkHref, isSyntacticallyValidExplicitBeadHref, parseBeadLinkHref } from './links';
+
+describe('bead link helpers', () => {
+  it('recognizes legacy bead shorthand and explicit bead URIs', () => {
+    expect(isBeadId('nerve-fms2')).toBe(true);
+    expect(isBeadLinkHref('bead:nerve-fms2')).toBe(true);
+    expect(isBeadLinkHref('bead:///repos/demo#nerve-fms2')).toBe(true);
+  });
+
+  it('rejects bare bead ids and normal file paths as markdown bead links', () => {
+    expect(isBeadLinkHref('nerve-fms2')).toBe(false);
+    expect(isBeadId('.plans/demo.md')).toBe(false);
+    expect(isBeadLinkHref('docs/todo.md')).toBe(false);
+  });
+
+  it('parses legacy same-context bead links', () => {
+    expect(parseBeadLinkHref('bead:nerve-fms2')).toEqual({ beadId: 'nerve-fms2' });
+    expect(decodeBeadLinkHref('bead:nerve-fms2')).toBe('nerve-fms2');
+    expect(buildBeadTabId('nerve-fms2')).toBe('bead:nerve-fms2');
+  });
+
+  it('parses explicit absolute bead URIs with custom payload parsing', () => {
+    expect(parseBeadLinkHref('bead:///home/alice/work/repos/demo/.beads#nerve-fms2')).toEqual({
+      beadId: 'nerve-fms2',
+      explicitTargetPath: '/home/alice/work/repos/demo/.beads',
+      currentDocumentPath: undefined,
+      workspaceAgentId: undefined,
+    });
+  });
+
+  it('preserves relative explicit bead targets and the current document context', () => {
+    expect(parseBeadLinkHref('bead://../projects/demo#nerve-fms2', {
+      currentDocumentPath: 'notes/beads.md',
+      workspaceAgentId: 'research',
+    })).toEqual({
+      beadId: 'nerve-fms2',
+      explicitTargetPath: '../projects/demo',
+      currentDocumentPath: 'notes/beads.md',
+      workspaceAgentId: 'research',
+    });
+  });
+
+  it('rejects relative explicit bead URIs when there is no current document path', () => {
+    expect(parseBeadLinkHref('bead://../projects/demo#nerve-fms2')).toBeNull();
+  });
+
+  it('still recognizes syntactically valid explicit bead URIs before context-aware resolution', () => {
+    expect(isSyntacticallyValidExplicitBeadHref('bead://../projects/demo#nerve-fms2')).toBe(true);
+    expect(isBeadLinkHref('bead://../projects/demo#nerve-fms2')).toBe(false);
+  });
+
+  it('builds distinct tab ids for explicit bead targets', () => {
+    expect(buildBeadTabId({
+      beadId: 'nerve-fms2',
+      explicitTargetPath: '../projects/demo',
+      currentDocumentPath: 'notes/beads.md',
+      workspaceAgentId: 'research',
+    })).toBe('bead://research:notes/beads.md:../projects/demo#nerve-fms2');
+  });
+});

--- a/src/features/beads/links.ts
+++ b/src/features/beads/links.ts
@@ -1,0 +1,109 @@
+const BEAD_ID_PATTERN = /^[A-Za-z0-9]+-[A-Za-z0-9][A-Za-z0-9_-]*$/;
+const LEGACY_BEAD_SCHEME = 'bead:';
+const EXPLICIT_BEAD_SCHEME = 'bead://';
+
+export interface BeadLinkTarget {
+  beadId: string;
+  explicitTargetPath?: string;
+  currentDocumentPath?: string;
+  workspaceAgentId?: string;
+}
+
+function decodeUriComponentOrRaw(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function isAbsoluteFilesystemPath(value: string): boolean {
+  return value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value);
+}
+
+export function isBeadId(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.includes('/') || trimmed.includes('.') || trimmed.includes('#') || trimmed.includes('?')) {
+    return false;
+  }
+  return BEAD_ID_PATTERN.test(trimmed);
+}
+
+export function isSyntacticallyValidExplicitBeadHref(href: string): boolean {
+  if (!href) return false;
+
+  const trimmed = href.trim();
+  if (!trimmed.toLowerCase().startsWith(EXPLICIT_BEAD_SCHEME)) return false;
+
+  const rawPayload = trimmed.slice(EXPLICIT_BEAD_SCHEME.length);
+  const hashIndex = rawPayload.indexOf('#');
+  if (hashIndex <= 0 || hashIndex === rawPayload.length - 1) return false;
+
+  const rawTargetPath = decodeUriComponentOrRaw(rawPayload.slice(0, hashIndex)).trim();
+  const beadId = decodeUriComponentOrRaw(rawPayload.slice(hashIndex + 1)).trim();
+  return Boolean(rawTargetPath) && isBeadId(beadId);
+}
+
+export function isBeadLinkHref(href: string): boolean {
+  return parseBeadLinkHref(href) !== null;
+}
+
+export function decodeBeadLinkHref(href: string): string {
+  return parseBeadLinkHref(href)?.beadId ?? href.trim();
+}
+
+export function parseBeadLinkHref(
+  href: string,
+  options: {
+    currentDocumentPath?: string;
+    workspaceAgentId?: string;
+  } = {},
+): BeadLinkTarget | null {
+  if (!href) return null;
+
+  const trimmed = href.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.toLowerCase().startsWith(EXPLICIT_BEAD_SCHEME)) {
+    const rawPayload = trimmed.slice(EXPLICIT_BEAD_SCHEME.length);
+    const hashIndex = rawPayload.indexOf('#');
+    if (hashIndex <= 0 || hashIndex === rawPayload.length - 1) return null;
+
+    const rawTargetPath = decodeUriComponentOrRaw(rawPayload.slice(0, hashIndex)).trim();
+    const beadId = decodeUriComponentOrRaw(rawPayload.slice(hashIndex + 1)).trim();
+    if (!rawTargetPath || !isBeadId(beadId)) return null;
+
+    const currentDocumentPath = options.currentDocumentPath?.trim();
+    if (!isAbsoluteFilesystemPath(rawTargetPath) && !currentDocumentPath) {
+      return null;
+    }
+
+    return {
+      beadId,
+      explicitTargetPath: rawTargetPath,
+      currentDocumentPath,
+      workspaceAgentId: options.workspaceAgentId?.trim() || undefined,
+    };
+  }
+
+  if (!trimmed.toLowerCase().startsWith(LEGACY_BEAD_SCHEME)) return null;
+
+  const beadId = decodeUriComponentOrRaw(trimmed.slice(LEGACY_BEAD_SCHEME.length)).trim();
+  if (!isBeadId(beadId)) return null;
+
+  return { beadId };
+}
+
+export function buildBeadTabId(target: BeadLinkTarget | string): string {
+  if (typeof target === 'string') {
+    return `bead:${target}`;
+  }
+
+  if (!target.explicitTargetPath) {
+    return `bead:${target.beadId}`;
+  }
+
+  const workspaceAgentId = target.workspaceAgentId?.trim() || 'main';
+  const currentDocumentPath = target.currentDocumentPath?.trim() || '';
+  return `bead://${workspaceAgentId}:${currentDocumentPath}:${target.explicitTargetPath}#${target.beadId}`;
+}

--- a/src/features/beads/types.ts
+++ b/src/features/beads/types.ts
@@ -1,0 +1,41 @@
+export interface BeadRelationSummary {
+  id: string;
+  title: string | null;
+  status: string | null;
+  dependencyType: string | null;
+}
+
+export interface BeadLinkedPlanSummary {
+  path: string;
+  title: string;
+  planId: string | null;
+  archived: boolean;
+  status: string | null;
+  updatedAt: number;
+}
+
+export interface BeadDetail {
+  id: string;
+  title: string;
+  notes: string | null;
+  status: string | null;
+  priority: number | null;
+  issueType: string | null;
+  owner: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+  closedAt: string | null;
+  closeReason: string | null;
+  dependencies: BeadRelationSummary[];
+  dependents: BeadRelationSummary[];
+  linkedPlan: BeadLinkedPlanSummary | null;
+}
+
+export interface OpenBeadTab {
+  id: string;
+  beadId: string;
+  name: string;
+  explicitTargetPath?: string;
+  currentDocumentPath?: string;
+  workspaceAgentId?: string;
+}

--- a/src/features/beads/useBeadDetail.ts
+++ b/src/features/beads/useBeadDetail.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import type { BeadDetail } from './types';
+import type { BeadLinkTarget } from './links';
+
+interface UseBeadDetailState {
+  bead: BeadDetail | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useBeadDetail(target: BeadLinkTarget): UseBeadDetailState {
+  const [state, setState] = useState<UseBeadDetailState>({ bead: null, loading: true, error: null });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ bead: null, loading: true, error: null });
+
+    const params = new URLSearchParams();
+    if (target.explicitTargetPath) {
+      params.set('targetPath', target.explicitTargetPath);
+    }
+    if (target.currentDocumentPath) {
+      params.set('currentDocumentPath', target.currentDocumentPath);
+    }
+    if (target.workspaceAgentId) {
+      params.set('workspaceAgentId', target.workspaceAgentId);
+    }
+
+    const suffix = params.toString() ? `?${params.toString()}` : '';
+
+    void fetch(`/api/beads/${encodeURIComponent(target.beadId)}${suffix}`)
+      .then(async (res) => {
+        const data = await res.json().catch(() => null) as {
+          ok?: boolean;
+          bead?: BeadDetail;
+          details?: string;
+          error?: string;
+        } | null;
+
+        if (cancelled) return;
+
+        if (!res.ok || !data?.ok || !data.bead) {
+          setState({
+            bead: null,
+            loading: false,
+            error: data?.details || data?.error || 'Failed to load bead',
+          });
+          return;
+        }
+
+        setState({ bead: data.bead, loading: false, error: null });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setState({ bead: null, loading: false, error: 'Network error' });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [target.beadId, target.currentDocumentPath, target.explicitTargetPath, target.workspaceAgentId]);
+
+  return state;
+}

--- a/src/features/beads/useBeadDetail.ts
+++ b/src/features/beads/useBeadDetail.ts
@@ -8,25 +8,31 @@ interface UseBeadDetailState {
   error: string | null;
 }
 
+interface UseBeadDetailFetchState {
+  bead: BeadDetail | null;
+  error: string | null;
+  requestKey: string | null;
+}
+
 export function useBeadDetail(target: BeadLinkTarget): UseBeadDetailState {
-  const [state, setState] = useState<UseBeadDetailState>({ bead: null, loading: true, error: null });
+  const [state, setState] = useState<UseBeadDetailFetchState>({ bead: null, error: null, requestKey: null });
+
+  const params = new URLSearchParams();
+  if (target.explicitTargetPath) {
+    params.set('targetPath', target.explicitTargetPath);
+  }
+  if (target.currentDocumentPath) {
+    params.set('currentDocumentPath', target.currentDocumentPath);
+  }
+  if (target.workspaceAgentId) {
+    params.set('workspaceAgentId', target.workspaceAgentId);
+  }
+
+  const suffix = params.toString() ? `?${params.toString()}` : '';
+  const requestKey = `${target.beadId}${suffix}`;
 
   useEffect(() => {
     let cancelled = false;
-    setState({ bead: null, loading: true, error: null });
-
-    const params = new URLSearchParams();
-    if (target.explicitTargetPath) {
-      params.set('targetPath', target.explicitTargetPath);
-    }
-    if (target.currentDocumentPath) {
-      params.set('currentDocumentPath', target.currentDocumentPath);
-    }
-    if (target.workspaceAgentId) {
-      params.set('workspaceAgentId', target.workspaceAgentId);
-    }
-
-    const suffix = params.toString() ? `?${params.toString()}` : '';
 
     void fetch(`/api/beads/${encodeURIComponent(target.beadId)}${suffix}`)
       .then(async (res) => {
@@ -42,23 +48,29 @@ export function useBeadDetail(target: BeadLinkTarget): UseBeadDetailState {
         if (!res.ok || !data?.ok || !data.bead) {
           setState({
             bead: null,
-            loading: false,
             error: data?.details || data?.error || 'Failed to load bead',
+            requestKey,
           });
           return;
         }
 
-        setState({ bead: data.bead, loading: false, error: null });
+        setState({ bead: data.bead, error: null, requestKey });
       })
       .catch(() => {
         if (cancelled) return;
-        setState({ bead: null, loading: false, error: 'Network error' });
+        setState({ bead: null, error: 'Network error', requestKey });
       });
 
     return () => {
       cancelled = true;
     };
-  }, [target.beadId, target.currentDocumentPath, target.explicitTargetPath, target.workspaceAgentId]);
+  }, [requestKey, suffix, target.beadId]);
 
-  return state;
+  const loading = state.requestKey !== requestKey;
+
+  return {
+    bead: loading ? null : state.bead,
+    loading,
+    error: loading ? null : state.error,
+  };
 }

--- a/src/features/chat/ChatPanel.tsx
+++ b/src/features/chat/ChatPanel.tsx
@@ -8,6 +8,7 @@ import { useMessageSearch } from './useMessageSearch';
 import { ActivityLog, ChatHeader, ProcessingIndicator, ScrollToBottomButton, StreamingMessage, ToolGroupBlock } from './components';
 import { isMessageCollapsible } from './types';
 import type { ChatMsg, ImageAttachment, OutgoingUploadPayload } from './types';
+import type { BeadLinkTarget } from '@/features/beads';
 
 interface ChatPanelProps {
   messages: ChatMsg[];
@@ -45,6 +46,8 @@ interface ChatPanelProps {
   onOpenWorkspacePath?: (path: string) => void | Promise<void>;
   /** Configured path prefixes that should render as clickable inline path links. */
   pathLinkPrefixes?: string[];
+  /** Open a dedicated bead viewer tab. */
+  onOpenBeadId?: (target: BeadLinkTarget) => void | Promise<void>;
 }
 
 export interface ChatPanelHandle {
@@ -62,6 +65,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
   onToggleMobileTopBar, isMobileTopBarHidden = false,
   onOpenWorkspacePath,
   pathLinkPrefixes,
+  onOpenBeadId,
 }, ref) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const messageRefs = useRef<Map<number, HTMLDivElement>>(new Map());
@@ -337,6 +341,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
                 agentName={agentName}
                 onOpenWorkspacePath={onOpenWorkspacePath}
                 pathLinkPrefixes={pathLinkPrefixes}
+                onOpenBeadId={onOpenBeadId}
               />
             </div>
           );

--- a/src/features/chat/MessageBubble.test.tsx
+++ b/src/features/chat/MessageBubble.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, waitFor } from '@testing-library/react';
 
 vi.mock('@/features/markdown/MarkdownRenderer', () => ({
-  MarkdownRenderer: ({ content, onOpenWorkspacePath }: { content: string; onOpenWorkspacePath?: ((path: string) => void) & { handlerId?: string } }) => (
+  MarkdownRenderer: ({ content, onOpenWorkspacePath }: { content: string; onOpenWorkspacePath?: ((path: string) => void) & { handlerId?: string }; onOpenBeadId?: ((beadId: string) => void) }) => (
     <div data-handler-id={onOpenWorkspacePath?.handlerId ?? ''}>{content}</div>
   ),
 }));

--- a/src/features/chat/MessageBubble.tsx
+++ b/src/features/chat/MessageBubble.tsx
@@ -5,6 +5,7 @@ import { isMessageCollapsible } from './types';
 import { decodeHtmlEntities } from '@/lib/formatting';
 import { isStructuredMarkdown } from '@/lib/text/isStructuredMarkdown';
 import type { ChatMsg } from './types';
+import type { BeadLinkTarget } from '@/features/beads';
 
 // Lazy-load markdown renderer (includes highlight.js)
 const MarkdownRenderer = lazy(() => import('@/features/markdown/MarkdownRenderer').then(m => ({ default: m.MarkdownRenderer })));
@@ -45,6 +46,7 @@ interface MessageBubbleProps {
   agentName?: string;
   onOpenWorkspacePath?: (path: string) => void | Promise<void>;
   pathLinkPrefixes?: string[];
+  onOpenBeadId?: (target: BeadLinkTarget) => void | Promise<void>;
 }
 
 const borderClass = (role: string) => {
@@ -73,7 +75,7 @@ function RoleBadge({ role, agentName = 'Agent' }: { role: string; agentName?: st
   return <span className="cockpit-badge">System</span>;
 }
 
-function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memoryKey, onToggleCollapse, onToggleMemory, firstMessageTime, searchQuery, isCurrentMatch, agentName, onOpenWorkspacePath, pathLinkPrefixes }: MessageBubbleProps) {
+function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memoryKey, onToggleCollapse, onToggleMemory, firstMessageTime, searchQuery, isCurrentMatch, agentName, onOpenWorkspacePath, pathLinkPrefixes, onOpenBeadId }: MessageBubbleProps) {
   const isUser = msg.role === 'user';
   const isAssistant = msg.role === 'assistant';
   const isSystem = msg.role === 'system' || msg.role === 'event';
@@ -190,7 +192,7 @@ function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memory
         {!isCollapsed && (
           <div className="ml-3 border-l border-primary/12 px-3 pb-2 pt-1 text-[0.8rem] text-foreground/70 msg-body-intermediate">
             <Suspense fallback={<span className="text-muted-foreground text-xs">…</span>}>
-              <MarkdownRenderer content={msg.rawText} searchQuery={searchQuery} onOpenWorkspacePath={onOpenWorkspacePath} pathLinkPrefixes={pathLinkPrefixes} />
+              <MarkdownRenderer content={msg.rawText} searchQuery={searchQuery} onOpenWorkspacePath={onOpenWorkspacePath} pathLinkPrefixes={pathLinkPrefixes} onOpenBeadId={onOpenBeadId} />
             </Suspense>
           </div>
         )}
@@ -220,7 +222,7 @@ function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memory
           ) : (
             <div className="text-muted-foreground/70 text-[0.8rem] flex-1 min-w-0 msg-body-intermediate">
               <Suspense fallback={<span className="text-muted-foreground text-xs">…</span>}>
-                <MarkdownRenderer content={displayContent} searchQuery={searchQuery} suppressImages={isAssistant} onOpenWorkspacePath={onOpenWorkspacePath} pathLinkPrefixes={pathLinkPrefixes} />
+                <MarkdownRenderer content={displayContent} searchQuery={searchQuery} suppressImages={isAssistant} onOpenWorkspacePath={onOpenWorkspacePath} pathLinkPrefixes={pathLinkPrefixes} onOpenBeadId={onOpenBeadId} />
               </Suspense>
             </div>
           )}
@@ -286,7 +288,7 @@ function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memory
             )}
             {displayContent && (
               <Suspense fallback={<div className="text-muted-foreground text-xs">Loading…</div>}>
-                <MarkdownRenderer content={displayContent} searchQuery={searchQuery} suppressImages={isAssistant} onOpenWorkspacePath={onOpenWorkspacePath} pathLinkPrefixes={pathLinkPrefixes} />
+                <MarkdownRenderer content={displayContent} searchQuery={searchQuery} suppressImages={isAssistant} onOpenWorkspacePath={onOpenWorkspacePath} pathLinkPrefixes={pathLinkPrefixes} onOpenBeadId={onOpenBeadId} />
               </Suspense>
             )}
           </div>
@@ -381,6 +383,7 @@ export const MessageBubble = memo(MessageBubbleInner, (prev, next) => {
   if (prev.agentName !== next.agentName) return false;
   if (prev.onOpenWorkspacePath !== next.onOpenWorkspacePath) return false;
   if (prev.pathLinkPrefixes !== next.pathLinkPrefixes) return false;
+  if (prev.onOpenBeadId !== next.onOpenBeadId) return false;
   
   // All relevant props are equal, skip re-render
   return true;

--- a/src/features/file-browser/EditorTabBar.tsx
+++ b/src/features/file-browser/EditorTabBar.tsx
@@ -1,21 +1,24 @@
 import { EditorTab } from './EditorTab';
 import type { OpenFile } from './types';
+import type { OpenBeadTab } from '@/features/beads';
 
 interface EditorTabBarProps {
   activeTab: string;
   openFiles: OpenFile[];
+  openBeads?: OpenBeadTab[];
   onSelectTab: (id: string) => void;
-  onCloseTab: (path: string) => void;
+  onCloseTab: (id: string) => void;
 }
 
 export function EditorTabBar({
   activeTab,
   openFiles,
+  openBeads = [],
   onSelectTab,
   onCloseTab,
 }: EditorTabBarProps) {
-  // Don't render tab bar if no files are open (chat-only mode)
-  if (openFiles.length === 0) return null;
+  // Don't render tab bar if no file/bead tabs are open (chat-only mode)
+  if (openFiles.length === 0 && openBeads.length === 0) return null;
 
   return (
     <div
@@ -45,6 +48,20 @@ export function EditorTabBar({
           onSelect={() => onSelectTab(file.path)}
           onClose={() => onCloseTab(file.path)}
           onMiddleClick={() => onCloseTab(file.path)}
+        />
+      ))}
+
+      {/* Bead viewer tabs */}
+      {openBeads.map((bead) => (
+        <EditorTab
+          key={bead.id}
+          id={bead.id}
+          label={bead.name}
+          active={activeTab === bead.id}
+          tooltip={bead.beadId}
+          onSelect={() => onSelectTab(bead.id)}
+          onClose={() => onCloseTab(bead.id)}
+          onMiddleClick={() => onCloseTab(bead.id)}
         />
       ))}
     </div>

--- a/src/features/file-browser/MarkdownDocumentView.test.tsx
+++ b/src/features/file-browser/MarkdownDocumentView.test.tsx
@@ -3,10 +3,27 @@ import { describe, expect, it, vi } from 'vitest';
 import { MarkdownDocumentView } from './MarkdownDocumentView';
 import type { OpenFile } from './types';
 
+const markdownRendererSpy = vi.fn();
+
 vi.mock('@/features/markdown/MarkdownRenderer', () => ({
-  MarkdownRenderer: ({ content, className }: { content: string; className?: string }) => (
-    <div data-testid="markdown-renderer" className={className}>{content}</div>
-  ),
+  MarkdownRenderer: ({
+    content,
+    className,
+    currentDocumentPath,
+    onOpenBeadId,
+    onOpenWorkspacePath,
+    workspaceAgentId,
+  }: {
+    content: string;
+    className?: string;
+    currentDocumentPath?: string;
+    onOpenBeadId?: (target: { beadId: string }) => void;
+    onOpenWorkspacePath?: (path: string, basePath?: string) => void;
+    workspaceAgentId?: string;
+  }) => {
+    markdownRendererSpy({ content, className, currentDocumentPath, onOpenBeadId, onOpenWorkspacePath, workspaceAgentId });
+    return <div data-testid="markdown-renderer" className={className}>{content}</div>;
+  },
 }));
 
 vi.mock('./FileEditor', () => ({
@@ -65,6 +82,35 @@ describe('MarkdownDocumentView', () => {
     expect(editButton).toHaveAttribute('aria-pressed', 'true');
     expect(previewButton).toHaveAttribute('aria-pressed', 'false');
     expect(screen.getByTestId('file-editor')).toBeInTheDocument();
+  });
+
+  it('passes bead and workspace handlers through to the markdown renderer while preserving document path fallback', () => {
+    const onOpenBeadId = vi.fn();
+    const onOpenWorkspacePath = vi.fn();
+
+    render(
+      <MarkdownDocumentView
+        file={file}
+        onContentChange={vi.fn()}
+        onSave={vi.fn()}
+        onRetry={vi.fn()}
+        onOpenBeadId={onOpenBeadId}
+        onOpenWorkspacePath={onOpenWorkspacePath}
+        workspaceAgentId="research"
+      />,
+    );
+
+    expect(markdownRendererSpy).toHaveBeenCalled();
+    const props = markdownRendererSpy.mock.calls.at(-1)?.[0];
+    expect(props.currentDocumentPath).toBe('docs/guide.md');
+    expect(props.onOpenBeadId).toBe(onOpenBeadId);
+    expect(props.workspaceAgentId).toBe('research');
+
+    props.onOpenWorkspacePath?.('docs/todo.md');
+    expect(onOpenWorkspacePath).toHaveBeenCalledWith('docs/todo.md', 'docs/guide.md');
+
+    props.onOpenWorkspacePath?.('docs/child.md', 'docs');
+    expect(onOpenWorkspacePath).toHaveBeenCalledWith('docs/child.md', 'docs');
   });
 
   it('shows the loading state in preview mode instead of a blank markdown pane', () => {

--- a/src/features/file-browser/MarkdownDocumentView.tsx
+++ b/src/features/file-browser/MarkdownDocumentView.tsx
@@ -10,6 +10,8 @@ interface MarkdownDocumentViewProps {
   onSave: (path: string) => void;
   onRetry: (path: string) => void;
   onOpenWorkspacePath?: (path: string, basePath?: string) => void | Promise<void>;
+  onOpenBeadId?: (target: import('@/features/beads').BeadLinkTarget) => void | Promise<void>;
+  workspaceAgentId?: string;
 }
 
 export function MarkdownDocumentView({
@@ -18,6 +20,8 @@ export function MarkdownDocumentView({
   onSave,
   onRetry,
   onOpenWorkspacePath,
+  onOpenBeadId,
+  workspaceAgentId,
 }: MarkdownDocumentViewProps) {
   const [mode, setMode] = useState<'preview' | 'edit'>('preview');
 
@@ -90,7 +94,9 @@ export function MarkdownDocumentView({
               content={file.content}
               className="markdown-document-content"
               currentDocumentPath={file.path}
+              onOpenBeadId={onOpenBeadId}
               onOpenWorkspacePath={(targetPath, basePath) => onOpenWorkspacePath?.(targetPath, basePath ?? file.path)}
+              workspaceAgentId={workspaceAgentId}
             />
           )}
         </div>

--- a/src/features/file-browser/TabbedContentArea.test.tsx
+++ b/src/features/file-browser/TabbedContentArea.test.tsx
@@ -1,0 +1,68 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TabbedContentArea } from './TabbedContentArea';
+import type { OpenFile } from './types';
+
+const markdownDocumentViewSpy = vi.fn();
+
+vi.mock('./MarkdownDocumentView', () => ({
+  MarkdownDocumentView: (props: {
+    file: OpenFile;
+    onOpenBeadId?: (target: { beadId: string }) => void;
+    onOpenWorkspacePath?: (path: string, basePath?: string) => void;
+    workspaceAgentId?: string;
+  }) => {
+    markdownDocumentViewSpy(props);
+    return <div data-testid="markdown-document-view">{props.file.path}</div>;
+  },
+}));
+
+vi.mock('./ImageViewer', () => ({
+  ImageViewer: () => <div data-testid="image-viewer" />,
+}));
+
+vi.mock('./FileEditor', () => ({
+  default: () => <div data-testid="file-editor" />,
+}));
+
+const file: OpenFile = {
+  path: 'docs/guide.md',
+  name: 'guide.md',
+  content: '# Guide',
+  savedContent: '# Guide',
+  dirty: false,
+  locked: false,
+  mtime: 0,
+  loading: false,
+};
+
+describe('TabbedContentArea', () => {
+  it('passes the bead-open handler into markdown document preview tabs', () => {
+    const onOpenBeadId = vi.fn();
+    const onOpenWorkspacePath = vi.fn();
+
+    render(
+      <TabbedContentArea
+        activeTab="docs/guide.md"
+        openFiles={[file]}
+        openBeads={[]}
+        workspaceAgentId="agent-1"
+        onSelectTab={vi.fn()}
+        onCloseTab={vi.fn()}
+        onContentChange={vi.fn()}
+        onSaveFile={vi.fn()}
+        onRetryFile={vi.fn()}
+        onOpenWorkspacePath={onOpenWorkspacePath}
+        onOpenBeadId={onOpenBeadId}
+        chatPanel={<div>chat</div>}
+      />,
+    );
+
+    expect(markdownDocumentViewSpy).toHaveBeenCalled();
+    const props = markdownDocumentViewSpy.mock.calls.at(-1)?.[0];
+    expect(props.file.path).toBe('docs/guide.md');
+    expect(props.onOpenBeadId).toBe(onOpenBeadId);
+    expect(props.onOpenWorkspacePath).toBe(onOpenWorkspacePath);
+    expect(props.workspaceAgentId).toBe('agent-1');
+  });
+});

--- a/src/features/file-browser/TabbedContentArea.tsx
+++ b/src/features/file-browser/TabbedContentArea.tsx
@@ -13,6 +13,7 @@ import { ImageViewer } from './ImageViewer';
 import { MarkdownDocumentView } from './MarkdownDocumentView';
 import { isImageFile, isMarkdownFile } from './utils/fileTypes';
 import type { OpenFile } from './types';
+import { BeadViewerTab, type BeadLinkTarget, type OpenBeadTab } from '@/features/beads';
 
 // Lazy-load CodeMirror editor — keeps it out of the initial bundle
 const FileEditor = lazy(() => import('./FileEditor'));
@@ -35,14 +36,16 @@ interface SaveToast {
 interface TabbedContentAreaProps {
   activeTab: string;
   openFiles: OpenFile[];
+  openBeads?: OpenBeadTab[];
   workspaceAgentId: string;
   onSelectTab: (id: string) => void;
-  onCloseTab: (path: string) => void;
+  onCloseTab: (id: string) => void;
   onContentChange: (path: string, content: string) => void;
   onSaveFile: (path: string) => void;
   onRetryFile: (path: string) => void;
   onReloadFile?: (path: string) => void;
   onOpenWorkspacePath?: (path: string, basePath?: string) => void | Promise<void>;
+  onOpenBeadId?: (target: BeadLinkTarget) => void;
   saveToast?: SaveToast | null;
   onDismissToast?: () => void;
   /** The chat panel rendered as-is (never unmounted). */
@@ -52,6 +55,7 @@ interface TabbedContentAreaProps {
 export function TabbedContentArea({
   activeTab,
   openFiles,
+  openBeads = [],
   workspaceAgentId,
   onSelectTab,
   onCloseTab,
@@ -60,11 +64,12 @@ export function TabbedContentArea({
   onRetryFile,
   onReloadFile,
   onOpenWorkspacePath,
+  onOpenBeadId,
   saveToast,
   onDismissToast,
   chatPanel,
 }: TabbedContentAreaProps) {
-  const hasOpenFiles = openFiles.length > 0;
+  const hasOpenTabs = openFiles.length > 0 || openBeads.length > 0;
   const visibleSaveToast = saveToast && (!saveToast.agentId || saveToast.agentId === workspaceAgentId)
     ? saveToast
     : null;
@@ -72,10 +77,11 @@ export function TabbedContentArea({
   return (
     <div className="h-full flex flex-col min-h-0 min-w-0">
       {/* Tab bar — only shown when files are open */}
-      {hasOpenFiles && (
+      {hasOpenTabs && (
         <EditorTabBar
           activeTab={activeTab}
           openFiles={openFiles}
+          openBeads={openBeads}
           onSelectTab={onSelectTab}
           onCloseTab={onCloseTab}
         />
@@ -85,7 +91,7 @@ export function TabbedContentArea({
       <div className="flex-1 min-h-0 relative">
         {/* Chat panel — always mounted, hidden when file tab is active */}
         <div
-          className={activeTab === 'chat' || !hasOpenFiles ? 'h-full' : 'hidden'}
+          className={activeTab === 'chat' || !hasOpenTabs ? 'h-full' : 'hidden'}
           role="tabpanel"
           id="tabpanel-chat"
           aria-labelledby="tab-chat"
@@ -111,6 +117,8 @@ export function TabbedContentArea({
                 onSave={onSaveFile}
                 onRetry={onRetryFile}
                 onOpenWorkspacePath={onOpenWorkspacePath}
+                onOpenBeadId={onOpenBeadId}
+                workspaceAgentId={workspaceAgentId}
               />
             ) : (
               <Suspense fallback={<EditorFallback />}>
@@ -122,6 +130,28 @@ export function TabbedContentArea({
                 />
               </Suspense>
             )}
+          </div>
+        ))}
+
+        {/* Bead viewer tabs */}
+        {openBeads.map((bead) => (
+          <div
+            key={bead.id}
+            className={activeTab === bead.id ? 'h-full' : 'hidden'}
+            role="tabpanel"
+            id={`tabpanel-${bead.id}`}
+            aria-labelledby={`tab-${bead.id}`}
+          >
+            <BeadViewerTab
+              beadTarget={{
+                beadId: bead.beadId,
+                explicitTargetPath: bead.explicitTargetPath,
+                currentDocumentPath: bead.currentDocumentPath,
+                workspaceAgentId: bead.workspaceAgentId,
+              }}
+              onOpenBeadId={onOpenBeadId}
+              onOpenWorkspacePath={onOpenWorkspacePath}
+            />
           </div>
         ))}
 

--- a/src/features/markdown/MarkdownRenderer.test.tsx
+++ b/src/features/markdown/MarkdownRenderer.test.tsx
@@ -309,6 +309,118 @@ describe('MarkdownRenderer', () => {
     consoleError.mockRestore();
   });
 
+  it('opens explicit bead-scheme links in-app when a bead handler is provided', () => {
+    const onOpenBeadId = vi.fn();
+    render(<MarkdownRenderer content="[viewer](bead:nerve-fms2)" onOpenBeadId={onOpenBeadId} />);
+
+    fireEvent.click(screen.getByRole('link', { name: 'viewer' }));
+
+    expect(onOpenBeadId).toHaveBeenCalledWith({ beadId: 'nerve-fms2' });
+  });
+
+  it('routes explicit bead-scheme links to bead tabs before workspace resolution or browser fallback', () => {
+    const onOpenBeadId = vi.fn();
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="[viewer](bead:nerve-fms2)"
+        onOpenBeadId={onOpenBeadId}
+        onOpenWorkspacePath={onOpenWorkspacePath}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: 'viewer' });
+    expect(link).toHaveAttribute('href', 'bead:nerve-fms2');
+    expect(link).not.toHaveAttribute('target', '_blank');
+
+    fireEvent.click(link);
+
+    expect(onOpenBeadId).toHaveBeenCalledWith({ beadId: 'nerve-fms2' });
+    expect(onOpenWorkspacePath).not.toHaveBeenCalled();
+  });
+
+  it('does not treat bare bead ids as bead links when a workspace handler is also present', async () => {
+    const onOpenBeadId = vi.fn();
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="[viewer](nerve-fms2)"
+        onOpenBeadId={onOpenBeadId}
+        onOpenWorkspacePath={onOpenWorkspacePath}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'viewer' }));
+
+    expect(onOpenBeadId).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onOpenWorkspacePath).toHaveBeenCalledWith('nerve-fms2', undefined);
+    });
+  });
+
+  it('passes explicit bead lookup context through for cross-context links', () => {
+    const onOpenBeadId = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="[viewer](bead:///home/derrick/.openclaw/workspace/projects/virtra-apex-docs/.beads#virtra-apex-docs-id2)"
+        currentDocumentPath="bead-link-dogfood.md"
+        workspaceAgentId="main"
+        onOpenBeadId={onOpenBeadId}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'viewer' }));
+
+    expect(onOpenBeadId).toHaveBeenCalledWith({
+      beadId: 'virtra-apex-docs-id2',
+      explicitTargetPath: '/home/derrick/.openclaw/workspace/projects/virtra-apex-docs/.beads',
+      currentDocumentPath: 'bead-link-dogfood.md',
+      workspaceAgentId: 'main',
+    });
+  });
+
+  it('preserves relative explicit bead links as anchors even before context-aware parsing is available', () => {
+    const onOpenBeadId = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="[viewer](bead://../projects/virtra-apex-docs/.beads#virtra-apex-docs-id2)"
+        onOpenBeadId={onOpenBeadId}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: 'viewer' });
+    expect(link).toHaveAttribute('href', 'bead://../projects/virtra-apex-docs/.beads#virtra-apex-docs-id2');
+    expect(link).toHaveAttribute('target', '_blank');
+
+    fireEvent.click(link);
+    expect(onOpenBeadId).not.toHaveBeenCalled();
+  });
+
+  it('routes relative explicit bead links in-app once current document context is available', () => {
+    const onOpenBeadId = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="[viewer](bead://../projects/virtra-apex-docs/.beads#virtra-apex-docs-id2)"
+        currentDocumentPath="notes/bead-link-dogfood.md"
+        workspaceAgentId="main"
+        onOpenBeadId={onOpenBeadId}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: 'viewer' });
+    expect(link).toHaveAttribute('href', 'bead://../projects/virtra-apex-docs/.beads#virtra-apex-docs-id2');
+    expect(link).not.toHaveAttribute('target', '_blank');
+
+    fireEvent.click(link);
+
+    expect(onOpenBeadId).toHaveBeenCalledWith({
+      beadId: 'virtra-apex-docs-id2',
+      explicitTargetPath: '../projects/virtra-apex-docs/.beads',
+      currentDocumentPath: 'notes/bead-link-dogfood.md',
+      workspaceAgentId: 'main',
+    });
+  });
+
   it('keeps external links as normal browser links when a handler is provided', () => {
     const onOpenWorkspacePath = vi.fn();
     render(<MarkdownRenderer content="[example](https://example.com)" onOpenWorkspacePath={onOpenWorkspacePath} />);

--- a/src/features/markdown/MarkdownRenderer.tsx
+++ b/src/features/markdown/MarkdownRenderer.tsx
@@ -1,10 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { hljs } from '@/lib/highlight';
 import { sanitizeHtml } from '@/lib/sanitize';
 import { escapeRegex } from '@/lib/constants';
 import { CodeBlockActions } from './CodeBlockActions';
+import { isBeadLinkHref, isSyntacticallyValidExplicitBeadHref, parseBeadLinkHref, type BeadLinkTarget } from '@/features/beads';
 import { renderInlinePathReferences } from './inlineReferences';
 
 interface MarkdownRendererProps {
@@ -15,6 +16,8 @@ interface MarkdownRendererProps {
   currentDocumentPath?: string;
   onOpenWorkspacePath?: (path: string, basePath?: string) => void | Promise<void>;
   pathLinkPrefixes?: string[];
+  onOpenBeadId?: (target: BeadLinkTarget) => void | Promise<void>;
+  workspaceAgentId?: string;
 }
 
 interface MarkdownAstNode {
@@ -179,6 +182,13 @@ function decodeWorkspacePathLink(href: string): string {
   }
 }
 
+function transformMarkdownUrl(url: string): string {
+  if (isBeadLinkHref(url) || isSyntacticallyValidExplicitBeadHref(url) || isWorkspacePathLink(url)) {
+    return url;
+  }
+  return defaultUrlTransform(url);
+}
+
 function splitWorkspaceLinkTarget(href: string): { path: string; fragment: string | null } {
   const trimmed = href.trim();
   const hashIndex = trimmed.indexOf('#');
@@ -227,6 +237,8 @@ export function MarkdownRenderer({
   currentDocumentPath,
   onOpenWorkspacePath,
   pathLinkPrefixes,
+  onOpenBeadId,
+  workspaceAgentId,
 }: MarkdownRendererProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -372,6 +384,23 @@ export function MarkdownRenderer({
           );
         }
 
+        const beadTarget = parseBeadLinkHref(href, { currentDocumentPath, workspaceAgentId });
+        if (onOpenBeadId && beadTarget) {
+          return (
+            <a
+              {...props}
+              href={href}
+              className={mergedClassName}
+              onClick={(event) => {
+                event.preventDefault();
+                void onOpenBeadId(beadTarget);
+              }}
+            >
+              {children}
+            </a>
+          );
+        }
+
         if (onOpenWorkspacePath && isWorkspacePathLink(href)) {
           const normalizedTarget = normalizeWorkspaceLinkTarget(href);
           const fragment = getWorkspaceLinkFragment(href);
@@ -413,11 +442,11 @@ export function MarkdownRenderer({
       },
       ...(suppressImages ? { img: () => null } : {}),
     };
-  }, [childOptions, currentDocumentPath, onOpenWorkspacePath, scrollToAnchor, suppressImages, updateLocationHash]);
+  }, [childOptions, currentDocumentPath, onOpenBeadId, onOpenWorkspacePath, scrollToAnchor, suppressImages, updateLocationHash, workspaceAgentId]);
 
   return (
     <div ref={containerRef} className={`markdown-content ${className}`}>
-      <ReactMarkdown remarkPlugins={[remarkGfm, remarkStableHeadingIds]} components={components}>
+      <ReactMarkdown remarkPlugins={[remarkGfm, remarkStableHeadingIds]} urlTransform={transformMarkdownUrl} components={components}>
         {content}
       </ReactMarkdown>
     </div>


### PR DESCRIPTION
## What

Adds the Beads viewer package for upstream review:

- introduces an in-app Bead viewer tab/UI
- supports explicit `bead://<path>#<bead-id>` links for path-aware bead resolution
- preserves legacy same-context `bead:<id>` compatibility
- wires markdown/document click-through so plans, markdown docs, and bead views can open each other cleanly in the Nerve UI
- includes focused tests for the new bead-link decoding / routing / viewer behavior

## Why

Closes #251

Nerve already benefits from markdown-heavy planning and Beads-heavy execution, but the UX breaks down when users need to move between the two inside the app. This PR gives Nerve a first-class Beads viewer and an explicit URI format for bead links so root-workspace and cross-path markdown can still resolve the correct Beads source without sacrificing the convenient legacy `bead:<id>` shorthand in same-context flows.

## How

- adds Beads feature UI components/state for opening bead tabs in-app
- extends markdown bead-link handling to recognize explicit `bead://<path>#<bead-id>` links as well as legacy `bead:<id>` links
- adds/updates route/server support so explicit bead targets can resolve against the requested path context
- threads bead open handlers through markdown/document rendering so click-through stays inside Nerve
- keeps the scope limited to the Beads viewer + link-resolution feature set from `feature/beads-view-ui`

Dogfood / validation notes:

- live dogfood click-through covered markdown → plan → bead tab → related links/backlinks without wrong-target, non-clickable, external-browser, or tab-focus/reopen regressions
- exercised explicit absolute `bead://`, explicit relative `bead://`, `.beads`-relative explicit targets, and legacy same-context `bead:<id>` paths using the shared `bead-link-dogfood.md` workflow
- `npm run lint` passes with 0 errors (existing warnings remain elsewhere)
- `npm run build` passes
- `npm run build:server` passes
- `npm test -- --run` passes (`126` files / `1662` tests)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [x] New features include tests
- [ ] UI changes include a screenshot or screen recording

## Screenshots

Not attached in this PR package. The maintainer-facing validation evidence is currently the live dogfood click-through pass described above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bead viewer tabs to display bead details, including metadata, dependencies, dependents, and linked plans
  * Bead links in markdown content are now clickable, allowing quick navigation to bead details
  * New API endpoint for retrieving bead information with contextual lookup support
  * Tab bar now supports managing both file and bead viewer tabs
  * Plan discovery system that automatically links plans to related beads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->