### PR TITLE
fix(sessions): derive root agent labels from identity

### DIFF
--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -57,6 +57,16 @@ function SessionDisplayLabels() {
   );
 }
 
+function SessionRefreshProbe() {
+  const { refreshSessions } = useSessionContext();
+
+  return (
+    <button data-testid="refresh-sessions" onClick={() => void refreshSessions()}>
+      Refresh sessions
+    </button>
+  );
+}
+
 function SessionUnreadProbe() {
   const { currentSession, unreadSessions, setCurrentSession } = useSessionContext();
 
@@ -446,6 +456,78 @@ describe('SessionContext', () => {
       expect(screen.getByText('Jen (main)')).toBeInTheDocument();
       expect(screen.getByText('Reviewer Prime (reviewer)')).toBeInTheDocument();
     });
+  });
+
+  it('does not refetch identity content for roots whose identity files have no parseable name', async () => {
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            { sessionKey: 'agent:reviewer:main', displayName: 'stale reviewer label' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const fetchSpy = vi.fn((input: string | URL | Request) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+      if (url.includes('/api/server-info')) return Promise.resolve(jsonResponse({ agentName: 'Jen' }));
+      if (url.includes('/api/workspace/identity?agentId=reviewer')) {
+        return Promise.resolve(jsonResponse({ ok: true, content: '# IDENTITY.md\n- Role: Review agent\n' }));
+      }
+      if (url.includes('/api/agentlog')) return Promise.resolve(jsonResponse([]));
+      if (url.includes('/api/sessions/hidden')) return Promise.resolve(jsonResponse({ ok: true, sessions: [] }));
+      return Promise.resolve(jsonResponse({}));
+    }) as typeof fetch;
+    globalThis.fetch = fetchSpy;
+
+    const { getByTestId } = render(
+      <SessionProvider>
+        <SessionRefreshProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        '/api/workspace/identity?agentId=reviewer',
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+
+    const identityCallsBeforeRefresh = fetchSpy.mock.calls.filter(([input]) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+      return url.includes('/api/workspace/identity?agentId=reviewer');
+    }).length;
+    expect(identityCallsBeforeRefresh).toBe(1);
+
+    await act(async () => {
+      getByTestId('refresh-sessions').click();
+    });
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('sessions.list', { limit: 1000 });
+    });
+
+    const identityCallsAfterRefresh = fetchSpy.mock.calls.filter(([input]) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+      return url.includes('/api/workspace/identity?agentId=reviewer');
+    }).length;
+    expect(identityCallsAfterRefresh).toBe(1);
   });
 
   it('marks background top-level roots unread on start and pings when chat reaches a terminal event', async () => {

--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, waitFor, act } from '@testing-library/react';
 import { SessionProvider, useSessionContext } from './SessionContext';
 import { getSessionKey, type GatewayEvent } from '@/types';
+import { getSessionDisplayLabel } from '@/features/sessions/sessionKeys';
 
 const mockUseGateway = vi.fn();
 const mockUseSettings = vi.fn();
@@ -39,6 +40,18 @@ function SessionLabels() {
       <div data-testid="current-session">{currentSession}</div>
       {sessions.map((session) => (
         <div key={getSessionKey(session)}>{session.label || session.displayName || getSessionKey(session)}</div>
+      ))}
+    </div>
+  );
+}
+
+function SessionDisplayLabels() {
+  const { sessions, agentName } = useSessionContext();
+
+  return (
+    <div>
+      {sessions.map((session) => (
+        <div key={getSessionKey(session)}>{getSessionDisplayLabel(session, agentName)}</div>
       ))}
     </div>
   );
@@ -392,6 +405,47 @@ describe('SessionContext', () => {
 
     expect(rpcMock).toHaveBeenCalledWith('sessions.list', { limit: 1000 });
     expect(rpcMock).not.toHaveBeenCalledWith('sessions.list', expect.objectContaining({ activeMinutes: expect.any(Number) }));
+  });
+
+  it('hydrates root session labels from IDENTITY.md names', async () => {
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            { sessionKey: 'agent:reviewer:main', displayName: 'stale reviewer label' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    globalThis.fetch = vi.fn((input: string | URL | Request) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+      if (url.includes('/api/server-info')) return Promise.resolve(jsonResponse({ agentName: 'Jen' }));
+      if (url.includes('/api/workspace/identity?agentId=reviewer')) {
+        return Promise.resolve(jsonResponse({ ok: true, content: '# IDENTITY.md\n- Name: Reviewer Prime\n- Role: Review agent\n' }));
+      }
+      if (url.includes('/api/agentlog')) return Promise.resolve(jsonResponse([]));
+      if (url.includes('/api/sessions/hidden')) return Promise.resolve(jsonResponse({ ok: true, sessions: [] }));
+      return Promise.resolve(jsonResponse({}));
+    }) as typeof fetch;
+
+    render(
+      <SessionProvider>
+        <SessionDisplayLabels />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Jen (main)')).toBeInTheDocument();
+      expect(screen.getByText('Reviewer Prime (reviewer)')).toBeInTheDocument();
+    });
   });
 
   it('marks background top-level roots unread on start and pings when chat reaches a terminal event', async () => {

--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -458,6 +458,50 @@ describe('SessionContext', () => {
     });
   });
 
+
+  it('clears stale identity labels when a non-main root has no parseable identity name', async () => {
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            { sessionKey: 'agent:reviewer:main', identityName: 'Reviewer Prime' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    globalThis.fetch = vi.fn((input: string | URL | Request) => {
+      const url = typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+
+      if (url.includes('/api/server-info')) return Promise.resolve(jsonResponse({ agentName: 'Jen' }));
+      if (url.includes('/api/workspace/identity?agentId=reviewer')) {
+        return Promise.resolve(jsonResponse({ ok: true, content: '# IDENTITY.md\n- Role: Review agent\n' }));
+      }
+      if (url.includes('/api/agentlog')) return Promise.resolve(jsonResponse([]));
+      if (url.includes('/api/sessions/hidden')) return Promise.resolve(jsonResponse({ ok: true, sessions: [] }));
+      return Promise.resolve(jsonResponse({}));
+    }) as typeof fetch;
+
+    render(
+      <SessionProvider>
+        <SessionDisplayLabels />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Jen (main)')).toBeInTheDocument();
+      expect(screen.getByText('reviewer')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Reviewer Prime (reviewer)')).not.toBeInTheDocument();
+  });
+
   it('does not refetch identity content for roots whose identity files have no parseable name', async () => {
     rpcMock.mockImplementation(async (method: string) => {
       if (method === 'sessions.list') {

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -242,6 +242,11 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     if (!rootId) return session;
 
     const identityName = rootId === 'main' ? agentName : rootIdentityNames[rootId];
+    if (rootId !== 'main' && !identityName) {
+      if (!session.identityName) return session;
+      const { identityName: _dropIdentity, ...rest } = session;
+      return rest;
+    }
     if (!identityName || session.identityName === identityName) return session;
     return { ...session, identityName };
   }), [agentName, rootIdentityNames, sessions]);

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -71,6 +71,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const [agentStatus, setAgentStatus] = useState<Record<string, GranularAgentState>>({});
   const [agentName, setAgentName] = useState('Agent');
   const [rootIdentityNames, setRootIdentityNames] = useState<Record<string, string>>({});
+  const [rootIdentityMisses, setRootIdentityMisses] = useState<Record<string, true>>({});
   const [unreadSessionKeys, setUnreadSessionKeys] = useState<Set<string>>(new Set());
   const unreadSessionKeysRef = useRef(unreadSessionKeys);
   const soundEnabledRef = useRef(soundEnabled);
@@ -176,7 +177,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         .filter(isTopLevelAgentSessionKey)
         .map((sessionKey) => getRootAgentId(sessionKey))
         .filter((rootId): rootId is string => Boolean(rootId) && rootId !== 'main'),
-    )).filter((rootId) => !rootIdentityNames[rootId]);
+    )).filter((rootId) => !rootIdentityNames[rootId] && !rootIdentityMisses[rootId]);
 
     if (rootAgentIds.length === 0) return;
 
@@ -188,19 +189,40 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         if (!res.ok) return null;
         const data = await res.json() as { ok?: boolean; content?: string };
         const identityName = typeof data.content === 'string' ? extractIdentityName(data.content) : null;
-        return identityName ? { rootId, identityName } : null;
+        if (identityName) return { rootId, identityName, kind: 'hit' as const };
+        return { rootId, kind: 'miss' as const };
       } catch (err) {
         if (err instanceof Error && err.name === 'AbortError') return null;
         return null;
       }
     })).then((results) => {
       if (controller.signal.aborted) return;
-      const resolved = results.filter((result): result is { rootId: string; identityName: string } => Boolean(result));
+      const resolved = results.filter((result): result is NonNullable<typeof result> => Boolean(result));
       if (resolved.length === 0) return;
+
+      setRootIdentityMisses((prev) => {
+        let changed = false;
+        const next = { ...prev };
+        for (const result of resolved) {
+          if (result.kind === 'hit') {
+            if (!next[result.rootId]) continue;
+            delete next[result.rootId];
+            changed = true;
+            continue;
+          }
+          if (next[result.rootId]) continue;
+          next[result.rootId] = true;
+          changed = true;
+        }
+        return changed ? next : prev;
+      });
+
       setRootIdentityNames((prev) => {
         const next = { ...prev };
         let changed = false;
-        for (const { rootId, identityName } of resolved) {
+        for (const result of resolved) {
+          if (result.kind !== 'hit') continue;
+          const { rootId, identityName } = result;
           if (next[rootId] === identityName) continue;
           next[rootId] = identityName;
           changed = true;
@@ -210,7 +232,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     });
 
     return () => controller.abort();
-  }, [rootIdentityNames, sessions]);
+  }, [rootIdentityMisses, rootIdentityNames, sessions]);
 
   const displaySessions = useMemo(() => sessions.map((session) => {
     const sessionKey = getSessionKey(session);

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -8,6 +8,7 @@ import { describeToolUse } from '@/utils/helpers';
 import { buildSessionTree } from '@/features/sessions/sessionTree';
 import {
   buildAgentRootSessionKey,
+  extractIdentityName,
   getAgentRegistrationName,
   getRootAgentSessionKey,
   getSessionDisplayLabel,
@@ -69,6 +70,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const [eventEntries, setEventEntries] = useState<EventEntry[]>([]);
   const [agentStatus, setAgentStatus] = useState<Record<string, GranularAgentState>>({});
   const [agentName, setAgentName] = useState('Agent');
+  const [rootIdentityNames, setRootIdentityNames] = useState<Record<string, string>>({});
   const [unreadSessionKeys, setUnreadSessionKeys] = useState<Set<string>>(new Set());
   const unreadSessionKeysRef = useRef(unreadSessionKeys);
   const soundEnabledRef = useRef(soundEnabled);
@@ -168,8 +170,63 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   
   // Update refs in effect to avoid render-time mutations
   useEffect(() => {
-    sessionsRef.current = sessions;
-  }, [sessions]);
+    const rootAgentIds = Array.from(new Set(
+      sessions
+        .map((session) => getSessionKey(session))
+        .filter(isTopLevelAgentSessionKey)
+        .map((sessionKey) => getRootAgentId(sessionKey))
+        .filter((rootId): rootId is string => Boolean(rootId) && rootId !== 'main'),
+    )).filter((rootId) => !rootIdentityNames[rootId]);
+
+    if (rootAgentIds.length === 0) return;
+
+    const controller = new AbortController();
+    void Promise.all(rootAgentIds.map(async (rootId) => {
+      try {
+        const params = new URLSearchParams({ agentId: rootId });
+        const res = await fetch(`/api/workspace/identity?${params.toString()}`, { signal: controller.signal });
+        if (!res.ok) return null;
+        const data = await res.json() as { ok?: boolean; content?: string };
+        const identityName = typeof data.content === 'string' ? extractIdentityName(data.content) : null;
+        return identityName ? { rootId, identityName } : null;
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return null;
+        return null;
+      }
+    })).then((results) => {
+      if (controller.signal.aborted) return;
+      const resolved = results.filter((result): result is { rootId: string; identityName: string } => Boolean(result));
+      if (resolved.length === 0) return;
+      setRootIdentityNames((prev) => {
+        const next = { ...prev };
+        let changed = false;
+        for (const { rootId, identityName } of resolved) {
+          if (next[rootId] === identityName) continue;
+          next[rootId] = identityName;
+          changed = true;
+        }
+        return changed ? next : prev;
+      });
+    });
+
+    return () => controller.abort();
+  }, [rootIdentityNames, sessions]);
+
+  const displaySessions = useMemo(() => sessions.map((session) => {
+    const sessionKey = getSessionKey(session);
+    if (!isTopLevelAgentSessionKey(sessionKey)) return session;
+
+    const rootId = getRootAgentId(sessionKey);
+    if (!rootId) return session;
+
+    const identityName = rootId === 'main' ? agentName : rootIdentityNames[rootId];
+    if (!identityName || session.identityName === identityName) return session;
+    return { ...session, identityName };
+  }), [agentName, rootIdentityNames, sessions]);
+
+  useEffect(() => {
+    sessionsRef.current = displaySessions;
+  }, [displaySessions]);
   
   const currentSessionRef = useRef(currentSession);
   useEffect(() => {
@@ -819,7 +876,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   }, [rpc]);
 
   const value = useMemo<SessionContextValue>(() => ({
-    sessions,
+    sessions: displaySessions,
     sessionsLoading,
     currentSession,
     setCurrentSession,
@@ -837,7 +894,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     eventEntries,
     agentName,
   }), [
-    sessions, sessionsLoading, currentSession, setCurrentSession, busyState, agentStatus,
+    displaySessions, sessionsLoading, currentSession, setCurrentSession, busyState, agentStatus,
     unreadSessions, markSessionRead,
     abortSession, refreshSessions, deleteSession, spawnSession, renameSession,
     updateSessionFromEvent, agentLogEntries, eventEntries, agentName,

--- a/src/features/kanban/CreateTaskDialog.test.tsx
+++ b/src/features/kanban/CreateTaskDialog.test.tsx
@@ -47,8 +47,8 @@ describe('CreateTaskDialog', () => {
     mockUseSessionContext.mockReturnValue({
       sessions: [
         { sessionKey: 'agent:main:main', label: 'Kim (main)' },
-        { sessionKey: 'agent:designer:main', label: 'Designer' },
-        { sessionKey: 'agent:reviewer:main', label: 'Reviewer' },
+        { sessionKey: 'agent:designer:main', identityName: 'Designer' },
+        { sessionKey: 'agent:reviewer:main', identityName: 'Reviewer' },
         { sessionKey: 'agent:designer:subagent:abc', label: 'Designer helper' },
       ],
       agentName: 'Kim',
@@ -63,8 +63,8 @@ describe('CreateTaskDialog', () => {
 
     expect(await screen.findByRole('option', { name: 'Unassigned' })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: 'Operator' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Designer' })).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: 'Reviewer' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Designer (designer)' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Reviewer (reviewer)' })).toBeInTheDocument();
     expect(screen.queryByRole('option', { name: 'Kim (main)' })).not.toBeInTheDocument();
     expect(screen.queryByRole('option', { name: 'Designer helper' })).not.toBeInTheDocument();
   });
@@ -76,7 +76,7 @@ describe('CreateTaskDialog', () => {
 
     await user.type(screen.getByLabelText(/title/i), 'Test task');
     await user.click(screen.getByRole('combobox', { name: 'Assignee' }));
-    await user.click(await screen.findByRole('option', { name: 'Designer' }));
+    await user.click(await screen.findByRole('option', { name: 'Designer (designer)' }));
     await user.click(screen.getByRole('button', { name: /create task/i }));
 
     await waitFor(() => {

--- a/src/features/kanban/TaskDetailDrawer.test.tsx
+++ b/src/features/kanban/TaskDetailDrawer.test.tsx
@@ -52,8 +52,8 @@ describe('TaskDetailDrawer', () => {
     });
     mockUseSessionContext.mockReturnValue({
       sessions: [
-        { sessionKey: 'agent:designer:main', label: 'Designer' },
-        { sessionKey: 'agent:reviewer:main', label: 'Reviewer' },
+        { sessionKey: 'agent:designer:main', identityName: 'Designer' },
+        { sessionKey: 'agent:reviewer:main', identityName: 'Reviewer' },
       ],
       agentName: 'Kim',
     });
@@ -62,7 +62,7 @@ describe('TaskDetailDrawer', () => {
   it('shows the friendly current assignee label when the task assignee is active', () => {
     renderDrawer(makeTask({ assignee: 'agent:designer' }));
 
-    expect(screen.getByRole('combobox', { name: 'Assignee' })).toHaveValue('Designer');
+    expect(screen.getByRole('combobox', { name: 'Assignee' })).toHaveValue('Designer (designer)');
   });
 
   it('does not render the assignee combobox inside an extra input-styled shell', () => {
@@ -102,7 +102,7 @@ describe('TaskDetailDrawer', () => {
     renderDrawer(makeTask({ assignee: 'agent:ghost-reviewer' }), onUpdate);
 
     await user.click(screen.getByRole('combobox', { name: 'Assignee' }));
-    await user.click(await screen.findByRole('option', { name: 'Reviewer' }));
+    await user.click(await screen.findByRole('option', { name: 'Reviewer (reviewer)' }));
     await user.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {

--- a/src/features/kanban/lib/assigneeOptions.test.ts
+++ b/src/features/kanban/lib/assigneeOptions.test.ts
@@ -20,8 +20,8 @@ describe('assigneeOptions', () => {
     expect(buildAssigneeOptions(sessions, 'Nerve')).toEqual([
       { value: '', label: 'Unassigned' },
       { value: 'operator', label: 'Operator' },
-      { value: 'agent:designer', label: 'Alpha Agent' },
-      { value: 'agent:reviewer', label: 'Reviewer' },
+      { value: 'agent:designer', label: 'designer' },
+      { value: 'agent:reviewer', label: 'reviewer' },
     ]);
   });
 
@@ -50,7 +50,7 @@ describe('assigneeOptions', () => {
     expect(buildAssigneeOptions(sessions, 'Nerve')).toEqual([
       { value: '', label: 'Unassigned' },
       { value: 'operator', label: 'Operator' },
-      { value: 'agent:builder', label: 'Builder' },
+      { value: 'agent:builder', label: 'builder' },
     ]);
   });
 
@@ -63,7 +63,7 @@ describe('assigneeOptions', () => {
     expect(buildAssigneeOptionsForEdit(sessions, 'agent:design-reviewer-2', 'Nerve')).toEqual([
       { value: '', label: 'Unassigned' },
       { value: 'operator', label: 'Operator' },
-      { value: 'agent:reviewer', label: 'Reviewer' },
+      { value: 'agent:reviewer', label: 'reviewer' },
       { value: 'agent:design-reviewer-2', label: 'Agent design reviewer 2 (inactive)', disabled: true },
     ]);
   });
@@ -77,7 +77,7 @@ describe('assigneeOptions', () => {
     const expected = [
       { value: '', label: 'Unassigned' },
       { value: 'operator', label: 'Operator' },
-      { value: 'agent:reviewer', label: 'Reviewer' },
+      { value: 'agent:reviewer', label: 'reviewer' },
     ];
 
     expect(buildAssigneeOptionsForEdit(sessions, '')).toEqual(expected);
@@ -95,7 +95,7 @@ describe('assigneeOptions', () => {
     expect(buildAssigneeOptionsForEdit(sessions, ' agent:reviewer ')).toEqual([
       { value: '', label: 'Unassigned' },
       { value: 'operator', label: 'Operator' },
-      { value: 'agent:reviewer', label: 'Reviewer' },
+      { value: 'agent:reviewer', label: 'reviewer' },
     ]);
   });
 

--- a/src/features/kanban/lib/assigneeOptions.test.ts
+++ b/src/features/kanban/lib/assigneeOptions.test.ts
@@ -38,6 +38,19 @@ describe('assigneeOptions', () => {
     ]);
   });
 
+  it('uses identity-backed labels for hydrated root agents', () => {
+    const sessions = [
+      session('agent:main:main'),
+      session('agent:designer:main', { identityName: 'Designer Prime' }),
+    ];
+
+    expect(buildAssigneeOptions(sessions, 'Nerve')).toEqual([
+      { value: '', label: 'Unassigned' },
+      { value: 'operator', label: 'Operator' },
+      { value: 'agent:designer', label: 'Designer Prime (designer)' },
+    ]);
+  });
+
   it('ignores non-top-level sessions', () => {
     const sessions = [
       session('agent:main:main'),

--- a/src/features/sessions/sessionKeys.test.ts
+++ b/src/features/sessions/sessionKeys.test.ts
@@ -3,6 +3,7 @@ import type { Session } from '@/types';
 import { getSessionKey } from '@/types';
 import {
   buildAgentRootSessionKey,
+  extractIdentityName,
   getAgentRegistrationName,
   getRootAgentId,
   getRootAgentSessionKey,
@@ -20,6 +21,12 @@ function session(sessionKey: string, extra: Partial<Session> = {}): Session {
 }
 
 describe('sessionKeys', () => {
+  it('extracts agent names from IDENTITY.md variants', () => {
+    expect(extractIdentityName('# IDENTITY.md - Who Am I?\n\n- **Name:** Blende\n- **Creature:** AI workshop familiar\n')).toBe('Blende');
+    expect(extractIdentityName('# IDENTITY.md\n- Name: forge\n- Role: Coding\n')).toBe('forge');
+    expect(extractIdentityName('# IDENTITY.md\n- Role: Coding only\n')).toBeNull();
+  });
+
   it('detects top-level agent sessions', () => {
     expect(isTopLevelAgentSessionKey('agent:main:main')).toBe(true);
     expect(isTopLevelAgentSessionKey('agent:reviewer:main')).toBe(true);
@@ -85,12 +92,22 @@ describe('sessionKeys', () => {
     expect(pickDefaultSessionKey(sessions)).toBe('agent:main:main');
   });
 
-  it('builds display labels from label, displayName, then root id', () => {
-    expect(getSessionDisplayLabel(session('agent:reviewer:main', { label: 'Reviewer', displayName: 'webchat:reviewer' }), 'Nerve')).toBe('Reviewer');
-    expect(getSessionDisplayLabel(session('agent:reviewer:main', { displayName: 'Reviewer Prime' }), 'Nerve')).toBe('Reviewer Prime');
-    expect(getSessionDisplayLabel(session('agent:reviewer:main', { label: 'Reviewer' }), 'Nerve')).toBe('Reviewer');
-    expect(getSessionDisplayLabel(session('agent:reviewer:main'), 'Nerve')).toBe('Agent reviewer');
+  it('builds display labels from identity name, then root id for root sessions', () => {
+    expect(getSessionDisplayLabel(session('agent:reviewer:main', { label: 'Reviewer', displayName: 'webchat:reviewer' }), 'Nerve')).toBe('reviewer');
+    expect(getSessionDisplayLabel(session('agent:reviewer:main', { displayName: 'Reviewer Prime' }), 'Nerve')).toBe('reviewer');
+    expect(getSessionDisplayLabel(session('agent:reviewer:main', { label: 'Reviewer' }), 'Nerve')).toBe('reviewer');
+    expect(getSessionDisplayLabel(session('agent:reviewer:main', { identityName: 'Reviewer Prime' }), 'Nerve')).toBe('Reviewer Prime (reviewer)');
+    expect(getSessionDisplayLabel(session('agent:reviewer:main'), 'Nerve')).toBe('reviewer');
     expect(getSessionDisplayLabel(session('agent:main:main'), 'Nerve')).toBe('Nerve (main)');
+  });
+
+  it('ignores gateway display names for non-main root sessions', () => {
+    expect(
+      getSessionDisplayLabel(
+        session('agent:coding:main', { displayName: 'Jordan Humphreys id:8243587348' }),
+        'Nerve',
+      ),
+    ).toBe('coding');
   });
 
   it('keeps the main root label canonical even if gateway metadata says heartbeat', () => {

--- a/src/features/sessions/sessionKeys.test.ts
+++ b/src/features/sessions/sessionKeys.test.ts
@@ -24,6 +24,7 @@ describe('sessionKeys', () => {
   it('extracts agent names from IDENTITY.md variants', () => {
     expect(extractIdentityName('# IDENTITY.md - Who Am I?\n\n- **Name:** Blende\n- **Creature:** AI workshop familiar\n')).toBe('Blende');
     expect(extractIdentityName('# IDENTITY.md\n- Name: forge\n- Role: Coding\n')).toBe('forge');
+    expect(extractIdentityName('# IDENTITY.md\nName: Reviewer Prime\nRole: Review agent\n')).toBe('Reviewer Prime');
     expect(extractIdentityName('# IDENTITY.md\n- Role: Coding only\n')).toBeNull();
   });
 

--- a/src/features/sessions/sessionKeys.ts
+++ b/src/features/sessions/sessionKeys.ts
@@ -132,7 +132,7 @@ export function getTopLevelAgentSessions(sessions: Session[]): Session[] {
 
 export function extractIdentityName(content: string): string | null {
   const normalized = content.replace(/\*\*/g, '');
-  const match = normalized.match(/^\s*[-*]\s*Name\s*:\s*(.+?)\s*$/im);
+  const match = normalized.match(/^\s*(?:[-*]\s*)?Name\s*:\s*(.+?)\s*$/im);
   return match?.[1]?.trim() || null;
 }
 

--- a/src/features/sessions/sessionKeys.ts
+++ b/src/features/sessions/sessionKeys.ts
@@ -130,20 +130,28 @@ export function getTopLevelAgentSessions(sessions: Session[]): Session[] {
     });
 }
 
+export function extractIdentityName(content: string): string | null {
+  const normalized = content.replace(/\*\*/g, '');
+  const match = normalized.match(/^\s*[-*]\s*Name\s*:\s*(.+?)\s*$/im);
+  return match?.[1]?.trim() || null;
+}
+
 export function getSessionDisplayLabel(session: Session, agentName = 'Agent'): string {
   const sessionKey = getSessionKey(session);
+  const rootId = getRootAgentId(sessionKey);
+  const identityName = session.identityName?.trim();
 
   if (sessionKey === 'agent:main:main') {
     return `${agentName} (main)`;
   }
 
+  if (isTopLevelAgentSessionKey(sessionKey)) {
+    if (identityName && rootId) return `${identityName} (${rootId})`;
+    if (rootId) return rootId;
+  }
+
   if (session.label?.trim()) return session.label.trim();
   if (session.displayName?.trim()) return session.displayName.trim();
-
-  if (isTopLevelAgentSessionKey(sessionKey)) {
-    const rootId = getRootAgentId(sessionKey);
-    if (rootId) return `Agent ${rootId}`;
-  }
 
   if (isCronSessionKey(sessionKey)) {
     return `Cron ${sessionKey.split(':')[3]?.slice(0, 8) || ''}`.trim();

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface Session {
   key?: string;
   id?: string;
   label?: string;
+  identityName?: string;
   state?: string;
   agentState?: string;
   busy?: boolean;


### PR DESCRIPTION
## What

Fix root-agent labeling so non-`main` top-level agents resolve from durable agent identity instead of transient session metadata.

## Why

This fixes root-agent rows showing stale `label` / `displayName` values from session metadata instead of the actual agent identity. `main` already used a dedicated identity path, but other root agents did not.

Closes #258

## How

- hydrate non-`main` root sessions with `identityName` from `/api/workspace/identity`
- parse `Name:` from each agent's `IDENTITY.md`
- render top-level root labels as `<identityName> (<rootId>)`
- keep canonical assignee/session values unchanged
- add regression coverage for session labeling and update kanban assignee-label tests to match the new root-label contract

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [ ] New features include tests
- [ ] UI changes include a screenshot or screen recording


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session labels now surface identity names from workspace identity files as "Identity Name (agent-id)" for clearer agent identification.
  * Sidebar and assignee pickers display identity-suffixed options for top-level agents.
  * Identity lookups are cached to avoid repeated fetches.

* **Bug Fixes**
  * Stale or unparsable identity labels are cleared so sidebar labels stay accurate after refresh.

* **Tests**
  * Added coverage for identity extraction, label hydration, caching, and refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->