### PR TITLE
fix(chat): tighten ArrowUp history recall behavior

### DIFF
--- a/src/features/chat/InputBar.test.tsx
+++ b/src/features/chat/InputBar.test.tsx
@@ -38,14 +38,18 @@ vi.mock('@/hooks/useTabCompletion', () => ({
   }),
 }));
 
-vi.mock('@/hooks/useInputHistory', () => ({
-  useInputHistory: () => ({
+const { mockUseInputHistory } = vi.hoisted(() => ({
+  mockUseInputHistory: vi.fn(() => ({
     addToHistory: vi.fn(),
     isNavigating: vi.fn(() => false),
     reset: vi.fn(),
     navigateUp: vi.fn(() => null),
     navigateDown: vi.fn(() => null),
-  }),
+  })),
+}));
+
+vi.mock('@/hooks/useInputHistory', () => ({
+  useInputHistory: mockUseInputHistory,
 }));
 
 vi.mock('@/contexts/SessionContext', () => ({
@@ -727,4 +731,73 @@ describe('InputBar', () => {
     expect(screen.getByText('Upload')).toBeInTheDocument();
   });
 
+});
+
+describe('InputBar ArrowUp behavior', () => {
+  it('moves caret to start on single-line input before recalling history', async () => {
+    const navigateUp = vi.fn(() => 'previous command');
+    mockUseInputHistory.mockReturnValue({
+      addToHistory: vi.fn(),
+      isNavigating: vi.fn(() => false),
+      reset: vi.fn(),
+      navigateUp,
+      navigateDown: vi.fn(() => null),
+    } as ReturnType<typeof useInputHistory>);
+
+    render(<InputBar onSend={vi.fn()} isGenerating={false} />);
+    const input = screen.getByLabelText('Message input') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'current draft' } });
+    input.setSelectionRange(input.value.length, input.value.length);
+
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+
+    expect(navigateUp).not.toHaveBeenCalled();
+    expect(input.value).toBe('current draft');
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(0);
+  });
+
+  it('recalls history when caret is already at start on single-line input', async () => {
+    const navigateUp = vi.fn(() => 'previous command');
+    mockUseInputHistory.mockReturnValue({
+      addToHistory: vi.fn(),
+      isNavigating: vi.fn(() => false),
+      reset: vi.fn(),
+      navigateUp,
+      navigateDown: vi.fn(() => null),
+    } as ReturnType<typeof useInputHistory>);
+
+    render(<InputBar onSend={vi.fn()} isGenerating={false} />);
+    const input = screen.getByLabelText('Message input') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'current draft' } });
+    input.setSelectionRange(0, 0);
+
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+
+    expect(navigateUp).toHaveBeenCalledWith('current draft');
+    expect(input.value).toBe('previous command');
+  });
+
+  it('keeps native behavior for multi-line input', async () => {
+    const navigateUp = vi.fn(() => 'previous command');
+    mockUseInputHistory.mockReturnValue({
+      addToHistory: vi.fn(),
+      isNavigating: vi.fn(() => false),
+      reset: vi.fn(),
+      navigateUp,
+      navigateDown: vi.fn(() => null),
+    } as ReturnType<typeof useInputHistory>);
+
+    render(<InputBar onSend={vi.fn()} isGenerating={false} />);
+    const input = screen.getByLabelText('Message input') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'line 1\nline 2' } });
+    input.setSelectionRange(input.value.length, input.value.length);
+    const beforeCaret = input.selectionStart;
+
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+
+    expect(navigateUp).not.toHaveBeenCalled();
+    expect(input.value).toBe('line 1\nline 2');
+    expect(input.selectionStart).toBe(beforeCaret);
+  });
 });

--- a/src/features/chat/InputBar.tsx
+++ b/src/features/chat/InputBar.tsx
@@ -1102,29 +1102,36 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
       return;
     }
 
-    // Up arrow — navigate to older history (only when cursor at start or input is empty)
+    // Up arrow history behavior for single-line inputs:
+    // 1) caret not at start -> move caret to start
+    // 2) caret already at start -> load older history entry
+    // Multi-line input keeps native ArrowUp behavior.
     if (e.key === 'ArrowUp' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
       const input = inputRef.current;
       if (!input) return;
 
-      // Only trigger if cursor is at the beginning or input is single line
       const isAtStart = input.selectionStart === 0 && input.selectionEnd === 0;
       const isSingleLine = !input.value.includes('\n');
 
-      if (isAtStart || isSingleLine) {
-        const entry = inputHistory.navigateUp(input.value);
-        if (entry !== null) {
-          e.preventDefault();
-          input.value = entry;
-          setDraftText(entry);
-          input.style.height = 'auto';
-          input.style.height = Math.min(input.scrollHeight, 160) + 'px';
-          input.setSelectionRange(input.value.length, input.value.length);
-        }
+      if (!isSingleLine) return;
+
+      if (!isAtStart) {
+        e.preventDefault();
+        input.setSelectionRange(0, 0);
+        return;
+      }
+
+      const entry = inputHistory.navigateUp(input.value);
+      if (entry !== null) {
+        e.preventDefault();
+        input.value = entry;
+        setDraftText(entry);
+        input.style.height = 'auto';
+        input.style.height = Math.min(input.scrollHeight, 160) + 'px';
+        input.setSelectionRange(input.value.length, input.value.length);
       }
       return;
     }
-
     // Down arrow — navigate to newer history or back to draft
     if (e.key === 'ArrowDown' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
       if (inputHistory.isNavigating()) {


### PR DESCRIPTION
## Summary
- only recall previous input on ArrowUp when the caret is already at the start of a single-line message
- move the caret to the beginning first when ArrowUp is pressed elsewhere in a single-line message
- add regression tests for single-line and multi-line ArrowUp behavior

## Testing
- pnpm exec vitest run src/features/chat/InputBar.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ArrowUp key handling in the chat input bar. When editing single-line inputs, ArrowUp only navigates history when the cursor is at the start; otherwise, it moves the cursor to the beginning without changing text. Multi-line inputs retain native behavior.

* **Tests**
  * Added test coverage for ArrowUp keyboard navigation in various input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->