### PR TITLE
feat(chat): add CHAT_PATH_LINKS alias mapping

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -338,6 +338,9 @@ export default function App({ onLogout }: AppProps) {
   const [chatPathLinkPrefixes, setChatPathLinkPrefixes] = useState<string[]>(
     DEFAULT_CHAT_PATH_LINKS_CONFIG.prefixes,
   );
+  const [chatPathLinkAliases, setChatPathLinkAliases] = useState<Record<string, string>>(
+    DEFAULT_CHAT_PATH_LINKS_CONFIG.aliases,
+  );
 
   useEffect(() => {
     const params = new URLSearchParams({ agentId: workspaceAgentId });
@@ -347,19 +350,23 @@ export default function App({ onLogout }: AppProps) {
       .then(async (res) => {
         if (res.status === 404) {
           setChatPathLinkPrefixes(DEFAULT_CHAT_PATH_LINKS_CONFIG.prefixes);
+          setChatPathLinkAliases(DEFAULT_CHAT_PATH_LINKS_CONFIG.aliases);
           return;
         }
         const data = await res.json() as { ok: boolean; content?: string };
         if (!data.ok || !data.content) {
           setChatPathLinkPrefixes(DEFAULT_CHAT_PATH_LINKS_CONFIG.prefixes);
+          setChatPathLinkAliases(DEFAULT_CHAT_PATH_LINKS_CONFIG.aliases);
           return;
         }
         const parsed = parseChatPathLinksConfig(data.content);
         setChatPathLinkPrefixes(parsed.prefixes);
+        setChatPathLinkAliases(parsed.aliases);
       })
       .catch(() => {
         if (!controller.signal.aborted) {
           setChatPathLinkPrefixes(DEFAULT_CHAT_PATH_LINKS_CONFIG.prefixes);
+          setChatPathLinkAliases(DEFAULT_CHAT_PATH_LINKS_CONFIG.aliases);
         }
       });
 
@@ -704,6 +711,7 @@ export default function App({ onLogout }: AppProps) {
             isMobileTopBarHidden={isMobileTopBarHidden}
             onOpenWorkspacePath={openWorkspacePath}
             pathLinkPrefixes={chatPathLinkPrefixes}
+            pathLinkAliases={chatPathLinkAliases}
           />
         </PanelErrorBoundary>
       }

--- a/src/features/chat/ChatPanel.tsx
+++ b/src/features/chat/ChatPanel.tsx
@@ -45,6 +45,8 @@ interface ChatPanelProps {
   onOpenWorkspacePath?: (path: string) => void | Promise<void>;
   /** Configured path prefixes that should render as clickable inline path links. */
   pathLinkPrefixes?: string[];
+  /** Configured shorthand aliases that should normalize to canonical workspace paths. */
+  pathLinkAliases?: Record<string, string>;
 }
 
 export interface ChatPanelHandle {
@@ -62,6 +64,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
   onToggleMobileTopBar, isMobileTopBarHidden = false,
   onOpenWorkspacePath,
   pathLinkPrefixes,
+  pathLinkAliases,
 }, ref) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const messageRefs = useRef<Map<number, HTMLDivElement>>(new Map());
@@ -337,6 +340,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
                 agentName={agentName}
                 onOpenWorkspacePath={onOpenWorkspacePath}
                 pathLinkPrefixes={pathLinkPrefixes}
+                pathLinkAliases={pathLinkAliases}
               />
             </div>
           );

--- a/src/features/chat/MessageBubble.tsx
+++ b/src/features/chat/MessageBubble.tsx
@@ -45,6 +45,7 @@ interface MessageBubbleProps {
   agentName?: string;
   onOpenWorkspacePath?: (path: string) => void | Promise<void>;
   pathLinkPrefixes?: string[];
+  pathLinkAliases?: Record<string, string>;
 }
 
 const borderClass = (role: string) => {
@@ -73,7 +74,7 @@ function RoleBadge({ role, agentName = 'Agent' }: { role: string; agentName?: st
   return <span className="cockpit-badge">System</span>;
 }
 
-function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memoryKey, onToggleCollapse, onToggleMemory, firstMessageTime, searchQuery, isCurrentMatch, agentName, onOpenWorkspacePath, pathLinkPrefixes }: MessageBubbleProps) {
+function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memoryKey, onToggleCollapse, onToggleMemory, firstMessageTime, searchQuery, isCurrentMatch, agentName, onOpenWorkspacePath, pathLinkPrefixes, pathLinkAliases }: MessageBubbleProps) {
   const isUser = msg.role === 'user';
   const isAssistant = msg.role === 'assistant';
   const isSystem = msg.role === 'system' || msg.role === 'event';
@@ -190,7 +191,7 @@ function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memory
         {!isCollapsed && (
           <div className="ml-3 border-l border-primary/12 px-3 pb-2 pt-1 text-[0.8rem] text-foreground/70 msg-body-intermediate">
             <Suspense fallback={<span className="text-muted-foreground text-xs">…</span>}>
-              <MarkdownRenderer content={msg.rawText} searchQuery={searchQuery} onOpenWorkspacePath={onOpenWorkspacePath} pathLinkPrefixes={pathLinkPrefixes} />
+              <MarkdownRenderer content={msg.rawText} searchQuery={searchQuery} onOpenWorkspacePath={onOpenWorkspacePath} pathLinkPrefixes={pathLinkPrefixes} pathLinkAliases={pathLinkAliases} />
             </Suspense>
           </div>
         )}
@@ -220,7 +221,7 @@ function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memory
           ) : (
             <div className="text-muted-foreground/70 text-[0.8rem] flex-1 min-w-0 msg-body-intermediate">
               <Suspense fallback={<span className="text-muted-foreground text-xs">…</span>}>
-                <MarkdownRenderer content={displayContent} searchQuery={searchQuery} suppressImages={isAssistant} onOpenWorkspacePath={onOpenWorkspacePath} pathLinkPrefixes={pathLinkPrefixes} />
+                <MarkdownRenderer content={displayContent} searchQuery={searchQuery} suppressImages={isAssistant} onOpenWorkspacePath={onOpenWorkspacePath} pathLinkPrefixes={pathLinkPrefixes} pathLinkAliases={pathLinkAliases} />
               </Suspense>
             </div>
           )}
@@ -286,7 +287,7 @@ function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memory
             )}
             {displayContent && (
               <Suspense fallback={<div className="text-muted-foreground text-xs">Loading…</div>}>
-                <MarkdownRenderer content={displayContent} searchQuery={searchQuery} suppressImages={isAssistant} onOpenWorkspacePath={onOpenWorkspacePath} pathLinkPrefixes={pathLinkPrefixes} />
+                <MarkdownRenderer content={displayContent} searchQuery={searchQuery} suppressImages={isAssistant} onOpenWorkspacePath={onOpenWorkspacePath} pathLinkPrefixes={pathLinkPrefixes} pathLinkAliases={pathLinkAliases} />
               </Suspense>
             )}
           </div>
@@ -381,6 +382,7 @@ export const MessageBubble = memo(MessageBubbleInner, (prev, next) => {
   if (prev.agentName !== next.agentName) return false;
   if (prev.onOpenWorkspacePath !== next.onOpenWorkspacePath) return false;
   if (prev.pathLinkPrefixes !== next.pathLinkPrefixes) return false;
+  if (prev.pathLinkAliases !== next.pathLinkAliases) return false;
   
   // All relevant props are equal, skip re-render
   return true;

--- a/src/features/chat/chatPathLinks.test.ts
+++ b/src/features/chat/chatPathLinks.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createChatPathLinksTemplate,
+  DEFAULT_CHAT_PATH_LINKS_CONFIG,
+  normalizeChatPathLinkAliases,
+  parseChatPathLinksConfig,
+  stringifyChatPathLinksConfig,
+} from './chatPathLinks';
+
+describe('chatPathLinks config', () => {
+  it('defaults to the canonical workspace prefix with no aliases', () => {
+    expect(DEFAULT_CHAT_PATH_LINKS_CONFIG).toEqual({ prefixes: ['/workspace/'], aliases: {} });
+  });
+
+  it('keeps configured prefixes trimmed while normalizing aliases to canonical workspace targets', () => {
+    expect(
+      parseChatPathLinksConfig(JSON.stringify({
+        prefixes: ['  /workspace/  ', '  /home/derrick/.openclaw/workspace  '],
+        aliases: {
+          ' projects ': ' workspace/projects ',
+          'notes\\': 'file:///workspace/docs/notes',
+        },
+      })),
+    ).toEqual({
+      prefixes: ['/workspace/', '/home/derrick/.openclaw/workspace/'],
+      aliases: {
+        'projects/': '/workspace/projects/',
+        'notes/': '/workspace/docs/notes/',
+      },
+    });
+  });
+
+  it('falls back for missing prefixes and ignores invalid aliases', () => {
+    expect(parseChatPathLinksConfig('{}')).toEqual({ prefixes: ['/workspace/'], aliases: {} });
+    expect(parseChatPathLinksConfig(JSON.stringify({ prefixes: ['   '], aliases: [] }))).toEqual({
+      prefixes: ['/workspace/'],
+      aliases: {},
+    });
+
+    expect(normalizeChatPathLinkAliases({
+      '': '/workspace/projects/',
+      '/workspace/projects/': '/workspace/projects/',
+      'file://projects/': '/workspace/projects/',
+      'mailto:projects/': '/workspace/projects/',
+      'projects/': '/home/derrick/.openclaw/workspace/projects/',
+      'docs/': 'https://example.com/docs/',
+      'notes/': '',
+      'valid\\': 'workspace/docs/valid',
+      'projects\\': '/workspace/projects-override',
+    })).toEqual({
+      'valid/': '/workspace/docs/valid/',
+      'projects/': '/workspace/projects-override/',
+    });
+  });
+
+  it('serializes and templates the aliases field with a trailing newline', () => {
+    expect(createChatPathLinksTemplate()).toBe(
+      '{\n'
+      + '  "prefixes": [\n'
+      + '    "/workspace/"\n'
+      + '  ],\n'
+      + '  "aliases": {}\n'
+      + '}\n',
+    );
+
+    expect(stringifyChatPathLinksConfig({
+      prefixes: ['/workspace', '/workspace/'],
+      aliases: {
+        'projects': 'workspace/projects',
+      },
+    })).toBe(
+      '{\n'
+      + '  "prefixes": [\n'
+      + '    "/workspace/"\n'
+      + '  ],\n'
+      + '  "aliases": {\n'
+      + '    "projects/": "/workspace/projects/"\n'
+      + '  }\n'
+      + '}\n',
+    );
+  });
+});

--- a/src/features/chat/chatPathLinks.ts
+++ b/src/features/chat/chatPathLinks.ts
@@ -1,25 +1,9 @@
-export interface ChatPathLinksConfig {
-  prefixes: string[];
-}
-
-export const DEFAULT_CHAT_PATH_LINKS_CONFIG: ChatPathLinksConfig = {
-  prefixes: ['/workspace/'],
-};
-
-function normalizePrefixes(rawPrefixes: unknown): string[] {
-  if (!Array.isArray(rawPrefixes)) return [...DEFAULT_CHAT_PATH_LINKS_CONFIG.prefixes];
-
-  const normalized = rawPrefixes
-    .filter((value): value is string => typeof value === 'string')
-    .map((value) => value.trim())
-    .filter((value) => value.length > 0);
-
-  return normalized.length > 0 ? normalized : [...DEFAULT_CHAT_PATH_LINKS_CONFIG.prefixes];
-}
-
-export function parseChatPathLinksConfig(content: string): ChatPathLinksConfig {
-  const parsed = JSON.parse(content) as { prefixes?: unknown };
-  return {
-    prefixes: normalizePrefixes(parsed?.prefixes),
-  };
-}
+export {
+  DEFAULT_CHAT_PATH_LINKS_CONFIG,
+  createChatPathLinksTemplate,
+  normalizeChatPathLinkAliases,
+  normalizeChatPathLinkPrefixes,
+  parseChatPathLinksConfig,
+  stringifyChatPathLinksConfig,
+  type ChatPathLinksConfig,
+} from './chatPathLinksConfig';

--- a/src/features/chat/chatPathLinksConfig.ts
+++ b/src/features/chat/chatPathLinksConfig.ts
@@ -1,0 +1,113 @@
+export interface ChatPathLinksConfig {
+  prefixes: string[];
+  aliases: Record<string, string>;
+}
+
+const DEFAULT_PREFIX = '/workspace/';
+const CANONICAL_WORKSPACE_PREFIX = '/workspace/';
+const FILE_WORKSPACE_PREFIX = 'file:///workspace/';
+const SCHEME_RE = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
+
+export const DEFAULT_CHAT_PATH_LINKS_CONFIG: ChatPathLinksConfig = {
+  prefixes: [DEFAULT_PREFIX],
+  aliases: {},
+};
+
+function withTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value : `${value}/`;
+}
+
+function normalizePrefixPath(value: string): string {
+  const trimmed = value.trim().replaceAll('\\', '/');
+  if (!trimmed) return '';
+  return withTrailingSlash(trimmed);
+}
+
+function dedupePrefixes(prefixes: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const prefix of prefixes) {
+    const normalized = normalizePrefixPath(prefix);
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+
+  return result;
+}
+
+function normalizeAliasKey(value: string): string {
+  const normalized = normalizePrefixPath(value);
+  if (!normalized) return '';
+  if (normalized.startsWith('/') || normalized.startsWith('file://') || SCHEME_RE.test(normalized)) return '';
+  return normalized;
+}
+
+function normalizeAliasValue(value: string): string {
+  const normalized = normalizePrefixPath(value);
+  if (!normalized) return '';
+
+  if (normalized.startsWith(FILE_WORKSPACE_PREFIX)) {
+    const canonical = normalized.slice('file://'.length);
+    return canonical.startsWith(CANONICAL_WORKSPACE_PREFIX) ? canonical : '';
+  }
+
+  if (normalized.startsWith(CANONICAL_WORKSPACE_PREFIX)) {
+    return normalized;
+  }
+
+  if (normalized.startsWith('workspace/')) {
+    return `${CANONICAL_WORKSPACE_PREFIX}${normalized.slice('workspace/'.length)}`;
+  }
+
+  return '';
+}
+
+export function normalizeChatPathLinkPrefixes(rawPrefixes: unknown): string[] {
+  if (!Array.isArray(rawPrefixes)) return [...DEFAULT_CHAT_PATH_LINKS_CONFIG.prefixes];
+
+  const normalized = dedupePrefixes(
+    rawPrefixes.filter((value): value is string => typeof value === 'string'),
+  );
+
+  return normalized.length > 0 ? normalized : [...DEFAULT_CHAT_PATH_LINKS_CONFIG.prefixes];
+}
+
+export function normalizeChatPathLinkAliases(rawAliases: unknown): Record<string, string> {
+  if (!rawAliases || typeof rawAliases !== 'object' || Array.isArray(rawAliases)) return {};
+
+  const entries = Object.entries(rawAliases as Record<string, unknown>);
+  const normalized: Record<string, string> = {};
+
+  for (const [rawKey, rawValue] of entries) {
+    if (typeof rawValue !== 'string') continue;
+
+    const key = normalizeAliasKey(rawKey);
+    const value = normalizeAliasValue(rawValue);
+    if (!key || !value) continue;
+
+    normalized[key] = value;
+  }
+
+  return normalized;
+}
+
+export function parseChatPathLinksConfig(content: string): ChatPathLinksConfig {
+  const parsed = JSON.parse(content) as { prefixes?: unknown; aliases?: unknown };
+  return {
+    prefixes: normalizeChatPathLinkPrefixes(parsed?.prefixes),
+    aliases: normalizeChatPathLinkAliases(parsed?.aliases),
+  };
+}
+
+export function stringifyChatPathLinksConfig(config: ChatPathLinksConfig): string {
+  return `${JSON.stringify({
+    prefixes: normalizeChatPathLinkPrefixes(config.prefixes),
+    aliases: normalizeChatPathLinkAliases(config.aliases),
+  }, null, 2)}\n`;
+}
+
+export function createChatPathLinksTemplate(): string {
+  return stringifyChatPathLinksConfig(DEFAULT_CHAT_PATH_LINKS_CONFIG);
+}

--- a/src/features/markdown/MarkdownRenderer.test.tsx
+++ b/src/features/markdown/MarkdownRenderer.test.tsx
@@ -114,6 +114,24 @@ describe('MarkdownRenderer', () => {
     expect(screen.queryByRole('link', { name: 'projects/nope.md' })).toBeNull();
   });
 
+  it('prefers the longest matching alias prefix when aliases overlap', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="Open projects/openclaw-nerve/src/App.tsx now"
+        onOpenWorkspacePath={onOpenWorkspacePath}
+        pathLinkPrefixes={['/workspace/']}
+        pathLinkAliases={{
+          'projects/': '/workspace/projects-generic/',
+          'projects/openclaw-nerve/': '/workspace/projects/openclaw-nerve/',
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'projects/openclaw-nerve/src/App.tsx' }));
+    expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/projects/openclaw-nerve/src/App.tsx', undefined);
+  });
+
   it('does not recurse through alias-to-alias chains', () => {
     render(
       <MarkdownRenderer

--- a/src/features/markdown/MarkdownRenderer.test.tsx
+++ b/src/features/markdown/MarkdownRenderer.test.tsx
@@ -83,6 +83,50 @@ describe('MarkdownRenderer', () => {
     expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/src/App.tsx', undefined);
   });
 
+  it('rewrites configured shorthand aliases to canonical workspace targets exactly once', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="Open projects/openclaw-nerve/src/App.tsx now"
+        onOpenWorkspacePath={onOpenWorkspacePath}
+        pathLinkPrefixes={['/workspace/', '/home/derrick/.openclaw/workspace/']}
+        pathLinkAliases={{ 'projects/': '/workspace/projects/' }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'projects/openclaw-nerve/src/App.tsx' }));
+    expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/projects/openclaw-nerve/src/App.tsx', undefined);
+  });
+
+  it('supports wrapped alias shorthand without widening interior-token matching', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="Open 'projects/openclaw-nerve/README.md' and path=projects/nope.md now"
+        onOpenWorkspacePath={onOpenWorkspacePath}
+        pathLinkPrefixes={['/workspace/']}
+        pathLinkAliases={{ 'projects/': '/workspace/projects/' }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: "'projects/openclaw-nerve/README.md'" }));
+    expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/projects/openclaw-nerve/README.md', undefined);
+    expect(screen.queryByRole('link', { name: 'projects/nope.md' })).toBeNull();
+  });
+
+  it('does not recurse through alias-to-alias chains', () => {
+    render(
+      <MarkdownRenderer
+        content="Open shortcut/demo.md now"
+        onOpenWorkspacePath={vi.fn()}
+        pathLinkPrefixes={['/workspace/']}
+        pathLinkAliases={{ 'shortcut/': 'projects/', 'projects/': '/workspace/projects/' }}
+      />,
+    );
+
+    expect(screen.queryByRole('link', { name: 'shortcut/demo.md' })).toBeNull();
+  });
+
   it('passes current document context to inline path references too', () => {
     const onOpenWorkspacePath = vi.fn();
     render(

--- a/src/features/markdown/MarkdownRenderer.test.tsx
+++ b/src/features/markdown/MarkdownRenderer.test.tsx
@@ -98,6 +98,36 @@ describe('MarkdownRenderer', () => {
     expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/projects/openclaw-nerve/src/App.tsx', undefined);
   });
 
+  it('linkifies alias-only configs by normalizing rewritten targets to canonical workspace paths', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="Open projects/openclaw-nerve/src/App.tsx now"
+        onOpenWorkspacePath={onOpenWorkspacePath}
+        pathLinkPrefixes={[]}
+        pathLinkAliases={{ 'projects/': '/workspace/projects/' }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'projects/openclaw-nerve/src/App.tsx' }));
+    expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/projects/openclaw-nerve/src/App.tsx', undefined);
+  });
+
+  it('supports alias-only configs that rewrite file workspace urls to canonical workspace paths', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="Open shortcut/openclaw-nerve/src/App.tsx now"
+        onOpenWorkspacePath={onOpenWorkspacePath}
+        pathLinkPrefixes={[]}
+        pathLinkAliases={{ 'shortcut/': 'file:///workspace/projects/' }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'shortcut/openclaw-nerve/src/App.tsx' }));
+    expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/projects/openclaw-nerve/src/App.tsx', undefined);
+  });
+
   it('supports wrapped alias shorthand without widening interior-token matching', () => {
     const onOpenWorkspacePath = vi.fn();
     render(

--- a/src/features/markdown/MarkdownRenderer.tsx
+++ b/src/features/markdown/MarkdownRenderer.tsx
@@ -15,6 +15,7 @@ interface MarkdownRendererProps {
   currentDocumentPath?: string;
   onOpenWorkspacePath?: (path: string, basePath?: string) => void | Promise<void>;
   pathLinkPrefixes?: string[];
+  pathLinkAliases?: Record<string, string>;
 }
 
 interface MarkdownAstNode {
@@ -129,16 +130,18 @@ function processChildren(
   options: {
     searchQuery?: string;
     pathLinkPrefixes?: string[];
+    pathLinkAliases?: Record<string, string>;
     onOpenWorkspacePath?: (path: string) => void | Promise<void>;
   } = {},
 ): React.ReactNode {
-  const { searchQuery, pathLinkPrefixes, onOpenWorkspacePath } = options;
+  const { searchQuery, pathLinkPrefixes, pathLinkAliases, onOpenWorkspacePath } = options;
   const renderPlainText = (text: string) => highlightText(text, searchQuery ?? '');
 
   return React.Children.map(children, (child) => {
     if (typeof child === 'string') {
       return renderInlinePathReferences(child, {
         prefixes: pathLinkPrefixes,
+        aliases: pathLinkAliases,
         onOpenPath: onOpenWorkspacePath,
         renderPlainText,
       });
@@ -227,16 +230,18 @@ export function MarkdownRenderer({
   currentDocumentPath,
   onOpenWorkspacePath,
   pathLinkPrefixes,
+  pathLinkAliases,
 }: MarkdownRendererProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   const childOptions = useMemo(() => ({
     searchQuery,
     pathLinkPrefixes,
+    pathLinkAliases,
     onOpenWorkspacePath: onOpenWorkspacePath
       ? (path: string) => onOpenWorkspacePath(path, currentDocumentPath)
       : undefined,
-  }), [searchQuery, pathLinkPrefixes, onOpenWorkspacePath, currentDocumentPath]);
+  }), [searchQuery, pathLinkPrefixes, pathLinkAliases, onOpenWorkspacePath, currentDocumentPath]);
 
   const scrollToAnchorId = useCallback((anchorId: string, behavior: ScrollBehavior = 'smooth') => {
     const root = containerRef.current;

--- a/src/features/markdown/inlineReferences.tsx
+++ b/src/features/markdown/inlineReferences.tsx
@@ -1,32 +1,146 @@
 import React from 'react';
 
-const LEADING_WRAP_RE = /^[([{"']+/;
-const TRAILING_WRAP_RE = /[)\]}"'.,:;!?]+$/;
+const TRAILING_PUNCTUATION_RE = /[.,:;!?]+$/;
 const SCHEME_RE = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
+const CANONICAL_WORKSPACE_PREFIX = '/workspace/';
+// Intentionally supported shorthand for the canonical /workspace/... path contract.
+// Keep this narrow: workspace/... is accepted, but malformed forms like bare workspace/
+// or interior-token junk are still rejected by the tokenization and suffix checks below.
+const BARE_WORKSPACE_PREFIX = 'workspace/';
+const FILE_WORKSPACE_PREFIX = 'file:///workspace/';
+const WRAPPER_PAIRS: Array<{ opener: string; closer: string }> = [
+  { opener: '`', closer: '`' },
+  { opener: "'", closer: "'" },
+  { opener: '"', closer: '"' },
+  { opener: '<', closer: '>' },
+];
 
-function trimCandidate(token: string): { leading: string; candidate: string; trailing: string } {
-  const leading = token.match(LEADING_WRAP_RE)?.[0] ?? '';
-  const withoutLeading = token.slice(leading.length);
-  const trailing = withoutLeading.match(TRAILING_WRAP_RE)?.[0] ?? '';
-  const candidate = trailing ? withoutLeading.slice(0, -trailing.length) : withoutLeading;
-  return { leading, candidate, trailing };
+function stripTrailingPunctuation(token: string): { core: string; trailing: string } {
+  const trailing = token.match(TRAILING_PUNCTUATION_RE)?.[0] ?? '';
+  return {
+    core: trailing ? token.slice(0, -trailing.length) : token,
+    trailing,
+  };
 }
 
-function isConfiguredPathCandidate(candidate: string, prefixes: string[]): boolean {
-  if (!candidate) return false;
-  if (SCHEME_RE.test(candidate) || candidate.startsWith('//')) return false;
-  return prefixes.some((prefix) => candidate.startsWith(prefix) && candidate.length > prefix.length);
+function decodeWorkspaceCandidate(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function rewriteAliasPrefix(candidate: string, aliases: Record<string, string>): string {
+  for (const [aliasPrefix, targetPrefix] of Object.entries(aliases)) {
+    if (!aliasPrefix || !targetPrefix) continue;
+    if (!candidate.startsWith(aliasPrefix)) continue;
+
+    return `${targetPrefix}${candidate.slice(aliasPrefix.length)}`;
+  }
+
+  return candidate;
+}
+
+function normalizeWorkspaceCandidate(
+  candidate: string,
+  prefixes: string[],
+  aliases: Record<string, string> = {},
+): string | null {
+  const rewrittenCandidate = rewriteAliasPrefix(candidate, aliases);
+
+  if (rewrittenCandidate.startsWith(FILE_WORKSPACE_PREFIX)) {
+    const normalized = decodeWorkspaceCandidate(rewrittenCandidate.slice('file://'.length));
+    return normalized.length > CANONICAL_WORKSPACE_PREFIX.length ? normalized : null;
+  }
+
+  if (rewrittenCandidate.startsWith(CANONICAL_WORKSPACE_PREFIX)) {
+    const normalized = decodeWorkspaceCandidate(rewrittenCandidate);
+    return normalized.length > CANONICAL_WORKSPACE_PREFIX.length ? normalized : null;
+  }
+
+  if (rewrittenCandidate.startsWith(BARE_WORKSPACE_PREFIX)) {
+    const suffix = rewrittenCandidate.slice(BARE_WORKSPACE_PREFIX.length);
+    if (!suffix) return null;
+
+    return decodeWorkspaceCandidate(`${CANONICAL_WORKSPACE_PREFIX}${suffix}`);
+  }
+
+  for (const prefix of prefixes) {
+    if (!prefix || prefix === CANONICAL_WORKSPACE_PREFIX) continue;
+    if (!rewrittenCandidate.startsWith(prefix)) continue;
+
+    const suffix = rewrittenCandidate.slice(prefix.length);
+    if (!suffix) return null;
+
+    return decodeWorkspaceCandidate(`${CANONICAL_WORKSPACE_PREFIX}${suffix.replace(/^\/+/, '')}`);
+  }
+
+  return null;
+}
+
+function extractWrappedPathSlice(
+  core: string,
+  prefixes: string[],
+  aliases: Record<string, string>,
+): { display: string; candidate: string } | null {
+  for (const { opener, closer } of WRAPPER_PAIRS) {
+    if (!core.startsWith(opener) || !core.endsWith(closer)) continue;
+
+    const inner = core.slice(opener.length, core.length - closer.length);
+    const candidate = normalizeWorkspaceCandidate(inner, prefixes, aliases);
+    if (!candidate) return null;
+
+    return {
+      display: core,
+      candidate,
+    };
+  }
+
+  return null;
+}
+
+function findConfiguredPathSlice(
+  token: string,
+  prefixes: string[],
+  aliases: Record<string, string>,
+): { before: string; display: string; candidate: string; after: string } | null {
+  if (!token) return null;
+  if (token.startsWith('//')) return null;
+
+  const { core, trailing } = stripTrailingPunctuation(token);
+  if (!core) return null;
+
+  const plainCandidate = normalizeWorkspaceCandidate(core, prefixes, aliases);
+  if (plainCandidate) {
+    return { before: '', display: core, candidate: plainCandidate, after: trailing };
+  }
+
+  const wrapped = extractWrappedPathSlice(core, prefixes, aliases);
+  if (wrapped) {
+    return {
+      before: '',
+      display: wrapped.display,
+      candidate: wrapped.candidate,
+      after: trailing,
+    };
+  }
+
+  if (SCHEME_RE.test(core)) return null;
+
+  return null;
 }
 
 export function renderInlinePathReferences(
   text: string,
   options: {
     prefixes?: string[];
+    aliases?: Record<string, string>;
     onOpenPath?: (path: string) => void | Promise<void>;
     renderPlainText?: (text: string) => React.ReactNode;
   } = {},
 ): React.ReactNode {
-  const { prefixes = [], onOpenPath, renderPlainText = (value: string) => value } = options;
+  const { prefixes = [], aliases = {}, onOpenPath, renderPlainText = (value: string) => value } = options;
   if (!text || prefixes.length === 0 || !onOpenPath) {
     return renderPlainText(text);
   }
@@ -40,15 +154,17 @@ export function renderInlinePathReferences(
       return <React.Fragment key={`ws-${index}-${token}`}>{renderPlainText(token)}</React.Fragment>;
     }
 
-    const { leading, candidate, trailing } = trimCandidate(token);
-    if (!isConfiguredPathCandidate(candidate, prefixes)) {
+    const pathSlice = findConfiguredPathSlice(token, prefixes, aliases);
+    if (!pathSlice) {
       return <React.Fragment key={`txt-${index}-${token}`}>{renderPlainText(token)}</React.Fragment>;
     }
 
     hasLink = true;
+    const { before, display, candidate, after } = pathSlice;
+
     return (
-      <React.Fragment key={`path-${index}-${candidate}-${leading}-${trailing}`}>
-        {leading ? renderPlainText(leading) : null}
+      <React.Fragment key={`path-${index}-${display}-${candidate}-${before}-${after}`}>
+        {before ? renderPlainText(before) : null}
         <a
           href={candidate}
           className="markdown-link"
@@ -59,9 +175,9 @@ export function renderInlinePathReferences(
             });
           }}
         >
-          {candidate}
+          {display}
         </a>
-        {trailing ? renderPlainText(trailing) : null}
+        {after ? renderPlainText(after) : null}
       </React.Fragment>
     );
   });

--- a/src/features/markdown/inlineReferences.tsx
+++ b/src/features/markdown/inlineReferences.tsx
@@ -141,7 +141,7 @@ export function renderInlinePathReferences(
   } = {},
 ): React.ReactNode {
   const { prefixes = [], aliases = {}, onOpenPath, renderPlainText = (value: string) => value } = options;
-  if (!text || prefixes.length === 0 || !onOpenPath) {
+  if (!text || (!onOpenPath) || (prefixes.length === 0 && Object.keys(aliases).length === 0)) {
     return renderPlainText(text);
   }
 

--- a/src/features/markdown/inlineReferences.tsx
+++ b/src/features/markdown/inlineReferences.tsx
@@ -32,14 +32,14 @@ function decodeWorkspaceCandidate(value: string): string {
 }
 
 function rewriteAliasPrefix(candidate: string, aliases: Record<string, string>): string {
-  for (const [aliasPrefix, targetPrefix] of Object.entries(aliases)) {
-    if (!aliasPrefix || !targetPrefix) continue;
-    if (!candidate.startsWith(aliasPrefix)) continue;
+  const matchingAlias = Object.entries(aliases)
+    .filter(([aliasPrefix, targetPrefix]) => aliasPrefix && targetPrefix && candidate.startsWith(aliasPrefix))
+    .sort(([leftAlias], [rightAlias]) => rightAlias.length - leftAlias.length)[0];
 
-    return `${targetPrefix}${candidate.slice(aliasPrefix.length)}`;
-  }
+  if (!matchingAlias) return candidate;
 
-  return candidate;
+  const [aliasPrefix, targetPrefix] = matchingAlias;
+  return `${targetPrefix}${candidate.slice(aliasPrefix.length)}`;
 }
 
 function normalizeWorkspaceCandidate(

--- a/src/features/workspace/tabs/ConfigTab.test.tsx
+++ b/src/features/workspace/tabs/ConfigTab.test.tsx
@@ -23,6 +23,7 @@ describe('ConfigTab', () => {
 
   beforeEach(() => {
     originalFetch = globalThis.fetch;
+    localStorage.clear();
   });
 
   afterEach(() => {

--- a/src/features/workspace/tabs/ConfigTab.test.tsx
+++ b/src/features/workspace/tabs/ConfigTab.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { createChatPathLinksTemplate } from '@/features/chat/chatPathLinks';
 import { ConfigTab } from './ConfigTab';
 
 type FetchResponse = {
@@ -71,6 +72,60 @@ describe('ConfigTab', () => {
     await waitFor(() => {
       expect(screen.getByRole('textbox')).toHaveValue('alpha soul draft');
     });
+  });
+
+  it('creates CHAT_PATH_LINKS.json with the shared alias-aware template', async () => {
+    const user = userEvent.setup();
+    const scrollIntoView = vi.fn();
+    const originalScrollIntoView = Object.getOwnPropertyDescriptor(window.HTMLElement.prototype, 'scrollIntoView');
+    Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    });
+    let putBody: string | undefined;
+
+    globalThis.fetch = vi.fn((input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+
+      if (!init?.method && url === '/api/workspace/soul?agentId=alpha') {
+        return Promise.resolve(jsonResponse({ ok: true, content: 'alpha soul' }));
+      }
+      if (!init?.method && url === '/api/workspace/chatPathLinks?agentId=alpha') {
+        return Promise.resolve(jsonResponse({ ok: false, error: 'File not found' }, { ok: false, status: 404 }));
+      }
+      if (init?.method === 'PUT' && url === '/api/workspace/chatPathLinks') {
+        putBody = String(init.body);
+        return Promise.resolve(jsonResponse({ ok: true }));
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof globalThis.fetch;
+
+    try {
+      render(<ConfigTab agentId="alpha" />);
+
+      await waitFor(() => {
+        expect(screen.getByText('alpha soul')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /select config file/i }));
+      await user.click(await screen.findByRole('option', { name: 'CHAT_PATH_LINKS.json' }));
+      expect(await screen.findByText('File does not exist yet')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /create chat_path_links\.json/i }));
+
+      expect(await screen.findByText('File created')).toBeInTheDocument();
+      expect(putBody).toBe(JSON.stringify({
+        content: createChatPathLinksTemplate(),
+        agentId: 'alpha',
+      }));
+    } finally {
+      if (originalScrollIntoView) {
+        Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', originalScrollIntoView);
+      } else {
+        delete (window.HTMLElement.prototype as { scrollIntoView?: unknown }).scrollIntoView;
+      }
+    }
   });
 
   it('shows a cron capability warning when the gateway is missing cron access', async () => {

--- a/src/features/workspace/tabs/ConfigTab.tsx
+++ b/src/features/workspace/tabs/ConfigTab.tsx
@@ -10,6 +10,7 @@ import { useWorkspaceFile } from '../hooks/useWorkspaceFile';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { getWorkspaceStorageKey } from '../workspaceScope';
 import { clearPersistedDraft, readPersistedDraft, writePersistedDraft } from '../persistedDrafts';
+import { createChatPathLinksTemplate } from '@/features/chat/chatPathLinks';
 
 const FILE_OPTIONS = [
   { key: 'soul', label: 'SOUL.md' },
@@ -152,7 +153,7 @@ export function ConfigTab({ agentId, cronWarning = null }: ConfigTabProps) {
   const handleCreate = useCallback(async () => {
     const label = FILE_OPTIONS.find(f => f.key === selectedKey)?.label || selectedKey;
     const template = selectedKey === 'chatPathLinks'
-      ? '{\n  "prefixes": [\n    "/workspace/"\n  ]\n}\n'
+      ? createChatPathLinksTemplate()
       : `# ${label}\n\n`;
     const result = await save(selectedKey, template);
     if (result === 'saved') {


### PR DESCRIPTION
## In Plain English

This teaches `CHAT_PATH_LINKS.json` one new trick: aliases.

Nerve already treats `workspace/...` as a built-in product shorthand for canonical `/workspace/...` paths. This PR handles the next layer: deployment-specific shorthand prefixes such as `projects/...` can now be declared in config and normalized to canonical `/workspace/...` prefixes before link matching/opening.

That means operators get portable shorthand support without hardcoding local conventions into product behavior, and raw config/editor users get parity without a bespoke alias-management UI in this lane.

## What

Add alias-mapping support to `CHAT_PATH_LINKS.json` so chat path links can be configured with both canonical prefixes and shorthand-to-canonical alias rewrites.

## Why

Closes #269.

The existing configurable path-link support can match explicit prefixes, but it cannot express local shorthand mappings such as:

- `projects/...` → `/workspace/projects/...`

That gap matters because `workspace/...` should remain built-in product behavior, while other shorthand forms are deployment-specific and should stay declarative. This PR adds that declarative alias layer without introducing a separate UI lane.

## How

- added a shared config parser/normalizer for `CHAT_PATH_LINKS.json` with support for:
  - `prefixes: string[]`
  - `aliases: Record<string, string>`
- enforced that alias targets normalize to canonical `/workspace/...` prefixes
- updated inline reference normalization so alias prefixes rewrite once before matching/opening
- preserved built-in `workspace/...` behavior as product behavior
- updated raw config/template handling so alias-aware config works anywhere the existing editor/template flow already exposes `CHAT_PATH_LINKS.json`
- added focused tests for config parsing, matching/rendering behavior, and config-tab/template behavior

Verified scope from dogfood:

- `CHAT_PATH_LINKS.json` supports prefixes plus aliases
- aliases map shorthand prefixes like `projects/` to canonical `/workspace/...` prefixes
- built-in `workspace/...` behavior remains product behavior
- no bespoke alias UI in this lane; raw template/editor parity only

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [x] New features include tests
- [ ] UI changes include a screenshot or screen recording


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable path link aliases with alias-based rewriting so path-like links resolve to canonical workspace targets.
  * Chat and message rendering now respect aliases so displayed links rewrite and open canonical paths.

* **Improvements**
  * More robust fallback to default path-link settings when configuration is missing or invalid.
  * Config creation uses a shared, normalized template and deterministic serialization.

* **Tests**
  * Expanded tests for alias normalization, markdown rewriting, and config-file creation workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->