### PR TITLE
Fix #214: [Bug]  Cannot get Nerve to work remote or via Tailscale

### DIFF
--- a/scripts/lib/access-plan.test.ts
+++ b/scripts/lib/access-plan.test.ts
@@ -40,7 +40,7 @@ describe('buildAccessPlan', () => {
   });
 
   it('adds follow-up steps when tailscale-serve is selected without a confirmed ts.net origin', () => {
-    expect(buildAccessPlan({
+    const plan = buildAccessPlan({
       profile: 'tailscale-serve',
       port: '3080',
       tailscale: {
@@ -50,7 +50,10 @@ describe('buildAccessPlan', () => {
         dnsName: null,
         serveOrigins: [],
       },
-    }).followUpSteps.length).toBeGreaterThan(0);
+    });
+    expect(plan.followUpSteps.length).toBeGreaterThan(0);
+    expect(plan.followUpSteps[0]).toContain('tailscale serve --bg http://127.0.0.1:3080');
+    expect(plan.followUpSteps[0]).not.toContain('--bg 443');
   });
 });
 

--- a/scripts/lib/access-plan.ts
+++ b/scripts/lib/access-plan.ts
@@ -122,7 +122,7 @@ export function buildAccessPlan(input: BuildAccessPlanInput): AccessPlan {
       const origin = tailscale?.serveOrigins?.[0] || null;
       if (!origin) {
         plan.followUpSteps = dedupe([
-          `Run: tailscale serve --bg 443 http://127.0.0.1:${port}`,
+          `Run: tailscale serve --bg http://127.0.0.1:${port}`,
           'Confirm Tailscale Serve exposes a usable https://<node>.tail<id>.ts.net origin, then re-run setup.',
         ]);
         return plan;

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -610,13 +610,13 @@ async function collectInteractive(
     console.log('');
     const configureServe = await confirm({
       theme: promptTheme,
-      message: `Configure Tailscale Serve now? (tailscale serve --bg 443 http://127.0.0.1:${port})`,
+      message: `Configure Tailscale Serve now? (tailscale serve --bg http://127.0.0.1:${port})`,
       default: true,
     });
 
     if (configureServe) {
       try {
-        execSync(`tailscale serve --bg 443 http://127.0.0.1:${port}`, { stdio: 'pipe', timeout: 15000, encoding: 'utf8' });
+        execSync(`tailscale serve --bg http://127.0.0.1:${port}`, { stdio: 'pipe', timeout: 15000, encoding: 'utf8' });
         success(`Tailscale Serve configured for http://127.0.0.1:${port}`);
       } catch (err) {
         const execErr = err as {
@@ -640,7 +640,7 @@ async function collectInteractive(
         warn(`Failed to configure Tailscale Serve automatically: ${detailWithStatus}`);
       }
     } else {
-      dim(`Run later: tailscale serve --bg 443 http://127.0.0.1:${port}`);
+      dim(`Run later: tailscale serve --bg http://127.0.0.1:${port}`);
     }
 
     tailscaleState = getTailscaleState();


### PR DESCRIPTION
Closes #214

## What

Removes the invalid `443` port argument from all `tailscale serve --bg` invocations. The correct syntax is `tailscale serve --bg <backend-url>`, not `tailscale serve --bg <port> <backend-url>`.

## Why

The `443` argument passed to `tailscale serve --bg` is invalid and causes the command to fail with `invalid argument format`, breaking the Tailscale Serve setup flow entirely. This affected three call sites: the interactive setup prompt in `scripts/setup.ts` and the follow-up step hint in `scripts/lib/access-plan.ts`.

## How

- `scripts/setup.ts` (line ~613): Updated the confirmation prompt message and the `execSync` call from `tailscale serve --bg 443 http://127.0.0.1:${port}` to `tailscale serve --bg http://127.0.0.1:${port}`.
- `scripts/setup.ts` (line ~643): Updated the deferred "Run later" hint to use the corrected syntax.
- `scripts/lib/access-plan.ts` (`buildAccessPlan`, line ~125): Updated the `followUpSteps` instruction string to drop the spurious `443` argument.
- `scripts/lib/access-plan.test.ts`: Expanded the existing test to assert that the generated follow-up step contains `tailscale serve --bg http://127.0.0.1:3080` and does **not** contain `--bg 443`.

No architectural changes; purely a string fix across three output sites.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [x] New features include tests
- [ ] UI changes include a screenshot or screen recording

## Screenshots

N/A — no UI changes; the only visible difference is the corrected command string shown in the setup prompt and follow-up hint.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Tailscale Serve setup commands and configuration prompts to remove the explicit port argument from generated commands.

* **Tests**
  * Enhanced validation tests for Tailscale Serve command generation to ensure proper formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->