### PR TITLE
fix(server): restore upload-config capability route

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -45,6 +45,7 @@ import skillsRoutes from './routes/skills.js';
 import filesRoutes from './routes/files.js';
 import voicePhrasesRoutes from './routes/voice-phrases.js';
 import fileBrowserRoutes from './routes/file-browser.js';
+import uploadConfigRoutes from './routes/upload-config.js';
 import uploadReferenceRoutes from './routes/upload-reference.js';
 import kanbanRoutes from './routes/kanban.js';
 // activity routes removed — tab dropped from workspace panel
@@ -89,7 +90,7 @@ const routes = [
   codexLimitsRoutes, claudeCodeLimitsRoutes, versionRoutes, versionCheckRoutes,
   gatewayRoutes, connectDefaultsRoutes,
   workspaceRoutes, cronsRoutes, sessionsRoutes, skillsRoutes, filesRoutes, apiKeysRoutes,
-  voicePhrasesRoutes, fileBrowserRoutes, uploadReferenceRoutes, channelsRoutes, kanbanRoutes,
+  voicePhrasesRoutes, fileBrowserRoutes, uploadConfigRoutes, uploadReferenceRoutes, channelsRoutes, kanbanRoutes,
 ];
 for (const route of routes) app.route('/', route);
 

--- a/server/lib/upload-config.ts
+++ b/server/lib/upload-config.ts
@@ -1,0 +1,77 @@
+export interface UploadFeatureConfig {
+  twoModeEnabled: boolean;
+  inlineEnabled: boolean;
+  fileReferenceEnabled: boolean;
+  modeChooserEnabled: boolean;
+  inlineAttachmentMaxMb: number;
+  inlineImageContextMaxBytes: number;
+  inlineImageAutoDowngradeToFileReference: boolean;
+  inlineImageShrinkMinDimension: number;
+  inlineImageMaxDimension: number;
+  inlineImageWebpQuality: number;
+  exposeInlineBase64ToAgent: boolean;
+}
+
+const DEFAULT_UPLOAD_FEATURE_CONFIG: UploadFeatureConfig = {
+  twoModeEnabled: false,
+  inlineEnabled: true,
+  fileReferenceEnabled: false,
+  modeChooserEnabled: false,
+  inlineAttachmentMaxMb: 4,
+  inlineImageContextMaxBytes: 32_768,
+  inlineImageAutoDowngradeToFileReference: true,
+  inlineImageShrinkMinDimension: 512,
+  inlineImageMaxDimension: 2048,
+  inlineImageWebpQuality: 82,
+  exposeInlineBase64ToAgent: false,
+};
+
+function readBooleanEnv(name: string, fallback: boolean): boolean {
+  const value = process.env[name];
+  if (value == null) return fallback;
+
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+
+  return fallback;
+}
+
+function readNumberEnv(name: string, fallback: number): number {
+  const value = process.env[name];
+  if (value == null) return fallback;
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function getUploadFeatureConfig(): UploadFeatureConfig {
+  return {
+    twoModeEnabled: readBooleanEnv('NERVE_UPLOAD_TWO_MODE_ENABLED', DEFAULT_UPLOAD_FEATURE_CONFIG.twoModeEnabled),
+    inlineEnabled: readBooleanEnv('NERVE_UPLOAD_INLINE_ENABLED', DEFAULT_UPLOAD_FEATURE_CONFIG.inlineEnabled),
+    fileReferenceEnabled: readBooleanEnv('NERVE_UPLOAD_FILE_REFERENCE_ENABLED', DEFAULT_UPLOAD_FEATURE_CONFIG.fileReferenceEnabled),
+    modeChooserEnabled: readBooleanEnv('NERVE_UPLOAD_MODE_CHOOSER_ENABLED', DEFAULT_UPLOAD_FEATURE_CONFIG.modeChooserEnabled),
+    inlineAttachmentMaxMb: readNumberEnv('NERVE_UPLOAD_INLINE_ATTACHMENT_MAX_MB', DEFAULT_UPLOAD_FEATURE_CONFIG.inlineAttachmentMaxMb),
+    inlineImageContextMaxBytes: readNumberEnv('NERVE_UPLOAD_INLINE_IMAGE_CONTEXT_MAX_BYTES', DEFAULT_UPLOAD_FEATURE_CONFIG.inlineImageContextMaxBytes),
+    inlineImageAutoDowngradeToFileReference: readBooleanEnv(
+      'NERVE_UPLOAD_INLINE_IMAGE_AUTO_DOWNGRADE_TO_FILE_REFERENCE',
+      DEFAULT_UPLOAD_FEATURE_CONFIG.inlineImageAutoDowngradeToFileReference,
+    ),
+    inlineImageShrinkMinDimension: readNumberEnv(
+      'NERVE_UPLOAD_INLINE_IMAGE_SHRINK_MIN_DIMENSION',
+      DEFAULT_UPLOAD_FEATURE_CONFIG.inlineImageShrinkMinDimension,
+    ),
+    inlineImageMaxDimension: readNumberEnv(
+      'NERVE_UPLOAD_IMAGE_OPTIMIZATION_MAX_DIMENSION',
+      DEFAULT_UPLOAD_FEATURE_CONFIG.inlineImageMaxDimension,
+    ),
+    inlineImageWebpQuality: readNumberEnv(
+      'NERVE_UPLOAD_IMAGE_OPTIMIZATION_WEBP_QUALITY',
+      DEFAULT_UPLOAD_FEATURE_CONFIG.inlineImageWebpQuality,
+    ),
+    exposeInlineBase64ToAgent: readBooleanEnv(
+      'NERVE_UPLOAD_EXPOSE_INLINE_BASE64_TO_AGENT',
+      DEFAULT_UPLOAD_FEATURE_CONFIG.exposeInlineBase64ToAgent,
+    ),
+  };
+}

--- a/server/routes/upload-config.test.ts
+++ b/server/routes/upload-config.test.ts
@@ -1,0 +1,90 @@
+/* @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+async function importRoute() {
+  vi.resetModules();
+  return import('./upload-config.js');
+}
+
+const ENV_KEYS = [
+  'NERVE_UPLOAD_TWO_MODE_ENABLED',
+  'NERVE_UPLOAD_INLINE_ENABLED',
+  'NERVE_UPLOAD_FILE_REFERENCE_ENABLED',
+  'NERVE_UPLOAD_MODE_CHOOSER_ENABLED',
+  'NERVE_UPLOAD_INLINE_ATTACHMENT_MAX_MB',
+  'NERVE_UPLOAD_INLINE_IMAGE_CONTEXT_MAX_BYTES',
+  'NERVE_UPLOAD_INLINE_IMAGE_AUTO_DOWNGRADE_TO_FILE_REFERENCE',
+  'NERVE_UPLOAD_INLINE_IMAGE_SHRINK_MIN_DIMENSION',
+  'NERVE_UPLOAD_IMAGE_OPTIMIZATION_MAX_DIMENSION',
+  'NERVE_UPLOAD_IMAGE_OPTIMIZATION_WEBP_QUALITY',
+  'NERVE_UPLOAD_EXPOSE_INLINE_BASE64_TO_AGENT',
+] as const;
+
+const originalEnv = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const value = originalEnv[key];
+    if (value == null) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+});
+
+describe('GET /api/upload-config', () => {
+  it('returns upload capability defaults when env overrides are absent', async () => {
+    for (const key of ENV_KEYS) delete process.env[key];
+
+    const { default: app } = await importRoute();
+    const res = await app.request('/api/upload-config');
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      twoModeEnabled: false,
+      inlineEnabled: true,
+      fileReferenceEnabled: false,
+      modeChooserEnabled: false,
+      inlineAttachmentMaxMb: 4,
+      inlineImageContextMaxBytes: 32768,
+      inlineImageAutoDowngradeToFileReference: true,
+      inlineImageShrinkMinDimension: 512,
+      inlineImageMaxDimension: 2048,
+      inlineImageWebpQuality: 82,
+      exposeInlineBase64ToAgent: false,
+    });
+  });
+
+  it('returns env-backed capability flags for the existing client contract', async () => {
+    process.env.NERVE_UPLOAD_TWO_MODE_ENABLED = 'true';
+    process.env.NERVE_UPLOAD_INLINE_ENABLED = 'true';
+    process.env.NERVE_UPLOAD_FILE_REFERENCE_ENABLED = 'true';
+    process.env.NERVE_UPLOAD_MODE_CHOOSER_ENABLED = 'true';
+    process.env.NERVE_UPLOAD_INLINE_ATTACHMENT_MAX_MB = '8';
+    process.env.NERVE_UPLOAD_INLINE_IMAGE_CONTEXT_MAX_BYTES = '65536';
+    process.env.NERVE_UPLOAD_INLINE_IMAGE_AUTO_DOWNGRADE_TO_FILE_REFERENCE = 'false';
+    process.env.NERVE_UPLOAD_INLINE_IMAGE_SHRINK_MIN_DIMENSION = '640';
+    process.env.NERVE_UPLOAD_IMAGE_OPTIMIZATION_MAX_DIMENSION = '1536';
+    process.env.NERVE_UPLOAD_IMAGE_OPTIMIZATION_WEBP_QUALITY = '76';
+    process.env.NERVE_UPLOAD_EXPOSE_INLINE_BASE64_TO_AGENT = 'true';
+
+    const { default: app } = await importRoute();
+    const res = await app.request('/api/upload-config');
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      twoModeEnabled: true,
+      inlineEnabled: true,
+      fileReferenceEnabled: true,
+      modeChooserEnabled: true,
+      inlineAttachmentMaxMb: 8,
+      inlineImageContextMaxBytes: 65536,
+      inlineImageAutoDowngradeToFileReference: false,
+      inlineImageShrinkMinDimension: 640,
+      inlineImageMaxDimension: 1536,
+      inlineImageWebpQuality: 76,
+      exposeInlineBase64ToAgent: true,
+    });
+  });
+});

--- a/server/routes/upload-config.ts
+++ b/server/routes/upload-config.ts
@@ -1,0 +1,9 @@
+import { Hono } from 'hono';
+import { rateLimitGeneral } from '../middleware/rate-limit.js';
+import { getUploadFeatureConfig } from '../lib/upload-config.js';
+
+const app = new Hono();
+
+app.get('/api/upload-config', rateLimitGeneral, (c) => c.json(getUploadFeatureConfig()));
+
+export default app;


### PR DESCRIPTION
## Summary
- restore the missing `/api/upload-config` capability route
- keep the change narrowly scoped to the supporting server capability/helper/tests

Closes #263.

## In Plain English
This PR restores a small but important backend endpoint that tells the frontend what upload/file-reference behavior is available.

Without that endpoint, the UI can make the wrong assumption about whether workspace file references are enabled. That leads to confusing behavior where Add-to-chat looks broken even though the real problem is that the client never got the capability data it expected.

This fix restores the server/client contract so the UI gets the correct capability config again. In short: the frontend stops guessing, and the related Add-to-chat behavior can work for the right reason.

## Provenance
Clean branch commit:
- `5b2b092` — `fix(server): restore upload config endpoint`

Validated downstream via local `workhorse` cherry-pick:
- `40e9e14` <- `5b2b092`

## Context
This is related to the Add-to-chat / attachment workflow lineage tracked in #232/#233 and #234/#235, but stays tightly scoped to restoring the missing capability endpoint.
