### PR TITLE
fix(sessions): satisfy lint on identity cleanup

### DIFF
--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -246,7 +246,8 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     const identityName = rootId === 'main' ? agentName : rootIdentityNames[rootId];
     if (rootId !== 'main' && !identityName) {
       if (!session.identityName) return session;
-      const { identityName: _dropIdentity, ...rest } = session;
+      const rest = { ...session };
+      delete rest.identityName;
       return rest;
     }
     if (!identityName || session.identityName === identityName) return session;


### PR DESCRIPTION
## Summary
- follow up on #259 with the lint-only fix that CI caught after merge
- replace the unused destructuring alias in `SessionContext.tsx` with a simple object copy plus `delete rest.identityName`
- keep the identity cleanup behavior unchanged while satisfying `@typescript-eslint/no-unused-vars`

## Test Plan
- npm run lint
- npm test -- --run src/features/sessions/sessionKeys.test.ts src/contexts/SessionContext.test.tsx src/features/kanban/CreateTaskDialog.test.tsx src/features/kanban/TaskDetailDrawer.test.tsx src/features/kanban/lib/assigneeOptions.test.ts
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal session handling implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->