### PR TITLE
fix(chat): parse untrusted system events

### DIFF
--- a/src/features/chat/operations/loadHistory.test.ts
+++ b/src/features/chat/operations/loadHistory.test.ts
@@ -20,6 +20,18 @@ describe('filterMessage', () => {
     expect(filterMessage({ role: 'assistant', content: 'Hi there' })).toBe(true);
   });
 
+  it('hides exact internal assistant control replies', () => {
+    expect(filterMessage({ role: 'assistant', content: 'NO_REPLY' })).toBe(false);
+    expect(filterMessage({ role: 'assistant', content: '  HEARTBEAT_OK\n' })).toBe(false);
+  });
+
+  it('hides pure internal wake bundles', () => {
+    expect(filterMessage({
+      role: 'user',
+      content: 'System (untrusted): [2026-04-16 18:27:55 GMT+3] Exec completed (wild-orb, code 0) :: done\n\nAn async command you ran earlier has completed. The result is shown in the system messages above. Handle the result internally. Do not relay it to the user unless explicitly requested.\nCurrent time: Thursday, April 16th, 2026 - 6:29 PM (Europe/Istanbul) / 2026-04-16 15:29 UTC',
+    })).toBe(false);
+  });
+
   it('passes through sub-agent completions (tagged)', () => {
     expect(filterMessage({
       role: 'user',
@@ -275,6 +287,21 @@ describe('processChatMessages', () => {
     const sysMsg = result.find(m => m.rawText.includes('background task'));
     expect(sysMsg).toBeDefined();
     expect(sysMsg!.isSystemNotification).toBe(true);
+  });
+
+  it('drops internal wake bundles and silent control replies from rendered history', () => {
+    const msgs: ChatMessage[] = [
+      { role: 'assistant', content: 'Already did it ⚡' },
+      {
+        role: 'user',
+        content: 'System (untrusted): [2026-04-16 18:27:55 GMT+3] Exec completed (wild-orb, code 0) :: done\nSystem (untrusted): [2026-04-16 18:28:54 GMT+3] Exec completed (rapid-sa, code 0) :: https://github.com/daggerhashimoto/openclaw-nerve/pull/278\n\nAn async command you ran earlier has completed. The result is shown in the system messages above. Handle the result internally. Do not relay it to the user unless explicitly requested.\nCurrent time: Thursday, April 16th, 2026 - 6:29 PM (Europe/Istanbul) / 2026-04-16 15:29 UTC',
+      },
+      { role: 'assistant', content: 'NO_REPLY' },
+    ];
+    const result = processChatMessages(msgs);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe('assistant');
+    expect(result[0].rawText).toBe('Already did it ⚡');
   });
 
   it('handles empty input', () => {

--- a/src/features/chat/operations/loadHistory.test.ts
+++ b/src/features/chat/operations/loadHistory.test.ts
@@ -140,7 +140,7 @@ describe('splitToolCallMessage', () => {
     expect(result.some(m => m.isThinking)).toBe(true);
   });
 
-  it('handles user messages with system events', () => {
+  it('handles user messages with timestamped system events', () => {
     const msg: ChatMessage = {
       role: 'user',
       content: 'System: [2026-02-17 20:30:23 GMT+1] Agent started\nHello!',
@@ -148,6 +148,29 @@ describe('splitToolCallMessage', () => {
     const result = splitToolCallMessage(msg);
     expect(result.some(m => m.role === 'event')).toBe(true);
     expect(result.some(m => m.role === 'user')).toBe(true);
+  });
+
+  it('handles untrusted system-event prefixes from newer OpenClaw builds', () => {
+    const msg: ChatMessage = {
+      role: 'user',
+      content: 'System (untrusted): [2026-04-16 18:11:51 GMT+3] Exec completed (gentle-l, code 0) :: done',
+    };
+    const result = splitToolCallMessage(msg);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe('event');
+    expect(result[0].rawText).toContain('System (untrusted): [2026-04-16 18:11:51 GMT+3] Exec completed');
+  });
+
+  it('strips async exec follow-up instructions from injected system-event bundles', () => {
+    const msg: ChatMessage = {
+      role: 'user',
+      content: 'System (untrusted): [2026-04-16 18:11:51 GMT+3] Exec completed (gentle-l, code 0) :: done\n\nAn async command you ran earlier has completed. The result is shown in the system messages above. Handle the result internally. Do not relay it to the user unless explicitly requested.\nCurrent time: Thursday, April 16th, 2026 - 6:12 PM (Europe/Istanbul) / 2026-04-16 15:12 UTC',
+    };
+    const result = splitToolCallMessage(msg);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe('event');
+    expect(result[0].rawText).not.toContain('An async command you ran earlier has completed.');
+    expect(result[0].rawText).not.toContain('Current time:');
   });
 });
 

--- a/src/features/chat/operations/loadHistory.test.ts
+++ b/src/features/chat/operations/loadHistory.test.ts
@@ -184,6 +184,29 @@ describe('splitToolCallMessage', () => {
     expect(result[0].rawText).not.toContain('An async command you ran earlier has completed.');
     expect(result[0].rawText).not.toContain('Current time:');
   });
+
+  it('strips standalone follow-up lines like "Handle the result internally."', () => {
+    const msg: ChatMessage = {
+      role: 'user',
+      content: 'System (untrusted): [2026-04-16 18:11:51 GMT+3] Exec completed (gentle-l, code 0) :: done\nHandle the result internally.\nDo not relay it to the user unless explicitly requested.',
+    };
+    const result = splitToolCallMessage(msg);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe('event');
+    expect(result[0].rawText).not.toContain('Handle the result internally.');
+  });
+
+  it('preserves later user text and paragraph breaks after a system event bundle', () => {
+    const msg: ChatMessage = {
+      role: 'user',
+      content: 'System (untrusted): [2026-04-16 18:11:51 GMT+3] Exec completed (gentle-l, code 0) :: done\n\nAn async command you ran earlier has completed.\nCurrent time: Thursday, April 16th, 2026 - 6:12 PM (Europe/Istanbul) / 2026-04-16 15:12 UTC\nHello there\n\nSecond paragraph',
+    };
+    const result = splitToolCallMessage(msg);
+    expect(result).toHaveLength(2);
+    expect(result[0].role).toBe('event');
+    expect(result[1].role).toBe('user');
+    expect(result[1].rawText).toBe('Hello there\n\nSecond paragraph');
+  });
 });
 
 describe('groupToolMessages', () => {

--- a/src/features/chat/operations/loadHistory.ts
+++ b/src/features/chat/operations/loadHistory.ts
@@ -127,7 +127,7 @@ const SYSTEM_NOTIFICATION_PATTERNS = [
 const SYSTEM_EVENT_LINE = /^System(?: \(untrusted\))?: \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})? [^\]]*\]/;
 
 /** Internal follow-up lines appended after async exec/cron system events. */
-const SYSTEM_EVENT_FOLLOWUP_LINE = /^(?:An async command you ran earlier has completed\.|A scheduled reminder has been triggered\.|A scheduled cron event was triggered(?:, but no event content was found)?\.|Handle this reminder internally\.|Handle this internally\.|Do not relay it to the user unless explicitly requested\.|Please relay the command output to the user in a helpful way\.|Please relay this reminder to the user in a helpful and friendly way\.|Current time:)/i;
+const SYSTEM_EVENT_FOLLOWUP_LINE = /^(?:An async command you ran earlier has completed\.|A scheduled reminder has been triggered\.|A scheduled cron event was triggered(?:, but no event content was found)?\.|Handle this reminder internally\.|Handle this internally\.|Handle the result internally\.?|Do not relay it to the user unless explicitly requested\.|Please relay the command output to the user in a helpful way\.|Please relay this reminder to the user in a helpful and friendly way\.|Current time:)/i;
 
 /** Internal assistant control replies that should never render as chat bubbles. */
 const INTERNAL_CONTROL_REPLY_RE = /^(?:NO_REPLY|HEARTBEAT_OK)$/;
@@ -279,8 +279,11 @@ function splitSystemEvents(text: string): Array<{ role: 'event' | 'user'; text: 
       sawSystemEvent = true;
     } else {
       const trimmed = line.trim();
-      if (sawSystemEvent && (!trimmed || SYSTEM_EVENT_FOLLOWUP_LINE.test(trimmed))) {
-        continue;
+      if (sawSystemEvent) {
+        if (!trimmed || SYSTEM_EVENT_FOLLOWUP_LINE.test(trimmed)) {
+          continue;
+        }
+        sawSystemEvent = false;
       }
       userBuffer.push(line);
     }

--- a/src/features/chat/operations/loadHistory.ts
+++ b/src/features/chat/operations/loadHistory.ts
@@ -123,6 +123,32 @@ const SYSTEM_NOTIFICATION_PATTERNS = [
   /^\[System Message\].*?(?:subagent|task|cron).*?(?:completed|finished|failed)/is,
 ];
 
+/** Matches timestamped gateway-injected system lines, including untrusted variants. */
+const SYSTEM_EVENT_LINE = /^System(?: \(untrusted\))?: \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})? [^\]]*\]/;
+
+/** Internal follow-up lines appended after async exec/cron system events. */
+const SYSTEM_EVENT_FOLLOWUP_LINE = /^(?:An async command you ran earlier has completed\.|A scheduled reminder has been triggered\.|A scheduled cron event was triggered(?:, but no event content was found)?\.|Handle this reminder internally\.|Handle this internally\.|Do not relay it to the user unless explicitly requested\.|Please relay the command output to the user in a helpful way\.|Please relay this reminder to the user in a helpful and friendly way\.|Current time:)/i;
+
+/** Internal assistant control replies that should never render as chat bubbles. */
+const INTERNAL_CONTROL_REPLY_RE = /^(?:NO_REPLY|HEARTBEAT_OK)$/;
+
+function isInternalWakeBundle(text: string): boolean {
+  let sawSystemEvent = false;
+
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (SYSTEM_EVENT_LINE.test(line)) {
+      sawSystemEvent = true;
+      continue;
+    }
+    if (SYSTEM_EVENT_FOLLOWUP_LINE.test(line)) continue;
+    return false;
+  }
+
+  return sawSystemEvent;
+}
+
 /** Check if text matches a system notification and extract label. */
 export function detectSystemNotification(text: string): { match: boolean; label: string } {
   // Extract task/job name from quotes if present
@@ -155,6 +181,15 @@ export function detectSystemNotification(text: string): { match: boolean; label:
 /** Determine whether a history message should be shown in the chat UI. */
 export function filterMessage(m: ChatMessage): boolean {
   const text = extractText(m);
+  const trimmedText = text.trim();
+
+  if (m.role === 'assistant' && INTERNAL_CONTROL_REPLY_RE.test(trimmedText)) {
+    return false;
+  }
+
+  if (m.role === 'user' && isInternalWakeBundle(trimmedText)) {
+    return false;
+  }
 
   // System notifications are now rendered as collapsible strips, not hidden.
   // They pass through the filter and get tagged during message processing.
@@ -162,7 +197,6 @@ export function filterMessage(m: ChatMessage): boolean {
   // Hide redundant tool results for Edit/Write operations
   // (diff view already shows the changes — only hide exact success patterns)
   if (m.role === 'tool' || m.role === 'toolResult') {
-    const trimmedText = text.trim();
     if (/^Successfully replaced text in .+\.$/.test(trimmedText)) return false;
     if (/^Successfully wrote \d+ bytes to .+\.$/.test(trimmedText)) return false;
   }
@@ -182,12 +216,6 @@ export function filterMessage(m: ChatMessage): boolean {
  * returned as a single-element array.
  */
 // ─── System event splitting ────────────────────────────────────────────────────
-
-/** Matches timestamped gateway-injected system lines, including untrusted variants. */
-const SYSTEM_EVENT_LINE = /^System(?: \(untrusted\))?: \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})? [^\]]*\]/;
-
-/** Internal follow-up lines appended after async exec/cron system events. */
-const SYSTEM_EVENT_FOLLOWUP_LINE = /^(?:An async command you ran earlier has completed\.|A scheduled reminder has been triggered\.|A scheduled cron event was triggered(?:, but no event content was found)?\.|Handle this reminder internally\.|Handle this internally\.|Do not relay it to the user unless explicitly requested\.|Please relay the command output to the user in a helpful way\.|Please relay this reminder to the user in a helpful and friendly way\.|Current time:)/i;
 
 /** Strip the TTS system prompt hint appended to voice messages by sendMessage. */
 const TTS_SYSTEM_HINT_RE = /\s*\[system: User sent a voice message\.[\s\S]*$/;

--- a/src/features/chat/operations/loadHistory.ts
+++ b/src/features/chat/operations/loadHistory.ts
@@ -183,8 +183,11 @@ export function filterMessage(m: ChatMessage): boolean {
  */
 // ─── System event splitting ────────────────────────────────────────────────────
 
-/** Matches "System: [2026-02-17 20:30:23 GMT+1] ..." lines injected by the gateway. */
-const SYSTEM_EVENT_LINE = /^System: \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})? [^\]]*\]/;
+/** Matches timestamped gateway-injected system lines, including untrusted variants. */
+const SYSTEM_EVENT_LINE = /^System(?: \(untrusted\))?: \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})? [^\]]*\]/;
+
+/** Internal follow-up lines appended after async exec/cron system events. */
+const SYSTEM_EVENT_FOLLOWUP_LINE = /^(?:An async command you ran earlier has completed\.|A scheduled reminder has been triggered\.|A scheduled cron event was triggered(?:, but no event content was found)?\.|Handle this reminder internally\.|Handle this internally\.|Do not relay it to the user unless explicitly requested\.|Please relay the command output to the user in a helpful way\.|Please relay this reminder to the user in a helpful and friendly way\.|Current time:)/i;
 
 /** Strip the TTS system prompt hint appended to voice messages by sendMessage. */
 const TTS_SYSTEM_HINT_RE = /\s*\[system: User sent a voice message\.[\s\S]*$/;
@@ -233,6 +236,7 @@ function extractUploadAttachments(rawText: string): {
 function splitSystemEvents(text: string): Array<{ role: 'event' | 'user'; text: string }> {
   const segments: Array<{ role: 'event' | 'user'; text: string }> = [];
   let userBuffer: string[] = [];
+  let sawSystemEvent = false;
 
   const flushUser = () => {
     const joined = userBuffer.join('\n').trim();
@@ -244,7 +248,12 @@ function splitSystemEvents(text: string): Array<{ role: 'event' | 'user'; text: 
     if (SYSTEM_EVENT_LINE.test(line)) {
       flushUser();
       segments.push({ role: 'event', text: stripAnsi(line) });
+      sawSystemEvent = true;
     } else {
+      const trimmed = line.trim();
+      if (sawSystemEvent && (!trimmed || SYSTEM_EVENT_FOLLOWUP_LINE.test(trimmed))) {
+        continue;
+      }
       userBuffer.push(line);
     }
   }


### PR DESCRIPTION
## Summary
- treat `System (untrusted): [timestamp] ...` lines as chat events, the same way older `System: [timestamp] ...` lines are handled
- strip the async exec/reminder follow-up prompt text from user-visible history parsing so it cannot leak into Operator chat bubbles
- add regression coverage for the new prefix and the leaked follow-up bundle

## Root cause
OpenClaw `2026.4.14` now emits sanitized internal transcript lines with the prefix `System (untrusted): ...`.

Nerve's history loader only recognized the older `System: ...` format, so those lines fell through as normal `user` text and rendered under the Operator badge.

## Verification
- `npm test -- --run src/features/chat/operations/loadHistory.test.ts`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of timestamped system events (including untrusted variants) and suppression of internal "wake bundle" content and silent control replies so they no longer appear in chat history.
  * Stripped internal follow-up/instruction lines and extraneous heartbeat/no-reply messages from displayed conversation content.

* **Tests**
  * Expanded tests for event parsing, segmentation, and filtering to ensure internal messages are not shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->