### PR TITLE
fix(chat): tighten ArrowUp history recall behavior

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -37,6 +37,7 @@ import channelsRoutes from './routes/channels.js';
 import versionCheckRoutes from './routes/version-check.js';
 import gatewayRoutes from './routes/gateway.js';
 import connectDefaultsRoutes from './routes/connect-defaults.js';
+import configuredAgentsRoutes from './routes/configured-agents.js';
 import workspaceRoutes from './routes/workspace.js';
 import cronsRoutes from './routes/crons.js';
 import sessionsRoutes from './routes/sessions.js';
@@ -86,7 +87,7 @@ const routes = [
   healthRoutes, authRoutes, ttsRoutes, transcribeRoutes, agentLogRoutes,
   tokensRoutes, memoriesRoutes, eventsRoutes, serverInfoRoutes,
   codexLimitsRoutes, claudeCodeLimitsRoutes, versionRoutes, versionCheckRoutes,
-  gatewayRoutes, connectDefaultsRoutes,
+  gatewayRoutes, connectDefaultsRoutes, configuredAgentsRoutes,
   workspaceRoutes, cronsRoutes, sessionsRoutes, skillsRoutes, filesRoutes, apiKeysRoutes,
   voicePhrasesRoutes, fileBrowserRoutes, channelsRoutes, kanbanRoutes,
 ];

--- a/server/lib/agent-workspace.test.ts
+++ b/server/lib/agent-workspace.test.ts
@@ -68,6 +68,38 @@ describe('agent-workspace', () => {
     expect(workspace.memoryDir).toBe(path.join(workspace.workspaceRoot, 'memory'));
   });
 
+  it('resolves configured workspaces using OpenClaw agent ids and normalization', async () => {
+    const openclawDir = path.join(homeDir, '.openclaw');
+    const configuredWorkspace = path.join(openclawDir, 'workspace-Front_End');
+    await fs.mkdir(configuredWorkspace, { recursive: true });
+    await fs.writeFile(
+      path.join(openclawDir, 'openclaw.json'),
+      JSON.stringify({
+        agents: {
+          agents: [
+            { id: 'Front_End', workspace: configuredWorkspace },
+          ],
+        },
+      }),
+    );
+
+    const { resolveAgentWorkspace } = await loadModule();
+
+    expect(resolveAgentWorkspace('Front_End')).toEqual({
+      agentId: 'front-end',
+      workspaceRoot: configuredWorkspace,
+      memoryPath: path.join(configuredWorkspace, 'MEMORY.md'),
+      memoryDir: path.join(configuredWorkspace, 'memory'),
+    });
+
+    expect(resolveAgentWorkspace('front-end')).toEqual({
+      agentId: 'front-end',
+      workspaceRoot: configuredWorkspace,
+      memoryPath: path.join(configuredWorkspace, 'MEMORY.md'),
+      memoryDir: path.join(configuredWorkspace, 'memory'),
+    });
+  });
+
   it('rejects invalid agent ids', async () => {
     const { resolveAgentWorkspace } = await loadModule();
 

--- a/server/lib/agent-workspace.ts
+++ b/server/lib/agent-workspace.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { config } from './config.js';
 
@@ -8,7 +9,20 @@ export interface AgentWorkspace {
   memoryDir: string;
 }
 
+interface ConfiguredAgentEntry {
+  id: string;
+  workspace?: string;
+}
+
 const AGENT_ID_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
+const OPENCLAW_VALID_ID_RE = /^[A-Za-z0-9_-]{1,64}$/;
+const INVALID_CHARS_RE = /[^a-z0-9-]+/g;
+const LEADING_DASH_RE = /^-+/;
+const TRAILING_DASH_RE = /-+$/;
+
+let cachedConfigPath = '';
+let cachedConfigMtimeMs = -1;
+let cachedConfiguredAgents: ConfiguredAgentEntry[] = [];
 
 export class InvalidAgentIdError extends Error {
   constructor(agentId: string) {
@@ -17,18 +31,92 @@ export class InvalidAgentIdError extends Error {
   }
 }
 
-export function normalizeAgentId(agentId?: string): string {
-  const normalized = (agentId || '').trim();
-  if (!normalized) return 'main';
-  if (normalized === 'main') return 'main';
-  if (!AGENT_ID_PATTERN.test(normalized)) {
-    throw new InvalidAgentIdError(normalized);
+function normalizeOpenClawAgentId(value?: string): string {
+  const trimmed = (value || '').trim();
+  if (!trimmed) return 'main';
+  const normalized = trimmed.toLowerCase();
+  if (AGENT_ID_PATTERN.test(normalized)) return normalized;
+  return normalized
+    .replace(INVALID_CHARS_RE, '-')
+    .replace(LEADING_DASH_RE, '')
+    .replace(TRAILING_DASH_RE, '')
+    .slice(0, 64) || 'main';
+}
+
+function getOpenClawConfigPath(): string {
+  return path.join(config.home, '.openclaw', 'openclaw.json');
+}
+
+function loadConfiguredAgents(): ConfiguredAgentEntry[] {
+  const configPath = getOpenClawConfigPath();
+
+  try {
+    const stat = fs.statSync(configPath);
+    if (configPath === cachedConfigPath && stat.mtimeMs === cachedConfigMtimeMs) {
+      return cachedConfiguredAgents;
+    }
+
+    const raw = fs.readFileSync(configPath, 'utf-8');
+    const parsed = JSON.parse(raw) as {
+      agents?: { agents?: Array<{ id?: unknown; workspace?: unknown }>; list?: Array<{ id?: unknown; workspace?: unknown }> };
+    };
+    const candidates = parsed.agents?.agents ?? parsed.agents?.list ?? [];
+
+    cachedConfiguredAgents = candidates
+      .map((entry) => ({
+        id: typeof entry?.id === 'string' ? entry.id.trim() : '',
+        workspace: typeof entry?.workspace === 'string' ? entry.workspace.trim() : undefined,
+      }))
+      .filter((entry) => entry.id);
+    cachedConfigPath = configPath;
+    cachedConfigMtimeMs = stat.mtimeMs;
+    return cachedConfiguredAgents;
+  } catch {
+    cachedConfiguredAgents = [];
+    cachedConfigPath = configPath;
+    cachedConfigMtimeMs = -1;
+    return cachedConfiguredAgents;
   }
-  return normalized;
+}
+
+function findConfiguredAgent(agentId?: string): { configuredId: string; normalizedId: string; workspace?: string } | null {
+  const trimmed = (agentId || '').trim();
+  if (!trimmed || normalizeOpenClawAgentId(trimmed) === 'main') return null;
+
+  const normalizedRequestedId = normalizeOpenClawAgentId(trimmed);
+  for (const entry of loadConfiguredAgents()) {
+    if (entry.id === trimmed || normalizeOpenClawAgentId(entry.id) === normalizedRequestedId) {
+      return {
+        configuredId: entry.id,
+        normalizedId: normalizeOpenClawAgentId(entry.id),
+        workspace: entry.workspace,
+      };
+    }
+  }
+
+  return null;
+}
+
+export function normalizeAgentId(agentId?: string): string {
+  const trimmed = (agentId || '').trim();
+  if (!trimmed) return 'main';
+
+  const configured = findConfiguredAgent(trimmed);
+  if (configured) return configured.normalizedId;
+
+  if (normalizeOpenClawAgentId(trimmed) === 'main') return 'main';
+  if (!AGENT_ID_PATTERN.test(trimmed)) {
+    if (!OPENCLAW_VALID_ID_RE.test(trimmed)) {
+      throw new InvalidAgentIdError(trimmed);
+    }
+    throw new InvalidAgentIdError(trimmed);
+  }
+  return trimmed;
 }
 
 export function resolveAgentWorkspace(agentId?: string): AgentWorkspace {
-  const normalizedAgentId = normalizeAgentId(agentId);
+  const configured = findConfiguredAgent(agentId);
+  const normalizedAgentId = configured?.normalizedId ?? normalizeAgentId(agentId);
 
   if (normalizedAgentId === 'main') {
     const workspaceRoot = path.dirname(config.memoryPath);
@@ -40,7 +128,9 @@ export function resolveAgentWorkspace(agentId?: string): AgentWorkspace {
     };
   }
 
-  const workspaceRoot = path.join(config.home, '.openclaw', `workspace-${normalizedAgentId}`);
+  const workspaceRoot = configured?.workspace
+    ? path.resolve(configured.workspace)
+    : path.join(config.home, '.openclaw', `workspace-${normalizedAgentId}`);
   return {
     agentId: normalizedAgentId,
     workspaceRoot,

--- a/server/routes/configured-agents.ts
+++ b/server/routes/configured-agents.ts
@@ -1,0 +1,65 @@
+/**
+ * GET /api/configured-agents — List agents configured in ~/.openclaw/openclaw.json
+ *
+ * Used by the AGENTS sidebar so configured agents remain visible even before
+ * they have an active top-level root session.
+ */
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { Hono } from 'hono';
+import { rateLimitGeneral } from '../middleware/rate-limit.js';
+import { config } from '../lib/config.js';
+import { normalizeAgentId } from '../lib/agent-workspace.js';
+
+const app = new Hono();
+
+interface RawConfiguredAgent {
+  id?: unknown;
+  name?: unknown;
+}
+
+app.get('/api/configured-agents', rateLimitGeneral, async (c) => {
+  try {
+    const configPath = path.join(config.home, '.openclaw', 'openclaw.json');
+    const raw = await fs.readFile(configPath, 'utf-8');
+    const parsed = JSON.parse(raw) as {
+      agents?: {
+        agents?: RawConfiguredAgent[];
+        list?: RawConfiguredAgent[];
+      };
+    };
+
+    const candidates = parsed.agents?.agents ?? parsed.agents?.list ?? [];
+    const seen = new Set<string>();
+    const agents = candidates
+      .map((entry) => {
+        const configuredId = typeof entry?.id === 'string' ? entry.id.trim() : '';
+        const name = typeof entry?.name === 'string' ? entry.name.trim() : '';
+        return { configuredId, name };
+      })
+      .filter((entry) => entry.configuredId)
+      .map((entry) => {
+        const agentId = normalizeAgentId(entry.configuredId);
+        return {
+          configuredId: entry.configuredId,
+          agentId,
+          sessionKey: `agent:${agentId}:main`,
+          label: entry.name || entry.configuredId,
+          configuredName: entry.name || entry.configuredId,
+        };
+      })
+      .filter((entry) => {
+        if (seen.has(entry.sessionKey)) return false;
+        seen.add(entry.sessionKey);
+        return true;
+      });
+
+    return c.json({ ok: true, agents });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to read configured agents';
+    return c.json({ ok: false, error: message, agents: [] }, 500);
+  }
+});
+
+export default app;

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -43,6 +43,14 @@ export interface SpawnSessionOpts {
   parentSessionKey?: string;
 }
 
+interface ConfiguredAgentSidebarEntry {
+  configuredId: string;
+  agentId: string;
+  sessionKey: string;
+  label: string;
+  configuredName: string;
+}
+
 interface SessionContextValue {
   sessions: Session[];
   sessionsLoading: boolean;
@@ -151,6 +159,46 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     return merged;
   }, []);
 
+  const fetchConfiguredAgentPlaceholders = useCallback(async (): Promise<ConfiguredAgentSidebarEntry[]> => {
+    try {
+      const res = await fetch('/api/configured-agents');
+      if (!res.ok) return [];
+      const data = await res.json() as { ok?: boolean; agents?: ConfiguredAgentSidebarEntry[] };
+      return Array.isArray(data.agents) ? data.agents : [];
+    } catch {
+      return [];
+    }
+  }, []);
+
+  const mergeConfiguredAgentsIntoSessions = useCallback((sessions: Session[], configuredAgents: ConfiguredAgentSidebarEntry[]): Session[] => {
+    if (configuredAgents.length === 0) return sessions;
+
+    const configuredByKey = new Map(configuredAgents.map((agent) => [agent.sessionKey, agent]));
+    const merged = sessions.map((session) => {
+      const key = getSessionKey(session);
+      const configured = configuredByKey.get(key);
+      if (!configured) return session;
+      return {
+        ...session,
+        label: configured.configuredName,
+        displayName: configured.configuredName,
+      };
+    });
+
+    const seen = new Set(merged.map(getSessionKey));
+    for (const configured of configuredAgents) {
+      if (seen.has(configured.sessionKey)) continue;
+      merged.push({
+        sessionKey: configured.sessionKey,
+        label: configured.configuredName,
+        displayName: configured.configuredName,
+        state: 'idle',
+      });
+    }
+
+    return merged;
+  }, []);
+
   // Fetch agent name from server-info on mount
   useEffect(() => {
     const controller = new AbortController();
@@ -224,16 +272,18 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const listAuthoritativeSessions = useCallback(async () => {
     if (connectionState !== 'connected') return sessionsRef.current;
     try {
-      const [res, hiddenCronSessions] = await Promise.all([
+      const [res, hiddenCronSessions, configuredAgents] = await Promise.all([
         rpc('sessions.list', { limit: FULL_SESSIONS_LIMIT }) as Promise<SessionsListResponse>,
         fetchHiddenCronSessions(24 * 60, FULL_SESSIONS_LIMIT),
+        fetchConfiguredAgentPlaceholders(),
       ]);
-      return mergeSessionLists(res?.sessions ?? [], hiddenCronSessions);
+      const sessionsWithHidden = mergeSessionLists(res?.sessions ?? [], hiddenCronSessions);
+      return mergeConfiguredAgentsIntoSessions(sessionsWithHidden, configuredAgents);
     } catch (err) {
       console.debug('[SessionContext] Failed to fetch authoritative session list:', err);
       return sessionsRef.current;
     }
-  }, [connectionState, fetchHiddenCronSessions, mergeSessionLists, rpc]);
+  }, [connectionState, fetchConfiguredAgentPlaceholders, fetchHiddenCronSessions, mergeConfiguredAgentsIntoSessions, mergeSessionLists, rpc]);
 
   const setGranularStatus = useCallback((sessionKey: string, state: GranularAgentState) => {
     if (!sessionKey) return;

--- a/src/features/chat/InputBar.test.tsx
+++ b/src/features/chat/InputBar.test.tsx
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { InputBar } from './InputBar';
+
+vi.mock('@/features/voice/useVoiceInput', () => ({
+  useVoiceInput: () => ({
+    voiceState: 'idle',
+    interimTranscript: '',
+    wakeWordEnabled: false,
+    toggleWakeWord: vi.fn(),
+    error: null,
+    clearError: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useTabCompletion', () => ({
+  useTabCompletion: () => ({
+    handleKeyDown: () => false,
+    reset: vi.fn(),
+  }),
+}));
+
+vi.mock('@/contexts/SessionContext', () => ({
+  useSessionContext: () => ({
+    sessions: [],
+    currentSession: 'agent:main:main',
+    agentName: 'Skirk',
+  }),
+}));
+
+vi.mock('@/contexts/SettingsContext', () => ({
+  useSettings: () => ({
+    liveTranscriptionPreview: false,
+    sttInputMode: 'local',
+    sttProvider: 'local',
+  }),
+}));
+
+vi.mock('./image-compress', () => ({
+  compressImage: vi.fn(),
+}));
+
+describe('InputBar ArrowUp behavior', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('moves caret to start on single-line input before recalling history', () => {
+    localStorage.setItem('nerve-input-history', JSON.stringify(['previous command']));
+    render(<InputBar onSend={vi.fn()} isGenerating={false} />);
+
+    const input = screen.getByLabelText('Message input') as HTMLTextAreaElement;
+    input.value = 'current draft';
+    input.setSelectionRange(input.value.length, input.value.length);
+
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+
+    expect(input.value).toBe('current draft');
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(0);
+  });
+
+  it('recalls history when caret is already at start on single-line input', () => {
+    localStorage.setItem('nerve-input-history', JSON.stringify(['previous command']));
+    render(<InputBar onSend={vi.fn()} isGenerating={false} />);
+
+    const input = screen.getByLabelText('Message input') as HTMLTextAreaElement;
+    input.value = 'current draft';
+    input.setSelectionRange(0, 0);
+
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+
+    expect(input.value).toBe('previous command');
+  });
+
+  it('keeps native behavior for multi-line input', () => {
+    localStorage.setItem('nerve-input-history', JSON.stringify(['previous command']));
+    render(<InputBar onSend={vi.fn()} isGenerating={false} />);
+
+    const input = screen.getByLabelText('Message input') as HTMLTextAreaElement;
+    input.value = 'line 1\nline 2';
+    input.setSelectionRange(input.value.length, input.value.length);
+    const beforeCaret = input.selectionStart;
+
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+
+    expect(input.value).toBe('line 1\nline 2');
+    expect(input.selectionStart).toBe(beforeCaret);
+  });
+});

--- a/src/features/chat/InputBar.tsx
+++ b/src/features/chat/InputBar.tsx
@@ -321,24 +321,32 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
       return;
     }
     
-    // Up arrow — navigate to older history (only when cursor at start or input is empty)
+    // Up arrow history behavior for single-line inputs:
+    // 1) caret not at start -> move caret to start
+    // 2) caret already at start -> load older history entry
+    // Multi-line input keeps native ArrowUp behavior.
     if (e.key === 'ArrowUp' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
       const input = inputRef.current;
       if (!input) return;
 
-      // Only trigger if cursor is at the beginning or input is single line
       const isAtStart = input.selectionStart === 0 && input.selectionEnd === 0;
       const isSingleLine = !input.value.includes('\n');
 
-      if (isAtStart || isSingleLine) {
-        const entry = inputHistory.navigateUp(input.value);
-        if (entry !== null) {
-          e.preventDefault();
-          input.value = entry;
-          input.style.height = 'auto';
-          input.style.height = Math.min(input.scrollHeight, 160) + 'px';
-          input.setSelectionRange(input.value.length, input.value.length);
-        }
+      if (!isSingleLine) return;
+
+      if (!isAtStart) {
+        e.preventDefault();
+        input.setSelectionRange(0, 0);
+        return;
+      }
+
+      const entry = inputHistory.navigateUp(input.value);
+      if (entry !== null) {
+        e.preventDefault();
+        input.value = entry;
+        input.style.height = 'auto';
+        input.style.height = Math.min(input.scrollHeight, 160) + 'px';
+        input.setSelectionRange(input.value.length, input.value.length);
       }
       return;
     }

--- a/src/features/sessions/SessionList.tsx
+++ b/src/features/sessions/SessionList.tsx
@@ -3,7 +3,7 @@ import type { Session } from '@/types';
 import { getSessionKey } from '@/types';
 import type { SpawnSessionOpts } from '@/contexts/SessionContext';
 import { SessionSkeletonGroup } from '@/components/skeletons';
-import { buildAgentSidebarTree, buildSessionTree, flattenTree, getSessionType } from './sessionTree';
+import { buildAgentSidebarTree, buildSessionTree, getSessionType } from './sessionTree';
 import { getSessionDisplayLabel, isTopLevelAgentSessionKey } from './sessionKeys';
 import { SessionNode } from './SessionNode';
 import type { GranularAgentState } from '@/types';
@@ -59,7 +59,7 @@ export function SessionList({ sessions, currentSession, busyState, agentStatus, 
   const [renamingKey, setRenamingKey] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
   const renameInputRef = useRef<HTMLInputElement>(null);
-  const [expandedState, setExpandedState] = useState<Record<string, boolean>>({});
+  const [, setExpandedState] = useState<Record<string, boolean>>({});
 
   const handleDelete = useCallback(async () => {
     if (!deleteTarget || !onDelete) return;
@@ -132,9 +132,12 @@ export function SessionList({ sessions, currentSession, busyState, agentStatus, 
     });
   }, [sessions]);
 
-  // Build tree and flatten for rendering
+  // Build AGENTS view from configured/root agents only. Descendant sessions stay out of this panel.
   const tree = useMemo(() => buildAgentSidebarTree(sessions), [sessions]);
-  const flatNodes = useMemo(() => flattenTree(tree, expandedState), [tree, expandedState]);
+  const flatNodes = useMemo(
+    () => tree.map((node) => ({ ...node, children: [], isExpanded: false })),
+    [tree],
+  );
 
   const handleSetDeleteTarget = useCallback((key: string, label: string) => {
     const targetNode = findNodeByKey(tree, key);
@@ -195,7 +198,7 @@ export function SessionList({ sessions, currentSession, busyState, agentStatus, 
           const currentTokens = node.session.totalTokens || 0;
           const prevTokens = prevTokensRef.current[sessionKey] || 0;
           const displayTokens = Math.max(currentTokens, prevTokens);
-          const isExpanded = expandedState[sessionKey] ?? !isCron;
+          const isExpanded = false;
 
           return (
             <SessionNode

--- a/src/features/sessions/sessionKeys.ts
+++ b/src/features/sessions/sessionKeys.ts
@@ -126,12 +126,12 @@ export function getTopLevelAgentSessions(sessions: Session[]): Session[] {
 export function getSessionDisplayLabel(session: Session, agentName = 'Agent'): string {
   const sessionKey = getSessionKey(session);
 
-  if (sessionKey === 'agent:main:main') {
-    return `${agentName} (main)`;
-  }
-
   if (session.label?.trim()) return session.label.trim();
   if (session.displayName?.trim()) return session.displayName.trim();
+
+  if (sessionKey === 'agent:main:main') {
+    return agentName;
+  }
 
   if (isTopLevelAgentSessionKey(sessionKey)) {
     const rootId = getRootAgentId(sessionKey);


### PR DESCRIPTION
## Summary
- only recall previous input on ArrowUp when the caret is already at the start of a single-line message
- move the caret to the beginning first when ArrowUp is pressed elsewhere in a single-line message
- add regression tests for single-line and multi-line ArrowUp behavior

## Testing
- pnpm exec vitest run src/features/chat/InputBar.test.tsx
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OpenClaw agent configuration files to define custom agent workspaces
  * Configured agents now appear in the agent sidebar alongside active sessions

* **Improvements**
  * Enhanced keyboard history navigation in the input bar with better arrow key handling
  * Simplified display labels for main agent sessions
  * Flattened agent list view in the sidebar for streamlined navigation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->