### PR TITLE
fix(markdown): follow-up workspace inline reference handling

### DIFF
--- a/.plans/2026-04-11-workhorse-packaging-and-chat-links-hardening.md
+++ b/.plans/2026-04-11-workhorse-packaging-and-chat-links-hardening.md
@@ -1,0 +1,200 @@
+# gambit-openclaw-nerve — workhorse packaging + chat links hardening
+
+**Date:** 2026-04-11  
+**Status:** In Progress  
+**Agent:** Chip 🐱‍💻
+
+---
+
+## Goal
+
+Audit the current local `workhorse` delta, separate canonical source-branch work from local integration-only rollups, package the upstream-worthy fixes into Issues/PRs on the correct branches, and then evaluate product hardening options for missing `CHAT_PATH_LINKS.json` behavior.
+
+---
+
+## Overview
+
+Yesterday’s lane ended with local `workhorse` ahead of `origin/workhorse` by five commits, all confirmed working in dogfood. The important repo-hygiene constraint Derrick reinforced is still the governing rule: product fixes should not live only on `workhorse`. Each upstream-worthy fix needs a clean home on the branch that actually owns it, with `workhorse` acting only as the downstream dogfood/integration branch.
+
+The immediate work is therefore packaging and provenance, not more blind coding. First we need a precise rundown of what the five local `workhorse` commits are doing, how they cluster into distinct product lanes, and which clean source branches already exist for them. That audit must also verify whether any of those owning branches already have upstream Issues/PRs in flight so we modify the existing owning branch instead of accidentally creating duplicate lanes. Every candidate source branch we touch, plus the new hardening lane if we create it, must be confirmed to descend directly from `upstream/master` rather than from `workhorse`.
+
+After that packaging work is stable, we can discuss hardening. The missing `CHAT_PATH_LINKS.json` file exposed a weak bootstrap/default path: the feature silently degraded into confusing behavior instead of clearly regenerating or surfacing the missing config. The hardening conversation should compare install-time OS-aware seeding, in-product editability/restart flow, and a guaranteed default-file regeneration path when the file is absent.
+
+---
+
+## Tasks
+
+### Task 1: Audit local `workhorse` commit stack and classify ownership
+
+**Bead ID:** `nerve-wlgl`  
+**SubAgent:** `primary`  
+**Prompt:** Inspect local `workhorse` versus `origin/workhorse`, summarize each of the five local commits in plain engineering language, map each commit to its canonical source branch (if one already exists), and recommend whether the current local stack should be treated as one branch/lane or split into multiple upstream lanes. Explicitly call out which commits are renderer/linkification work versus upload-config/Add-to-chat work versus any hardening/bootstrap follow-up that is not yet productized. Also check GitHub for existing upstream Issues/PRs tied to those owning branches so we reuse the current lane instead of duplicating it, and verify each owning branch descends from `upstream/master` rather than `workhorse`.
+
+**Folders Created/Deleted/Modified:**
+- `.plans/`
+- repo metadata only during analysis
+
+**Files Created/Deleted/Modified:**
+- `.plans/2026-04-11-workhorse-packaging-and-chat-links-hardening.md`
+
+**Status:** ✅ Complete
+
+**Results:** Local `workhorse` is ahead of `origin/workhorse` by 5 commits and the stack cleanly splits into two existing source branches, not one monolith. Four commits belong to `bugfix/workspace-inline-reference-slice` and one commit belongs to `fix/upload-config-capability`.
+
+Commit rundown / ownership:
+- `4e3c8fb` — linkifies embedded `/workspace/...` path slices in markdown/chat and adds focused renderer coverage. This is a cherry-pick of `36cca92` from `bugfix/workspace-inline-reference-slice`.
+- `2b064f0` — narrows inline path token typing so the matcher stops overreaching. Matches `d3d3a64` on `bugfix/workspace-inline-reference-slice`.
+- `719db38` — fixes wrapped/punctuation-adjacent workspace inline links in the renderer. Matches `a04876e` on `bugfix/workspace-inline-reference-slice`.
+- `5435706` — tightens workspace-rooted matching plus resolve-path guardrails/tests so only intended workspace-style paths become actionable. This is a cherry-pick of `6cf2616` from `bugfix/workspace-inline-reference-slice`.
+- `40e9e14` — restores the server upload-config capability endpoint with helper + route + tests. Matches clean branch `fix/upload-config-capability` commit `5b2b092`.
+
+Git ancestry verification:
+- `bugfix/workspace-inline-reference-slice` and `fix/upload-config-capability` both merge-base with `upstream/master` at `a5f7973`, and both have the same merge-base against `workhorse`.
+- `git merge-base --is-ancestor upstream/master <branch>` succeeds for both branches.
+- `git merge-base --is-ancestor workhorse <branch>` fails for both branches, so neither clean branch descends from current `workhorse`.
+
+GitHub state (upstream `daggerhashimoto/openclaw-nerve`):
+- No existing upstream PRs match branch names `bugfix/workspace-inline-reference-slice` or `fix/upload-config-capability`.
+- No upstream issue/PR currently covers the upload-config restoration lane.
+- The broader chat-path-links feature already exists upstream as issue `#237` and PRs `#238` (closed, wrong stack) / `#239` (merged). The current four workspace commits are follow-up fixes/hardening on that already-landed lane, not a duplicate of the original feature PR.
+- Existing open attachment/add-to-chat upstream lanes are `#232` / PR `#233` (workspace file-tree Add to chat) and `#234` / PR `#235` (directory context insertion). The local upload-config fix appears adjacent infrastructure for those workflows, not an already-filed upstream lane.
+- No upstream issue/PR was found yet for missing-file/default-regeneration hardening around `CHAT_PATH_LINKS.json`.
+
+Packaging recommendation:
+- Split the local 5-commit delta into multiple upstream lanes.
+- Lane 1: workspace linkification follow-up fixes = the 4 commits owned by `bugfix/workspace-inline-reference-slice`.
+- Lane 2: upload-config / Add-to-chat capability restoration = the 1 commit owned by `fix/upload-config-capability`.
+- Lane 3: separate future hardening/bootstrap lane for `CHAT_PATH_LINKS.json` missing-file/default regeneration; keep it out of the two validated bugfix lanes because no code for that policy exists in the current 5-commit stack.
+
+Decision note: `workhorse` is acting as a downstream integration branch here. The clean source of truth already exists for the first two lanes, so the next step should update/reuse those owning branches rather than creating fresh duplicate branches from `workhorse`.
+
+---
+
+### Task 2: Reconcile branch provenance and decide packaging strategy
+
+**Bead ID:** `nerve-bs0u`  
+**SubAgent:** `primary`  
+**Prompt:** Using the Task 1 audit, confirm which clean source branches already contain the validated fixes, identify any local-only `workhorse` commits that still lack a proper owning source branch, and propose the exact packaging plan for upstream work: branch names, issue boundaries, PR boundaries, and which items should remain local-only integration commits if any.
+
+**Folders Created/Deleted/Modified:**
+- `.plans/`
+- git branches / refs as needed for inspection only
+
+**Files Created/Deleted/Modified:**
+- `.plans/2026-04-11-workhorse-packaging-and-chat-links-hardening.md`
+
+**Status:** ✅ Complete
+
+**Results:** Packaging decision is now explicit and operational:
+- No local-only `workhorse` commit lacks an owning clean branch. All 5 local commits already have proper canonical homes: 4 on `bugfix/workspace-inline-reference-slice`, 1 on `fix/upload-config-capability`.
+- Branch/package boundaries:
+  - `bugfix/workspace-inline-reference-slice` stays a standalone upstream follow-up lane for post-`#239` chat-path-link rendering fixes. Treat it as a narrow bugfix slice, not as a continuation of the already-closed feature issue `#237`.
+  - `fix/upload-config-capability` stays a separate one-commit infrastructure/attachment-capability lane. Do not fold it into the workspace linkification branch or directly into PRs `#233`/`#235`.
+  - missing-file/default-regeneration behavior for `CHAT_PATH_LINKS.json` should be a third future lane, opened as its own issue before implementation.
+- Issue strategy:
+  - Open a new focused issue for the workspace linkification follow-up regressions/edge cases; reference `#237` / merged `#239` as prior art instead of reopening or reusing them.
+  - Open a new focused issue for upload-config capability restoration; mention its relationship to the open Add-to-chat stack (`#232`/`#233` and `#234`/`#235`) because it restores supporting server capability, but keep scope independent.
+  - Open a separate hardening/bootstrap issue for auto-regenerating/defaulting `CHAT_PATH_LINKS.json` when missing, before any code work starts.
+- PR strategy:
+  - Push `bugfix/workspace-inline-reference-slice` as-is and open one PR from that branch after creating its focused issue.
+  - Push `fix/upload-config-capability` as-is and open one PR from that branch after creating its focused issue.
+  - Do not rebase either branch onto `workhorse`; both already descend cleanly from `upstream/master` and are appropriately scoped.
+  - Only adjust branch text (commit messages/PR descriptions/issue linkage) if needed during packaging; no product-code replay is required.
+- What remains local-only on `workhorse` after packaging:
+  - No unique product commit should remain local-only there.
+  - `workhorse` may temporarily continue carrying the same cherry-picks as downstream dogfood/integration history until the clean branches are pushed and upstream review lands, but provenance should point to the clean branches, not `workhorse`.
+
+---
+
+### Task 3: Close out Issues + PRs for the approved packaging plan
+
+**Bead ID:** `nerve-gyqp`  
+**SubAgent:** `coder`  
+**Prompt:** Execute the approved upstream packaging plan: create any missing clean source branch work needed from current validated commits, open or update the corresponding GitHub Issues/PRs, and leave `workhorse` as the downstream integration branch only. Record commit provenance carefully so the final summary can show canonical branch commit(s), `workhorse` cherry-pick commit(s), and linked Issue/PR numbers.
+
+**Folders Created/Deleted/Modified:**
+- product source files only if packaging gaps require a clean-branch replay
+- `.plans/`
+
+**Files Created/Deleted/Modified:**
+- `.plans/2026-04-11-workhorse-packaging-and-chat-links-hardening.md`
+- any touched source/test files required for canonical branch packaging
+
+**Status:** ✅ Complete
+
+**Results:** Both approved clean branches were verified, pushed, and packaged upstream without touching product code.
+
+Verification / provenance checks:
+- `bugfix/workspace-inline-reference-slice` still exists locally at `6cf2616` and `git merge-base --is-ancestor upstream/master bugfix/workspace-inline-reference-slice` succeeds.
+- `fix/upload-config-capability` still exists locally at `5b2b092` and `git merge-base --is-ancestor upstream/master fix/upload-config-capability` succeeds.
+- Neither branch had an existing upstream PR open from the Gambit fork before packaging.
+- Both branches were pushed to `origin` and now track:
+  - `origin/bugfix/workspace-inline-reference-slice`
+  - `origin/fix/upload-config-capability`
+
+Workspace linkification follow-up lane:
+- Issue `#262` — <https://github.com/daggerhashimoto/openclaw-nerve/issues/262>
+- PR `#264` — <https://github.com/daggerhashimoto/openclaw-nerve/pull/264>
+- Branch: `bugfix/workspace-inline-reference-slice`
+- Canonical clean-branch commits:
+  - `36cca92` — `fix(markdown): linkify embedded workspace path slices`
+  - `d3d3a64` — `fix(markdown): narrow inline path match typing`
+  - `a04876e` — `Fix wrapped workspace inline path links`
+  - `6cf2616` — `Tighten workspace-rooted inline path matching`
+- Validated downstream via local `workhorse` cherry-picks:
+  - `4e3c8fb` <- `36cca92`
+  - `2b064f0` <- `d3d3a64`
+  - `719db38` <- `a04876e`
+  - `5435706` <- `6cf2616`
+- Packaging note: the new issue explicitly references prior art `#237` / merged PR `#239` and scopes this lane as a post-merge bugfix follow-up rather than reopening the original feature request.
+- Review follow-up update (2026-04-11): addressed PR `#264` review feedback on the owning branch — inline workspace candidates now percent-decode before dispatch, inline code stops linkifying when already inside a markdown link to avoid nested anchors, and overmatch regressions now assert zero rendered links. Focused markdown tests and targeted eslint passed after the fix.
+
+Upload-config capability restoration lane:
+- Issue `#263` — <https://github.com/daggerhashimoto/openclaw-nerve/issues/263>
+- PR `#265` — <https://github.com/daggerhashimoto/openclaw-nerve/pull/265>
+- Branch: `fix/upload-config-capability`
+- Canonical clean-branch commit:
+  - `5b2b092` — `fix(server): restore upload config endpoint`
+- Validated downstream via local `workhorse` cherry-pick:
+  - `40e9e14` <- `5b2b092`
+- Packaging note: the new issue references related Add-to-chat lineage `#232`/`#233` and `#234`/`#235`, while keeping the lane narrowly scoped to the missing `/api/upload-config` capability route.
+
+Hardening lane decision:
+- No `CHAT_PATH_LINKS.json` hardening/bootstrap issue was created in this packaging pass.
+- Recommendation remains to evaluate that as a separate later lane, exactly as planned, instead of muddying the two clean bugfix PRs above.
+
+---
+
+### Task 4: Evaluate chat-links hardening strategies
+
+**Bead ID:** `Pending`  
+**SubAgent:** `research`  
+**Prompt:** Review the current `feature/chat-path-links` lineage, the live missing-file failure mode for `CHAT_PATH_LINKS.json`, and Derrick’s three hardening options. Produce an engineering recommendation that compares: (1) OS-aware install-time seeding of home-path prefixes, (2) Nerve settings UI access/edit/restart flow, and (3) doing both. Include a minimum-safe hardening requirement: if the chat links file is missing, generate the default file automatically and avoid silent broken states.
+
+**Folders Created/Deleted/Modified:**
+- `.plans/`
+- source files only if code inspection is needed
+
+**Files Created/Deleted/Modified:**
+- `.plans/2026-04-11-workhorse-packaging-and-chat-links-hardening.md`
+
+**Status:** ⏳ Pending
+
+**Results:** Pending.
+
+---
+
+## Final Results
+
+**Status:** ⏳ Pending
+
+**What We Built:** Pending.
+
+**Commits:**
+- Pending
+
+**Lessons Learned:** Pending.
+
+---
+
+*Created on 2026-04-11*

--- a/server/routes/file-browser.test.ts
+++ b/server/routes/file-browser.test.ts
@@ -174,6 +174,39 @@ describe('file-browser routes', () => {
       expect(json).toEqual({ ok: true, path: 'src/main.ts', type: 'file', binary: false });
     });
 
+    it('accepts absolute host paths rooted at the real workspace by normalizing them to workspace-relative', async () => {
+      await fs.mkdir(path.join(tmpDir, 'src'));
+      await fs.writeFile(path.join(tmpDir, 'src', 'main.ts'), 'export {};');
+      const app = await buildApp();
+      const absoluteTarget = path.join(tmpDir, 'src', 'main.ts').split(path.sep).join('/');
+
+      const res = await app.request(`/api/files/resolve?path=${encodeURIComponent(absoluteTarget)}`);
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { ok: boolean; path: string; type: string; binary: boolean };
+      expect(json).toEqual({ ok: true, path: 'src/main.ts', type: 'file', binary: false });
+    });
+
+    it('keeps absolute host workspace paths rooted even when relativeTo is provided', async () => {
+      await fs.mkdir(path.join(tmpDir, 'src'));
+      await fs.mkdir(path.join(tmpDir, 'notes'));
+      await fs.writeFile(path.join(tmpDir, 'src', 'main.ts'), 'export {};');
+      const app = await buildApp();
+      const absoluteTarget = path.join(tmpDir, 'src', 'main.ts').split(path.sep).join('/');
+
+      const res = await app.request(`/api/files/resolve?path=${encodeURIComponent(absoluteTarget)}&relativeTo=notes/index.md`);
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { ok: boolean; path: string; type: string; binary: boolean };
+      expect(json).toEqual({ ok: true, path: 'src/main.ts', type: 'file', binary: false });
+    });
+
+    it('treats the absolute workspace root itself as a non-openable root target', async () => {
+      const app = await buildApp();
+      const absoluteRoot = tmpDir.split(path.sep).join('/');
+
+      const res = await app.request(`/api/files/resolve?path=${encodeURIComponent(absoluteRoot)}`);
+      expect(res.status).toBe(404);
+    });
+
     it('returns 403 for invalid or excluded targets', async () => {
       const app = await buildApp();
       const res = await app.request('/api/files/resolve?path=../../etc');

--- a/server/routes/file-browser.ts
+++ b/server/routes/file-browser.ts
@@ -173,7 +173,7 @@ function gatewayFilesToTree(files: Awaited<ReturnType<typeof gatewayFilesList>>)
     }));
 }
 
-function normalizeWorkspaceLookupPath(input: string): string {
+function normalizeWorkspaceLookupPath(input: string, workspaceRoot?: string): string {
   const trimmed = input.trim();
   if (trimmed === '/workspace' || trimmed === '/workspace/') {
     return '.';
@@ -181,6 +181,20 @@ function normalizeWorkspaceLookupPath(input: string): string {
 
   if (trimmed.startsWith('/workspace/')) {
     return trimmed.slice('/workspace/'.length);
+  }
+
+  const normalizedWorkspaceRoot = workspaceRoot
+    ? getWorkspaceRoot(workspaceRoot).split(path.sep).join('/').replace(/\/+$/, '')
+    : '';
+
+  if (normalizedWorkspaceRoot) {
+    if (trimmed === normalizedWorkspaceRoot || trimmed === `${normalizedWorkspaceRoot}/`) {
+      return '.';
+    }
+
+    if (trimmed.startsWith(`${normalizedWorkspaceRoot}/`)) {
+      return trimmed.slice(normalizedWorkspaceRoot.length + 1);
+    }
   }
 
   return trimmed;
@@ -303,14 +317,17 @@ app.get('/api/files/resolve', async (c) => {
   }
 
   const rawTargetPath = targetPath.trim().replace(/\\/g, '/');
-  const normalizedTargetPath = normalizeWorkspaceLookupPath(rawTargetPath);
+  const normalizedTargetPath = normalizeWorkspaceLookupPath(rawTargetPath, workspace.workspaceRoot);
   const workspaceRelativePath = (() => {
     if (!relativeTo) return normalizedTargetPath;
-    if (rawTargetPath === '/workspace' || rawTargetPath === '/workspace/') return '.';
-    if (rawTargetPath.startsWith('/workspace/')) return rawTargetPath.slice('/workspace/'.length);
+    if (normalizedTargetPath === '.') return '.';
+    if (normalizedTargetPath !== rawTargetPath) return normalizedTargetPath;
     if (rawTargetPath.startsWith('/')) return rawTargetPath.replace(/^\/+/, '');
 
-    const normalizedRelativeTo = normalizeWorkspaceLookupPath(relativeTo.replace(/\\/g, '/')).replace(/^\/+/, '');
+    const normalizedRelativeTo = normalizeWorkspaceLookupPath(
+      relativeTo.replace(/\\/g, '/'),
+      workspace.workspaceRoot,
+    ).replace(/^\/+/, '');
     const relativeDir = path.posix.dirname(normalizedRelativeTo);
     return path.posix.normalize(path.posix.join(relativeDir === '.' ? '' : relativeDir, normalizedTargetPath));
   })();

--- a/src/features/chat/chatPathLinks.test.ts
+++ b/src/features/chat/chatPathLinks.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_CHAT_PATH_LINKS_CONFIG, parseChatPathLinksConfig } from './chatPathLinks';
+
+describe('chatPathLinks config', () => {
+  it('defaults to the canonical workspace prefix', () => {
+    expect(DEFAULT_CHAT_PATH_LINKS_CONFIG).toEqual({ prefixes: ['/workspace/'] });
+  });
+
+  it('keeps configured prefixes trimmed without requiring a separate workspace shorthand entry', () => {
+    expect(
+      parseChatPathLinksConfig(JSON.stringify({
+        prefixes: ['  /workspace/  ', '  /home/derrick/.openclaw/workspace/  '],
+      })),
+    ).toEqual({
+      prefixes: ['/workspace/', '/home/derrick/.openclaw/workspace/'],
+    });
+  });
+
+  it('falls back to the canonical workspace prefix when prefixes are missing or empty', () => {
+    expect(parseChatPathLinksConfig('{}')).toEqual({ prefixes: ['/workspace/'] });
+    expect(parseChatPathLinksConfig(JSON.stringify({ prefixes: [] }))).toEqual({ prefixes: ['/workspace/'] });
+    expect(parseChatPathLinksConfig(JSON.stringify({ prefixes: ['   '] }))).toEqual({ prefixes: ['/workspace/'] });
+  });
+});

--- a/src/features/markdown/MarkdownRenderer.test.tsx
+++ b/src/features/markdown/MarkdownRenderer.test.tsx
@@ -92,7 +92,7 @@ describe('MarkdownRenderer', () => {
       />,
     );
 
-    expect(screen.queryByRole('link', { name: '/workspace/src/App.tsx' })).toBeNull();
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
   });
 
   it('does not linkify a bare /workspace prefix with no path after it', () => {
@@ -166,6 +166,23 @@ describe('MarkdownRenderer', () => {
     expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/src/App.tsx', undefined);
   });
 
+  it('decodes percent-escaped inline workspace link targets before dispatch', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="Open file:///workspace/My%20Doc.md and /workspace/foo%23bar.md now"
+        pathLinkPrefixes={['/workspace/']}
+        onOpenWorkspacePath={onOpenWorkspacePath}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'file:///workspace/My%20Doc.md' }));
+    fireEvent.click(screen.getByRole('link', { name: '/workspace/foo%23bar.md' }));
+
+    expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(1, '/workspace/My Doc.md', undefined);
+    expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(2, '/workspace/foo#bar.md', undefined);
+  });
+
   it('linkifies full host-absolute workspace paths while opening the canonical workspace target', () => {
     const onOpenWorkspacePath = vi.fn();
     render(
@@ -192,8 +209,7 @@ describe('MarkdownRenderer', () => {
       />,
     );
 
-    expect(screen.queryByRole('link', { name: '/home/derrick/.openclaw/workspace/src/App.tsx' })).toBeNull();
-    expect(screen.queryByRole('link', { name: '/workspace/src/App.tsx' })).toBeNull();
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
   });
 
   it('linkifies wrapped workspace-rooted paths as single inline tokens while normalizing host-absolute forms', () => {
@@ -277,6 +293,30 @@ describe('MarkdownRenderer', () => {
 
     expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(1, '/workspace/src/App.tsx', undefined);
     expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(2, '/workspace/src/Main.tsx', undefined);
+  });
+
+  it('does not create nested workspace anchors inside markdown links that wrap inline code', async () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="[`/workspace/src/App.tsx`](docs/todo.md)"
+        pathLinkPrefixes={['/workspace/']}
+        onOpenWorkspacePath={onOpenWorkspacePath}
+      />,
+    );
+
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveTextContent('/workspace/src/App.tsx');
+    expect(links[0].querySelector('a')).toBeNull();
+    expect(document.querySelectorAll('code a')).toHaveLength(0);
+
+    fireEvent.click(links[0]);
+
+    await waitFor(() => {
+      expect(onOpenWorkspacePath).toHaveBeenCalledWith('docs/todo.md', undefined);
+    });
+    expect(onOpenWorkspacePath).toHaveBeenCalledTimes(1);
   });
 
   it('opens workspace links in-app when a handler is provided', async () => {

--- a/src/features/markdown/MarkdownRenderer.test.tsx
+++ b/src/features/markdown/MarkdownRenderer.test.tsx
@@ -154,9 +154,102 @@ describe('MarkdownRenderer', () => {
     expect(screen.queryByRole('link', { name: 'src/App.tsx' })).toBeNull();
   });
 
-  it('does not linkify configured path text inside inline code', () => {
-    render(<MarkdownRenderer content="Use `/workspace/src/App.tsx` later" pathLinkPrefixes={['/workspace/']} onOpenWorkspacePath={vi.fn()} />);
-    expect(screen.queryByRole('link', { name: '/workspace/src/App.tsx' })).toBeNull();
+  it('linkifies wrapped file URIs while normalizing the opened workspace path', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="Open file:///workspace/src/App.tsx, now"
+        pathLinkPrefixes={['/workspace/']}
+        onOpenWorkspacePath={onOpenWorkspacePath}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: 'file:///workspace/src/App.tsx' });
+    expect(link.parentElement?.textContent).toBe('Open file:///workspace/src/App.tsx, now');
+
+    fireEvent.click(link);
+    expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/src/App.tsx', undefined);
+  });
+
+  it('linkifies wrapped workspace paths as a single inline token', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content={"Open '/workspace/src/App.tsx' \"/workspace/src/Main.tsx\" </workspace/src/Guide.md> now"}
+        pathLinkPrefixes={['/workspace/']}
+        onOpenWorkspacePath={onOpenWorkspacePath}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: "'/workspace/src/App.tsx'" }));
+    fireEvent.click(screen.getByRole('link', { name: '"/workspace/src/Main.tsx"' }));
+    fireEvent.click(screen.getByRole('link', { name: '</workspace/src/Guide.md>' }));
+
+    expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(1, '/workspace/src/App.tsx', undefined);
+    expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(2, '/workspace/src/Main.tsx', undefined);
+    expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(3, '/workspace/src/Guide.md', undefined);
+  });
+
+  it('keeps trailing punctuation outside wrapped workspace links', () => {
+    render(
+      <MarkdownRenderer
+        content="Open '/workspace/src/App.tsx', now"
+        pathLinkPrefixes={['/workspace/']}
+        onOpenWorkspacePath={vi.fn()}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: "'/workspace/src/App.tsx'" });
+    expect(link.parentElement?.textContent).toBe("Open '/workspace/src/App.tsx', now");
+  });
+
+  it('does not linkify bare wrapped workspace prefixes or bare file workspace prefixes', () => {
+    render(
+      <MarkdownRenderer
+        content="Open '/workspace/' and file:///workspace/ later"
+        pathLinkPrefixes={['/workspace/']}
+        onOpenWorkspacePath={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole('link', { name: "'/workspace/'" })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'file:///workspace/' })).toBeNull();
+  });
+
+  it('does not turn unmatched wrappers into whole wrapped links', () => {
+    render(
+      <MarkdownRenderer
+        content="Open '/workspace/src/App.tsx later"
+        pathLinkPrefixes={['/workspace/']}
+        onOpenWorkspacePath={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole('link', { name: "'/workspace/src/App.tsx" })).toBeNull();
+    expect(screen.getByRole('link', { name: '/workspace/src/App.tsx' })).toBeInTheDocument();
+  });
+
+  it('linkifies configured path text inside inline code spans', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="Use `file:///workspace/src/App.tsx` and `/workspace/src/Main.tsx` later"
+        pathLinkPrefixes={['/workspace/']}
+        onOpenWorkspacePath={onOpenWorkspacePath}
+      />,
+    );
+
+    const fileUriLink = screen.getByRole('link', { name: 'file:///workspace/src/App.tsx' });
+    const workspaceLink = screen.getByRole('link', { name: '/workspace/src/Main.tsx' });
+
+    expect(fileUriLink.closest('code')).not.toBeNull();
+    expect(workspaceLink.closest('code')).not.toBeNull();
+
+    fireEvent.click(fileUriLink);
+    fireEvent.click(workspaceLink);
+
+    expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(1, '/workspace/src/App.tsx', undefined);
+    expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(2, '/workspace/src/Main.tsx', undefined);
   });
 
   it('opens workspace links in-app when a handler is provided', async () => {

--- a/src/features/markdown/MarkdownRenderer.test.tsx
+++ b/src/features/markdown/MarkdownRenderer.test.tsx
@@ -144,9 +144,39 @@ describe('MarkdownRenderer', () => {
     consoleError.mockRestore();
   });
 
+  it('does linkify bare workspace/... forms while normalizing them to the canonical workspace target', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="Open workspace/AGENTS.md and workspace/agents-sections/12-maintenance-and-updates.md now"
+        pathLinkPrefixes={['/workspace/']}
+        onOpenWorkspacePath={onOpenWorkspacePath}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'workspace/AGENTS.md' }));
+    fireEvent.click(screen.getByRole('link', { name: 'workspace/agents-sections/12-maintenance-and-updates.md' }));
+
+    expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(1, '/workspace/AGENTS.md', undefined);
+    expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(2, '/workspace/agents-sections/12-maintenance-and-updates.md', undefined);
+  });
+
   it('does not linkify relative paths when only /workspace is configured', () => {
     render(<MarkdownRenderer content="src/App.tsx" pathLinkPrefixes={['/workspace/']} onOpenWorkspacePath={vi.fn()} />);
     expect(screen.queryByRole('link', { name: 'src/App.tsx' })).toBeNull();
+  });
+
+  it('does not promote interior bare workspace tails or a bare workspace/ prefix into links', () => {
+    render(
+      <MarkdownRenderer
+        content="Open path=workspace/AGENTS.md and workspace/ later"
+        pathLinkPrefixes={['/workspace/']}
+        onOpenWorkspacePath={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+    expect(screen.queryByRole('link', { name: 'workspace/' })).toBeNull();
   });
 
   it('linkifies wrapped file URIs while normalizing the opened workspace path', () => {

--- a/src/features/markdown/MarkdownRenderer.test.tsx
+++ b/src/features/markdown/MarkdownRenderer.test.tsx
@@ -161,6 +161,23 @@ describe('MarkdownRenderer', () => {
     expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(2, '/workspace/agents-sections/12-maintenance-and-updates.md', undefined);
   });
 
+  it('treats bare workspace/... as an intentional shorthand even when host-absolute prefixes are configured', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="Open workspace/src/App.tsx and workspace/docs/Guide.md now"
+        pathLinkPrefixes={['/home/derrick/.openclaw/workspace/']}
+        onOpenWorkspacePath={onOpenWorkspacePath}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'workspace/src/App.tsx' }));
+    fireEvent.click(screen.getByRole('link', { name: 'workspace/docs/Guide.md' }));
+
+    expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(1, '/workspace/src/App.tsx', undefined);
+    expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(2, '/workspace/docs/Guide.md', undefined);
+  });
+
   it('does not linkify relative paths when only /workspace is configured', () => {
     render(<MarkdownRenderer content="src/App.tsx" pathLinkPrefixes={['/workspace/']} onOpenWorkspacePath={vi.fn()} />);
     expect(screen.queryByRole('link', { name: 'src/App.tsx' })).toBeNull();
@@ -246,7 +263,7 @@ describe('MarkdownRenderer', () => {
     const onOpenWorkspacePath = vi.fn();
     render(
       <MarkdownRenderer
-        content={"Open '/workspace/src/App.tsx' \"/workspace/src/Main.tsx\" </workspace/src/Guide.md> '/home/derrick/.openclaw/workspace/src/Host.tsx' now"}
+        content={"Open '/workspace/src/App.tsx' \"/workspace/src/Main.tsx\" </workspace/src/Guide.md> 'workspace/src/Inline.tsx' '/home/derrick/.openclaw/workspace/src/Host.tsx' now"}
         pathLinkPrefixes={['/workspace/', '/home/derrick/.openclaw/workspace/']}
         onOpenWorkspacePath={onOpenWorkspacePath}
       />,
@@ -255,12 +272,14 @@ describe('MarkdownRenderer', () => {
     fireEvent.click(screen.getByRole('link', { name: "'/workspace/src/App.tsx'" }));
     fireEvent.click(screen.getByRole('link', { name: '"/workspace/src/Main.tsx"' }));
     fireEvent.click(screen.getByRole('link', { name: '</workspace/src/Guide.md>' }));
+    fireEvent.click(screen.getByRole('link', { name: "'workspace/src/Inline.tsx'" }));
     fireEvent.click(screen.getByRole('link', { name: "'/home/derrick/.openclaw/workspace/src/Host.tsx'" }));
 
     expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(1, '/workspace/src/App.tsx', undefined);
     expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(2, '/workspace/src/Main.tsx', undefined);
     expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(3, '/workspace/src/Guide.md', undefined);
-    expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(4, '/workspace/src/Host.tsx', undefined);
+    expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(4, '/workspace/src/Inline.tsx', undefined);
+    expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(5, '/workspace/src/Host.tsx', undefined);
   });
 
   it('keeps trailing punctuation outside wrapped workspace links', () => {

--- a/src/features/markdown/MarkdownRenderer.test.tsx
+++ b/src/features/markdown/MarkdownRenderer.test.tsx
@@ -83,6 +83,35 @@ describe('MarkdownRenderer', () => {
     expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/src/App.tsx', undefined);
   });
 
+  it('linkifies only the /workspace slice when it appears inside a token', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="Open path=/workspace/src/App.tsx, now"
+        onOpenWorkspacePath={onOpenWorkspacePath}
+        pathLinkPrefixes={['/workspace/']}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: '/workspace/src/App.tsx' });
+    expect(link.parentElement?.textContent).toBe('Open path=/workspace/src/App.tsx, now');
+
+    fireEvent.click(link);
+    expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/src/App.tsx', undefined);
+  });
+
+  it('does not linkify a bare /workspace prefix with no path after it', () => {
+    render(
+      <MarkdownRenderer
+        content="Open /workspace/ later"
+        onOpenWorkspacePath={vi.fn()}
+        pathLinkPrefixes={['/workspace/']}
+      />,
+    );
+
+    expect(screen.queryByRole('link', { name: '/workspace/' })).toBeNull();
+  });
+
   it('passes current document context to inline path references too', () => {
     const onOpenWorkspacePath = vi.fn();
     render(

--- a/src/features/markdown/MarkdownRenderer.test.tsx
+++ b/src/features/markdown/MarkdownRenderer.test.tsx
@@ -83,21 +83,16 @@ describe('MarkdownRenderer', () => {
     expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/src/App.tsx', undefined);
   });
 
-  it('linkifies only the /workspace slice when it appears inside a token', () => {
-    const onOpenWorkspacePath = vi.fn();
+  it('does not linkify /workspace paths when they only appear as an interior token slice', () => {
     render(
       <MarkdownRenderer
         content="Open path=/workspace/src/App.tsx, now"
-        onOpenWorkspacePath={onOpenWorkspacePath}
+        onOpenWorkspacePath={vi.fn()}
         pathLinkPrefixes={['/workspace/']}
       />,
     );
 
-    const link = screen.getByRole('link', { name: '/workspace/src/App.tsx' });
-    expect(link.parentElement?.textContent).toBe('Open path=/workspace/src/App.tsx, now');
-
-    fireEvent.click(link);
-    expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/src/App.tsx', undefined);
+    expect(screen.queryByRole('link', { name: '/workspace/src/App.tsx' })).toBeNull();
   });
 
   it('does not linkify a bare /workspace prefix with no path after it', () => {
@@ -171,12 +166,42 @@ describe('MarkdownRenderer', () => {
     expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/src/App.tsx', undefined);
   });
 
-  it('linkifies wrapped workspace paths as a single inline token', () => {
+  it('linkifies full host-absolute workspace paths while opening the canonical workspace target', () => {
     const onOpenWorkspacePath = vi.fn();
     render(
       <MarkdownRenderer
-        content={"Open '/workspace/src/App.tsx' \"/workspace/src/Main.tsx\" </workspace/src/Guide.md> now"}
-        pathLinkPrefixes={['/workspace/']}
+        content="Open /home/derrick/.openclaw/workspace/src/App.tsx now"
+        pathLinkPrefixes={['/workspace/', '/home/derrick/.openclaw/workspace/']}
+        onOpenWorkspacePath={onOpenWorkspacePath}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: '/home/derrick/.openclaw/workspace/src/App.tsx' });
+    expect(link.parentElement?.textContent).toBe('Open /home/derrick/.openclaw/workspace/src/App.tsx now');
+
+    fireEvent.click(link);
+    expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/src/App.tsx', undefined);
+  });
+
+  it('does not promote interior host-absolute workspace tails into links', () => {
+    render(
+      <MarkdownRenderer
+        content="Open path=/home/derrick/.openclaw/workspace/src/App.tsx now"
+        pathLinkPrefixes={['/workspace/', '/home/derrick/.openclaw/workspace/']}
+        onOpenWorkspacePath={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole('link', { name: '/home/derrick/.openclaw/workspace/src/App.tsx' })).toBeNull();
+    expect(screen.queryByRole('link', { name: '/workspace/src/App.tsx' })).toBeNull();
+  });
+
+  it('linkifies wrapped workspace-rooted paths as single inline tokens while normalizing host-absolute forms', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content={"Open '/workspace/src/App.tsx' \"/workspace/src/Main.tsx\" </workspace/src/Guide.md> '/home/derrick/.openclaw/workspace/src/Host.tsx' now"}
+        pathLinkPrefixes={['/workspace/', '/home/derrick/.openclaw/workspace/']}
         onOpenWorkspacePath={onOpenWorkspacePath}
       />,
     );
@@ -184,10 +209,12 @@ describe('MarkdownRenderer', () => {
     fireEvent.click(screen.getByRole('link', { name: "'/workspace/src/App.tsx'" }));
     fireEvent.click(screen.getByRole('link', { name: '"/workspace/src/Main.tsx"' }));
     fireEvent.click(screen.getByRole('link', { name: '</workspace/src/Guide.md>' }));
+    fireEvent.click(screen.getByRole('link', { name: "'/home/derrick/.openclaw/workspace/src/Host.tsx'" }));
 
     expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(1, '/workspace/src/App.tsx', undefined);
     expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(2, '/workspace/src/Main.tsx', undefined);
     expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(3, '/workspace/src/Guide.md', undefined);
+    expect(onOpenWorkspacePath).toHaveBeenNthCalledWith(4, '/workspace/src/Host.tsx', undefined);
   });
 
   it('keeps trailing punctuation outside wrapped workspace links', () => {
@@ -216,7 +243,7 @@ describe('MarkdownRenderer', () => {
     expect(screen.queryByRole('link', { name: 'file:///workspace/' })).toBeNull();
   });
 
-  it('does not turn unmatched wrappers into whole wrapped links', () => {
+  it('does not turn unmatched wrappers into inner-tail links', () => {
     render(
       <MarkdownRenderer
         content="Open '/workspace/src/App.tsx later"
@@ -226,7 +253,7 @@ describe('MarkdownRenderer', () => {
     );
 
     expect(screen.queryByRole('link', { name: "'/workspace/src/App.tsx" })).toBeNull();
-    expect(screen.getByRole('link', { name: '/workspace/src/App.tsx' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: '/workspace/src/App.tsx' })).toBeNull();
   });
 
   it('linkifies configured path text inside inline code spans', () => {

--- a/src/features/markdown/MarkdownRenderer.tsx
+++ b/src/features/markdown/MarkdownRenderer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { hljs } from '@/lib/highlight';
@@ -55,6 +55,35 @@ type MarkdownLinkProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & Markdow
   children?: React.ReactNode;
   href?: string;
 };
+
+const MarkdownLinkContext = createContext(false);
+
+function InlineCodeContent({
+  codeString,
+  children,
+  pathLinkPrefixes,
+  currentDocumentPath,
+  onOpenWorkspacePath,
+}: {
+  codeString: string;
+  children?: React.ReactNode;
+  pathLinkPrefixes?: string[];
+  currentDocumentPath?: string;
+  onOpenWorkspacePath?: (path: string, basePath?: string) => void | Promise<void>;
+}) {
+  const isInsideMarkdownLink = useContext(MarkdownLinkContext);
+
+  if (isInsideMarkdownLink) {
+    return <>{children}</>;
+  }
+
+  return renderInlinePathReferences(codeString, {
+    prefixes: pathLinkPrefixes,
+    onOpenPath: onOpenWorkspacePath
+      ? (path: string) => onOpenWorkspacePath(path, currentDocumentPath)
+      : undefined,
+  });
+}
 
 function slugifyHeadingText(text: string): string {
   const normalized = text
@@ -338,12 +367,16 @@ export function MarkdownRenderer({
         }
 
         const inlineContent = inline
-          ? renderInlinePathReferences(codeString, {
-            prefixes: pathLinkPrefixes,
-            onOpenPath: onOpenWorkspacePath
-              ? (path: string) => onOpenWorkspacePath(path, currentDocumentPath)
-              : undefined,
-          })
+          ? (
+            <InlineCodeContent
+              codeString={codeString}
+              pathLinkPrefixes={pathLinkPrefixes}
+              currentDocumentPath={currentDocumentPath}
+              onOpenWorkspacePath={onOpenWorkspacePath}
+            >
+              {children}
+            </InlineCodeContent>
+          )
           : children;
 
         return (
@@ -385,44 +418,48 @@ export function MarkdownRenderer({
           const normalizedTarget = normalizeWorkspaceLinkTarget(href);
           const fragment = getWorkspaceLinkFragment(href);
           return (
-            <a
-              {...props}
-              href={href}
-              className={mergedClassName}
-              onClick={(event) => {
-                event.preventDefault();
-                Promise.resolve()
-                  .then(() => onOpenWorkspacePath(normalizedTarget, currentDocumentPath))
-                  .then(() => {
-                    if (fragment) {
-                      updateLocationHash(fragment);
-                    }
-                  })
-                  .catch((error) => {
-                    console.error('Failed to open workspace path link:', error);
-                  });
-              }}
-            >
-              {children}
-            </a>
+            <MarkdownLinkContext.Provider value={true}>
+              <a
+                {...props}
+                href={href}
+                className={mergedClassName}
+                onClick={(event) => {
+                  event.preventDefault();
+                  Promise.resolve()
+                    .then(() => onOpenWorkspacePath(normalizedTarget, currentDocumentPath))
+                    .then(() => {
+                      if (fragment) {
+                        updateLocationHash(fragment);
+                      }
+                    })
+                    .catch((error) => {
+                      console.error('Failed to open workspace path link:', error);
+                    });
+                }}
+              >
+                {children}
+              </a>
+            </MarkdownLinkContext.Provider>
           );
         }
 
         return (
-          <a
-            {...props}
-            href={href}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={mergedClassName}
-          >
-            {children}
-          </a>
+          <MarkdownLinkContext.Provider value={true}>
+            <a
+              {...props}
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={mergedClassName}
+            >
+              {children}
+            </a>
+          </MarkdownLinkContext.Provider>
         );
       },
       ...(suppressImages ? { img: () => null } : {}),
     };
-  }, [childOptions, currentDocumentPath, onOpenWorkspacePath, scrollToAnchor, suppressImages, updateLocationHash]);
+  }, [childOptions, currentDocumentPath, onOpenWorkspacePath, pathLinkPrefixes, scrollToAnchor, suppressImages, updateLocationHash]);
 
   return (
     <div ref={containerRef} className={`markdown-content ${className}`}>

--- a/src/features/markdown/MarkdownRenderer.tsx
+++ b/src/features/markdown/MarkdownRenderer.tsx
@@ -337,9 +337,18 @@ export function MarkdownRenderer({
           }
         }
 
+        const inlineContent = inline
+          ? renderInlinePathReferences(codeString, {
+            prefixes: pathLinkPrefixes,
+            onOpenPath: onOpenWorkspacePath
+              ? (path: string) => onOpenWorkspacePath(path, currentDocumentPath)
+              : undefined,
+          })
+          : children;
+
         return (
           <code className={codeClassName} {...props}>
-            {children}
+            {inlineContent}
           </code>
         );
       },

--- a/src/features/markdown/inlineReferences.tsx
+++ b/src/features/markdown/inlineReferences.tsx
@@ -1,36 +1,113 @@
 import React from 'react';
 
-const TRAILING_WRAP_RE = /[)\]}"'.,:;!?]+$/;
+const TRAILING_PUNCTUATION_RE = /[.,:;!?]+$/;
 const SCHEME_RE = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
+const FILE_WORKSPACE_PREFIX = 'file:///workspace/';
+const WRAPPER_PAIRS: Array<{ opener: string; closer: string }> = [
+  { opener: '`', closer: '`' },
+  { opener: "'", closer: "'" },
+  { opener: '"', closer: '"' },
+  { opener: '<', closer: '>' },
+];
 
-function findConfiguredPathSlice(
-  token: string,
+function stripTrailingPunctuation(token: string): { core: string; trailing: string } {
+  const trailing = token.match(TRAILING_PUNCTUATION_RE)?.[0] ?? '';
+  return {
+    core: trailing ? token.slice(0, -trailing.length) : token,
+    trailing,
+  };
+}
+
+function findConfiguredPrefixMatch(
+  value: string,
   prefixes: string[],
-): { before: string; candidate: string; after: string } | null {
-  if (!token) return null;
-  if (SCHEME_RE.test(token) || token.startsWith('//')) return null;
-
+): { index: number; prefix: string } | null {
   let bestMatch: { index: number; prefix: string } | null = null;
 
   for (const prefix of prefixes) {
-    const index = token.indexOf(prefix);
+    const index = value.indexOf(prefix);
     if (index < 0) continue;
     if (!bestMatch || index < bestMatch.index || (index === bestMatch.index && prefix.length > bestMatch.prefix.length)) {
       bestMatch = { index, prefix };
     }
   }
 
+  return bestMatch;
+}
+
+function extractWrappedPathSlice(
+  core: string,
+  prefixes: string[],
+): { before: string; display: string; candidate: string; after: string } | null {
+  for (const { opener, closer } of WRAPPER_PAIRS) {
+    if (!core.startsWith(opener) || !core.endsWith(closer)) continue;
+
+    const inner = core.slice(opener.length, core.length - closer.length);
+
+    if (inner.startsWith(FILE_WORKSPACE_PREFIX)) {
+      const candidate = inner.slice('file://'.length);
+      if (candidate.length <= '/workspace/'.length) return null;
+      return {
+        before: '',
+        display: core,
+        candidate,
+        after: '',
+      };
+    }
+
+    const innerMatch = findConfiguredPrefixMatch(inner, prefixes);
+    if (!innerMatch) continue;
+
+    const candidate = inner.slice(innerMatch.index);
+    if (candidate.length <= innerMatch.prefix.length) return null;
+    if (innerMatch.index !== 0) return null;
+
+    return {
+      before: '',
+      display: core,
+      candidate,
+      after: '',
+    };
+  }
+
+  return null;
+}
+
+function findConfiguredPathSlice(
+  token: string,
+  prefixes: string[],
+): { before: string; display: string; candidate: string; after: string } | null {
+  if (!token) return null;
+  if (token.startsWith('//')) return null;
+
+  const { core, trailing } = stripTrailingPunctuation(token);
+  if (!core) return null;
+
+  if (core.startsWith(FILE_WORKSPACE_PREFIX)) {
+    const candidate = core.slice('file://'.length);
+    if (candidate.length <= '/workspace/'.length) return null;
+    return { before: '', display: core, candidate, after: trailing };
+  }
+
+  const wrapped = extractWrappedPathSlice(core, prefixes);
+  if (wrapped) {
+    return {
+      ...wrapped,
+      after: `${wrapped.after}${trailing}`,
+    };
+  }
+
+  if (SCHEME_RE.test(core)) return null;
+
+  const bestMatch = findConfiguredPrefixMatch(core, prefixes);
   if (!bestMatch) return null;
 
-  const before = token.slice(0, bestMatch.index);
-  const fromPrefix = token.slice(bestMatch.index);
-  const trailing = fromPrefix.match(TRAILING_WRAP_RE)?.[0] ?? '';
-  const candidate = trailing ? fromPrefix.slice(0, -trailing.length) : fromPrefix;
-  const after = trailing ? token.slice(bestMatch.index + candidate.length) : '';
+  const before = core.slice(0, bestMatch.index);
+  const candidate = core.slice(bestMatch.index);
 
   if (candidate.length <= bestMatch.prefix.length) return null;
 
-  return { before, candidate, after };
+  return { before, display: candidate, candidate, after: trailing };
 }
 
 export function renderInlinePathReferences(
@@ -61,10 +138,10 @@ export function renderInlinePathReferences(
     }
 
     hasLink = true;
-    const { before, candidate, after } = pathSlice;
+    const { before, display, candidate, after } = pathSlice;
 
     return (
-      <React.Fragment key={`path-${index}-${candidate}-${before}-${after}`}>
+      <React.Fragment key={`path-${index}-${display}-${candidate}-${before}-${after}`}>
         {before ? renderPlainText(before) : null}
         <a
           href={candidate}
@@ -76,7 +153,7 @@ export function renderInlinePathReferences(
             });
           }}
         >
-          {candidate}
+          {display}
         </a>
         {after ? renderPlainText(after) : null}
       </React.Fragment>

--- a/src/features/markdown/inlineReferences.tsx
+++ b/src/features/markdown/inlineReferences.tsx
@@ -3,6 +3,10 @@ import React from 'react';
 const TRAILING_PUNCTUATION_RE = /[.,:;!?]+$/;
 const SCHEME_RE = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
 const CANONICAL_WORKSPACE_PREFIX = '/workspace/';
+// Intentionally supported shorthand for the canonical /workspace/... path contract.
+// Keep this narrow: workspace/... is accepted, but malformed forms like bare workspace/
+// or interior-token junk (for example path=workspace/foo.md) are still rejected by the
+// tokenization and suffix checks below.
 const BARE_WORKSPACE_PREFIX = 'workspace/';
 const FILE_WORKSPACE_PREFIX = 'file:///workspace/';
 const WRAPPER_PAIRS: Array<{ opener: string; closer: string }> = [

--- a/src/features/markdown/inlineReferences.tsx
+++ b/src/features/markdown/inlineReferences.tsx
@@ -12,13 +12,13 @@ function findConfiguredPathSlice(
 
   let bestMatch: { index: number; prefix: string } | null = null;
 
-  prefixes.forEach((prefix) => {
+  for (const prefix of prefixes) {
     const index = token.indexOf(prefix);
-    if (index < 0) return;
+    if (index < 0) continue;
     if (!bestMatch || index < bestMatch.index || (index === bestMatch.index && prefix.length > bestMatch.prefix.length)) {
       bestMatch = { index, prefix };
     }
-  });
+  }
 
   if (!bestMatch) return null;
 

--- a/src/features/markdown/inlineReferences.tsx
+++ b/src/features/markdown/inlineReferences.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 const TRAILING_PUNCTUATION_RE = /[.,:;!?]+$/;
 const SCHEME_RE = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
 const CANONICAL_WORKSPACE_PREFIX = '/workspace/';
+const BARE_WORKSPACE_PREFIX = 'workspace/';
 const FILE_WORKSPACE_PREFIX = 'file:///workspace/';
 const WRAPPER_PAIRS: Array<{ opener: string; closer: string }> = [
   { opener: '`', closer: '`' },
@@ -36,6 +37,13 @@ function normalizeWorkspaceCandidate(candidate: string, prefixes: string[]): str
   if (candidate.startsWith(CANONICAL_WORKSPACE_PREFIX)) {
     const normalized = decodeWorkspaceCandidate(candidate);
     return normalized.length > CANONICAL_WORKSPACE_PREFIX.length ? normalized : null;
+  }
+
+  if (candidate.startsWith(BARE_WORKSPACE_PREFIX)) {
+    const suffix = candidate.slice(BARE_WORKSPACE_PREFIX.length);
+    if (!suffix) return null;
+
+    return decodeWorkspaceCandidate(`${CANONICAL_WORKSPACE_PREFIX}${suffix}`);
   }
 
   for (const prefix of prefixes) {

--- a/src/features/markdown/inlineReferences.tsx
+++ b/src/features/markdown/inlineReferences.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 const TRAILING_PUNCTUATION_RE = /[.,:;!?]+$/;
 const SCHEME_RE = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
+const CANONICAL_WORKSPACE_PREFIX = '/workspace/';
 const FILE_WORKSPACE_PREFIX = 'file:///workspace/';
 const WRAPPER_PAIRS: Array<{ opener: string; closer: string }> = [
   { opener: '`', closer: '`' },
@@ -18,55 +19,43 @@ function stripTrailingPunctuation(token: string): { core: string; trailing: stri
   };
 }
 
-function findConfiguredPrefixMatch(
-  value: string,
-  prefixes: string[],
-): { index: number; prefix: string } | null {
-  let bestMatch: { index: number; prefix: string } | null = null;
-
-  for (const prefix of prefixes) {
-    const index = value.indexOf(prefix);
-    if (index < 0) continue;
-    if (!bestMatch || index < bestMatch.index || (index === bestMatch.index && prefix.length > bestMatch.prefix.length)) {
-      bestMatch = { index, prefix };
-    }
+function normalizeWorkspaceCandidate(candidate: string, prefixes: string[]): string | null {
+  if (candidate.startsWith(FILE_WORKSPACE_PREFIX)) {
+    const normalized = candidate.slice('file://'.length);
+    return normalized.length > CANONICAL_WORKSPACE_PREFIX.length ? normalized : null;
   }
 
-  return bestMatch;
+  if (candidate.startsWith(CANONICAL_WORKSPACE_PREFIX)) {
+    return candidate.length > CANONICAL_WORKSPACE_PREFIX.length ? candidate : null;
+  }
+
+  for (const prefix of prefixes) {
+    if (!prefix || prefix === CANONICAL_WORKSPACE_PREFIX) continue;
+    if (!candidate.startsWith(prefix)) continue;
+
+    const suffix = candidate.slice(prefix.length);
+    if (!suffix) return null;
+
+    return `${CANONICAL_WORKSPACE_PREFIX}${suffix.replace(/^\/+/, '')}`;
+  }
+
+  return null;
 }
 
 function extractWrappedPathSlice(
   core: string,
   prefixes: string[],
-): { before: string; display: string; candidate: string; after: string } | null {
+): { display: string; candidate: string } | null {
   for (const { opener, closer } of WRAPPER_PAIRS) {
     if (!core.startsWith(opener) || !core.endsWith(closer)) continue;
 
     const inner = core.slice(opener.length, core.length - closer.length);
-
-    if (inner.startsWith(FILE_WORKSPACE_PREFIX)) {
-      const candidate = inner.slice('file://'.length);
-      if (candidate.length <= '/workspace/'.length) return null;
-      return {
-        before: '',
-        display: core,
-        candidate,
-        after: '',
-      };
-    }
-
-    const innerMatch = findConfiguredPrefixMatch(inner, prefixes);
-    if (!innerMatch) continue;
-
-    const candidate = inner.slice(innerMatch.index);
-    if (candidate.length <= innerMatch.prefix.length) return null;
-    if (innerMatch.index !== 0) return null;
+    const candidate = normalizeWorkspaceCandidate(inner, prefixes);
+    if (!candidate) return null;
 
     return {
-      before: '',
       display: core,
       candidate,
-      after: '',
     };
   }
 
@@ -83,31 +72,24 @@ function findConfiguredPathSlice(
   const { core, trailing } = stripTrailingPunctuation(token);
   if (!core) return null;
 
-  if (core.startsWith(FILE_WORKSPACE_PREFIX)) {
-    const candidate = core.slice('file://'.length);
-    if (candidate.length <= '/workspace/'.length) return null;
-    return { before: '', display: core, candidate, after: trailing };
+  const plainCandidate = normalizeWorkspaceCandidate(core, prefixes);
+  if (plainCandidate) {
+    return { before: '', display: core, candidate: plainCandidate, after: trailing };
   }
 
   const wrapped = extractWrappedPathSlice(core, prefixes);
   if (wrapped) {
     return {
-      ...wrapped,
-      after: `${wrapped.after}${trailing}`,
+      before: '',
+      display: wrapped.display,
+      candidate: wrapped.candidate,
+      after: trailing,
     };
   }
 
   if (SCHEME_RE.test(core)) return null;
 
-  const bestMatch = findConfiguredPrefixMatch(core, prefixes);
-  if (!bestMatch) return null;
-
-  const before = core.slice(0, bestMatch.index);
-  const candidate = core.slice(bestMatch.index);
-
-  if (candidate.length <= bestMatch.prefix.length) return null;
-
-  return { before, display: candidate, candidate, after: trailing };
+  return null;
 }
 
 export function renderInlinePathReferences(

--- a/src/features/markdown/inlineReferences.tsx
+++ b/src/features/markdown/inlineReferences.tsx
@@ -19,14 +19,23 @@ function stripTrailingPunctuation(token: string): { core: string; trailing: stri
   };
 }
 
+function decodeWorkspaceCandidate(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 function normalizeWorkspaceCandidate(candidate: string, prefixes: string[]): string | null {
   if (candidate.startsWith(FILE_WORKSPACE_PREFIX)) {
-    const normalized = candidate.slice('file://'.length);
+    const normalized = decodeWorkspaceCandidate(candidate.slice('file://'.length));
     return normalized.length > CANONICAL_WORKSPACE_PREFIX.length ? normalized : null;
   }
 
   if (candidate.startsWith(CANONICAL_WORKSPACE_PREFIX)) {
-    return candidate.length > CANONICAL_WORKSPACE_PREFIX.length ? candidate : null;
+    const normalized = decodeWorkspaceCandidate(candidate);
+    return normalized.length > CANONICAL_WORKSPACE_PREFIX.length ? normalized : null;
   }
 
   for (const prefix of prefixes) {
@@ -36,7 +45,7 @@ function normalizeWorkspaceCandidate(candidate: string, prefixes: string[]): str
     const suffix = candidate.slice(prefix.length);
     if (!suffix) return null;
 
-    return `${CANONICAL_WORKSPACE_PREFIX}${suffix.replace(/^\/+/, '')}`;
+    return decodeWorkspaceCandidate(`${CANONICAL_WORKSPACE_PREFIX}${suffix.replace(/^\/+/, '')}`);
   }
 
   return null;

--- a/src/features/markdown/inlineReferences.tsx
+++ b/src/features/markdown/inlineReferences.tsx
@@ -1,21 +1,36 @@
 import React from 'react';
 
-const LEADING_WRAP_RE = /^[([{"']+/;
 const TRAILING_WRAP_RE = /[)\]}"'.,:;!?]+$/;
 const SCHEME_RE = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
 
-function trimCandidate(token: string): { leading: string; candidate: string; trailing: string } {
-  const leading = token.match(LEADING_WRAP_RE)?.[0] ?? '';
-  const withoutLeading = token.slice(leading.length);
-  const trailing = withoutLeading.match(TRAILING_WRAP_RE)?.[0] ?? '';
-  const candidate = trailing ? withoutLeading.slice(0, -trailing.length) : withoutLeading;
-  return { leading, candidate, trailing };
-}
+function findConfiguredPathSlice(
+  token: string,
+  prefixes: string[],
+): { before: string; candidate: string; after: string } | null {
+  if (!token) return null;
+  if (SCHEME_RE.test(token) || token.startsWith('//')) return null;
 
-function isConfiguredPathCandidate(candidate: string, prefixes: string[]): boolean {
-  if (!candidate) return false;
-  if (SCHEME_RE.test(candidate) || candidate.startsWith('//')) return false;
-  return prefixes.some((prefix) => candidate.startsWith(prefix) && candidate.length > prefix.length);
+  let bestMatch: { index: number; prefix: string } | null = null;
+
+  prefixes.forEach((prefix) => {
+    const index = token.indexOf(prefix);
+    if (index < 0) return;
+    if (!bestMatch || index < bestMatch.index || (index === bestMatch.index && prefix.length > bestMatch.prefix.length)) {
+      bestMatch = { index, prefix };
+    }
+  });
+
+  if (!bestMatch) return null;
+
+  const before = token.slice(0, bestMatch.index);
+  const fromPrefix = token.slice(bestMatch.index);
+  const trailing = fromPrefix.match(TRAILING_WRAP_RE)?.[0] ?? '';
+  const candidate = trailing ? fromPrefix.slice(0, -trailing.length) : fromPrefix;
+  const after = trailing ? token.slice(bestMatch.index + candidate.length) : '';
+
+  if (candidate.length <= bestMatch.prefix.length) return null;
+
+  return { before, candidate, after };
 }
 
 export function renderInlinePathReferences(
@@ -40,15 +55,17 @@ export function renderInlinePathReferences(
       return <React.Fragment key={`ws-${index}-${token}`}>{renderPlainText(token)}</React.Fragment>;
     }
 
-    const { leading, candidate, trailing } = trimCandidate(token);
-    if (!isConfiguredPathCandidate(candidate, prefixes)) {
+    const pathSlice = findConfiguredPathSlice(token, prefixes);
+    if (!pathSlice) {
       return <React.Fragment key={`txt-${index}-${token}`}>{renderPlainText(token)}</React.Fragment>;
     }
 
     hasLink = true;
+    const { before, candidate, after } = pathSlice;
+
     return (
-      <React.Fragment key={`path-${index}-${candidate}-${leading}-${trailing}`}>
-        {leading ? renderPlainText(leading) : null}
+      <React.Fragment key={`path-${index}-${candidate}-${before}-${after}`}>
+        {before ? renderPlainText(before) : null}
         <a
           href={candidate}
           className="markdown-link"
@@ -61,7 +78,7 @@ export function renderInlinePathReferences(
         >
           {candidate}
         </a>
-        {trailing ? renderPlainText(trailing) : null}
+        {after ? renderPlainText(after) : null}
       </React.Fragment>
     );
   });


### PR DESCRIPTION
## Summary
- linkify embedded `/workspace/...` path slices inside surrounding text
- narrow inline path matching so the renderer does not overreach
- fix wrapped / punctuation-adjacent workspace inline links
- keep this in the existing `workspace-inline-reference` follow-up lane while making bare `workspace/...` an intentionally supported shorthand for canonical `/workspace/...`
- keep malformed negatives plain so bare `workspace/` and interior-token junk like `path=workspace/foo.md` do not become links

Closes #262.

## In Plain English
This PR keeps the same post-#239 workspace-inline-reference follow-up lane, but clarifies one important contract: bare `workspace/...` is now intentionally supported shorthand for the canonical `/workspace/...` path form.

That means users can paste either `/workspace/foo.ts` or `workspace/foo.ts` and get the same workspace target, while malformed near-misses still stay plain text instead of turning into accidental links. In short: better link detection for the accepted shorthand, without widening the matcher into unsafe or noisy false positives.

## Provenance
Clean branch commit stack:
- `36cca92` — `fix(markdown): linkify embedded workspace path slices`
- `d3d3a64` — `fix(markdown): narrow inline path match typing`
- `a04876e` — `Fix wrapped workspace inline path links`
- `6cf2616` — `Tighten workspace-rooted inline path matching`
- `d0d4b40` — `fix(markdown): address PR review follow-ups`
- `bea1fa1` — `Support bare workspace inline references`
- `349dc5c` — `Clarify workspace shorthand inline path contract`

Validated downstream via local `workhorse` cherry-picks:
- `4e3c8fb` <- `36cca92`
- `2b064f0` <- `d3d3a64`
- `719db38` <- `a04876e`
- `5435706` <- `6cf2616`
- `a8faf29` <- `349dc5c`

## Context
This is still the post-merge follow-up lane to the original workspace path links feature from #237 / #239. The change here is not a new path family; it is a clarification that bare `workspace/...` belongs to the same workspace-inline-reference contract and normalizes to canonical `/workspace/...` targets.
