### PR TITLE
docs(tailscale): update Serve command examples

### DIFF
--- a/docs/INSTALLER-STEPS.md
+++ b/docs/INSTALLER-STEPS.md
@@ -243,7 +243,7 @@ Behavior by interactive profile:
   - patches gateway allowed origins using the tailnet IP origin
 - `Tailscale Serve`
   - keeps Nerve on `127.0.0.1`
-  - asks whether to run `tailscale serve --bg 443 http://127.0.0.1:<PORT>`
+  - asks whether to run `tailscale serve --bg http://127.0.0.1:<PORT>`
   - detects the resulting `https://<node>.tail<id>.ts.net` origin
   - patches both Nerve and the gateway for that `*.ts.net` origin
   - if Serve cannot be confirmed, asks whether to fall back to `tailnet IP` or stop

--- a/docs/TAILSCALE.md
+++ b/docs/TAILSCALE.md
@@ -133,7 +133,7 @@ This keeps Nerve on localhost and lets Tailscale publish a private HTTPS URL.
 On the Nerve machine:
 
 ```bash
-tailscale serve --bg 443 http://127.0.0.1:3080
+tailscale serve --bg http://127.0.0.1:3080
 ```
 
 ### 2. Find the Serve URL


### PR DESCRIPTION
## What

Updates the remaining documentation examples that still used the old `tailscale serve --bg 443 ...` form.

## Why

PR #276 fixed the actual setup code and tests, but two docs pages still showed the stale command syntax. This follow-up keeps the docs aligned with the setup wizard and generated follow-up steps.

## How

- update `docs/TAILSCALE.md` to use `tailscale serve --bg http://127.0.0.1:3080`
- update `docs/INSTALLER-STEPS.md` to describe the same corrected command format

## Type of Change

- [x] 📝 Documentation update
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change

## Checklist

- [x] Docs reviewed against the merged behavior in `master`
- [x] No code changes
- [x] No screenshots needed

Follow-up to #276.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated Tailscale Serve setup command examples in installation and configuration documentation by removing explicit port arguments for a simplified configuration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->