### PR TITLE
fix(ui): keep panel divider interactive when sidebar collapsed

### DIFF
--- a/src/components/ResizablePanels.test.tsx
+++ b/src/components/ResizablePanels.test.tsx
@@ -1,37 +1,42 @@
-/** Tests for the ResizablePanels component. */
-import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import { ResizablePanels } from './ResizablePanels';
 
 describe('ResizablePanels', () => {
-  it('allows the right sidebar to shrink to 15% by clamping the left pane to 85%', () => {
+  it('keeps the divider interactive when right pane width is fixed', () => {
     const onResize = vi.fn();
-    const { container } = render(
+    const onRightWidthChange = vi.fn();
+
+    render(
       <ResizablePanels
-        left={<div>Left</div>}
-        right={<div>Right</div>}
+        left={<div>left</div>}
+        right={<div>right</div>}
         leftPercent={55}
         onResize={onResize}
+        rightWidthPx={320}
+        onRightWidthChange={onRightWidthChange}
       />,
     );
 
-    const panelRoot = container.firstElementChild as HTMLDivElement;
-    vi.spyOn(panelRoot, 'getBoundingClientRect').mockReturnValue({
+    const container = screen.getByText('left').parentElement?.parentElement as HTMLDivElement;
+    vi.spyOn(container, 'getBoundingClientRect').mockReturnValue({
       x: 0,
       y: 0,
-      left: 0,
       top: 0,
+      left: 0,
       right: 1000,
-      bottom: 500,
+      bottom: 600,
       width: 1000,
-      height: 500,
+      height: 600,
       toJSON: () => ({}),
-    } as DOMRect);
+    });
 
-    fireEvent.mouseDown(screen.getByTitle('Drag to resize. Double click to reset'));
-    fireEvent.mouseMove(window, { clientX: 900 });
+    const separator = screen.getByRole('separator', { name: 'Resize panels' });
+    fireEvent.mouseDown(separator, { clientX: 680 });
+    fireEvent.mouseMove(window, { clientX: 700 });
     fireEvent.mouseUp(window);
 
-    expect(onResize).toHaveBeenCalledWith(85);
+    expect(onRightWidthChange).toHaveBeenCalledWith(300);
+    expect(onResize).toHaveBeenCalledWith(70);
   });
 });

--- a/src/components/ResizablePanels.tsx
+++ b/src/components/ResizablePanels.tsx
@@ -44,6 +44,7 @@ export function ResizablePanels({
   onRightWidthChange,
 }: ResizablePanelsProps) {
   const [localPercent, setLocalPercent] = useState(leftPercent);
+  const [localRightWidth, setLocalRightWidth] = useState<number | null>(rightWidthPx);
   const containerRef = useRef<HTMLDivElement>(null);
   const isDragging = useRef(false);
 
@@ -54,6 +55,12 @@ export function ResizablePanels({
       setLocalPercent(leftPercent);
     }
   }, [leftPercent]);
+
+  useEffect(() => {
+    if (!isDragging.current) {
+      setLocalRightWidth(rightWidthPx);
+    }
+  }, [rightWidthPx]);
 
   useLayoutEffect(() => {
     if (!containerRef.current || rightWidthPx !== null || !onRightWidthChange) return;
@@ -74,6 +81,28 @@ export function ResizablePanels({
     return () => observer.disconnect();
   }, [localPercent, onRightWidthChange, rightWidthPx]);
 
+  const clampPercent = useCallback((percent: number) => (
+    Math.max(minLeftPercent, Math.min(maxLeftPercent, percent))
+  ), [minLeftPercent, maxLeftPercent]);
+
+  const applyPointerPosition = useCallback((clientX: number) => {
+    if (!containerRef.current) return null;
+
+    const rect = containerRef.current.getBoundingClientRect();
+    const rawPercent = ((clientX - rect.left) / rect.width) * 100;
+    const clampedPercent = clampPercent(rawPercent);
+
+    setLocalPercent(clampedPercent);
+
+    if (rightWidthPx !== null) {
+      const nextRightWidth = rect.width * ((100 - clampedPercent) / 100);
+      setLocalRightWidth(nextRightWidth);
+      onRightWidthChange?.(nextRightWidth);
+    }
+
+    return clampedPercent;
+  }, [clampPercent, onRightWidthChange, rightWidthPx]);
+
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     isDragging.current = true;
@@ -82,12 +111,9 @@ export function ResizablePanels({
   }, []);
 
   const handleMouseMove = useCallback((e: MouseEvent) => {
-    if (!isDragging.current || !containerRef.current) return;
-    const rect = containerRef.current.getBoundingClientRect();
-    const newPercent = ((e.clientX - rect.left) / rect.width) * 100;
-    const clamped = Math.max(minLeftPercent, Math.min(maxLeftPercent, newPercent));
-    setLocalPercent(clamped);
-  }, [minLeftPercent, maxLeftPercent]);
+    if (!isDragging.current) return;
+    applyPointerPosition(e.clientX);
+  }, [applyPointerPosition]);
 
   const handleMouseUp = useCallback(() => {
     if (isDragging.current) {
@@ -102,8 +128,16 @@ export function ResizablePanels({
   const handleDoubleClick = useCallback(() => {
     const defaultPercent = 55;
     setLocalPercent(defaultPercent);
+
+    if (containerRef.current && rightWidthPx !== null) {
+      const containerWidth = containerRef.current.getBoundingClientRect().width;
+      const nextRightWidth = containerWidth * ((100 - defaultPercent) / 100);
+      setLocalRightWidth(nextRightWidth);
+      onRightWidthChange?.(nextRightWidth);
+    }
+
     onResize(defaultPercent);
-  }, [onResize]);
+  }, [onResize, onRightWidthChange, rightWidthPx]);
 
   useEffect(() => {
     window.addEventListener('mousemove', handleMouseMove);
@@ -114,36 +148,35 @@ export function ResizablePanels({
     };
   }, [handleMouseMove, handleMouseUp]);
 
+  const effectiveRightWidth = rightWidthPx !== null ? Math.max(0, localRightWidth ?? rightWidthPx) : null;
+
   return (
     <div ref={containerRef} className="flex-1 flex overflow-hidden">
       {/* Left panel */}
       <div
         className={`min-h-0 overflow-hidden ${leftClassName}`}
-        style={rightWidthPx !== null ? { flex: '1 1 auto', minWidth: 0 } : { flex: `${localPercent} 1 0%`, minWidth: 0 }}
+        style={effectiveRightWidth !== null ? { flex: '1 1 auto', minWidth: 0 } : { flex: `${localPercent} 1 0%`, minWidth: 0 }}
       >
         {left}
       </div>
-      
+
       {/* Resize handle */}
-      {rightWidthPx === null ? (
-        <div
-          onMouseDown={handleMouseDown}
-          onDoubleClick={handleDoubleClick}
-          className="group relative flex w-3 cursor-col-resize shrink-0 items-stretch justify-center"
-          title="Drag to resize. Double click to reset"
-        >
-          <div className="pointer-events-none my-3 w-px rounded-full bg-border transition-colors group-hover:bg-primary/55 group-hover:shadow-[0_0_16px_rgba(0,0,0,0.22)] group-active:bg-primary/70" />
-        </div>
-      ) : (
-        <div className="relative flex w-3 shrink-0 items-stretch justify-center" aria-hidden="true">
-          <div className="pointer-events-none my-3 w-px rounded-full bg-border" />
-        </div>
-      )}
-      
+      <div
+        onMouseDown={handleMouseDown}
+        onDoubleClick={handleDoubleClick}
+        className="group relative flex w-3 cursor-col-resize shrink-0 items-stretch justify-center"
+        title="Drag to resize. Double click to reset"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize panels"
+      >
+        <div className="pointer-events-none my-3 w-px rounded-full bg-border transition-colors group-hover:bg-primary/55 group-hover:shadow-[0_0_16px_rgba(0,0,0,0.22)] group-active:bg-primary/70" />
+      </div>
+
       {/* Right panel */}
       <div
         className={`min-h-0 overflow-hidden ${rightClassName}`}
-        style={rightWidthPx !== null ? { flex: '0 0 auto', width: `${Math.max(0, rightWidthPx)}px`, minWidth: 0 } : { flex: `${100 - localPercent} 1 0%`, minWidth: 0 }}
+        style={effectiveRightWidth !== null ? { flex: '0 0 auto', width: `${effectiveRightWidth}px`, minWidth: 0 } : { flex: `${100 - localPercent} 1 0%`, minWidth: 0 }}
       >
         {right}
       </div>


### PR DESCRIPTION
## Summary

Fixes a bug where the resize divider between the main chat panel and the AGENTS panel becomes non-interactive after collapsing the file browser sidebar.

## Problem

When the file browser sidebar is collapsed via the toggle button, the layout switches to a "fixed right-panel-width" mode. In this mode, the resize divider (the draggable separator between chat and AGENTS panels) was rendered as a static non-interactive element.

However, if the page was refreshed with the sidebar already collapsed, the divider worked correctly.

## Root Cause

The ResizablePanels component conditionally rendered the divider:
- Interactive (draggable) when `rightWidthPx === null`
- Static (non-interactive) when `rightWidthPx !== null`

## Solution

Remove the conditional rendering. The divider is now always interactive, regardless of panel mode:
- Track `localRightWidth` state for smooth resizing in fixed-width mode
- Apply pointer position changes to both percent and fixed-width modes
- Support double-click reset in fixed-width mode
- Add `role="separator"` and `aria-label` for accessibility

## Files Changed

- `src/components/ResizablePanels.tsx` - Core fix
- `src/components/ResizablePanels.test.tsx` - Regression test

## Validation

- All tests pass
- Build succeeds
- No type errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resizable panels drag behavior and calculations for better accuracy.
  * Enhanced double-click reset functionality to properly restore panel widths.

* **Accessibility**
  * Resize handle now includes proper ARIA labels and is consistently available during interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->