### PR TITLE
fix(workspaces): refresh config watch and restore labels

### DIFF
--- a/server/lib/file-watcher.test.ts
+++ b/server/lib/file-watcher.test.ts
@@ -1,0 +1,136 @@
+/** Tests for root workspace watcher discovery. */
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+type WatchCallback = (eventType: string, filename: string | Buffer | null) => void;
+type WatchRecord = { target: string; callback: WatchCallback; close: ReturnType<typeof vi.fn> };
+
+const runtime = vi.hoisted(() => ({
+  configPath: '/tmp/home/.openclaw/openclaw.json',
+  existing: new Set<string>(),
+  watched: [] as WatchRecord[],
+  listConfiguredAgentWorkspaces: vi.fn(() => [] as Array<{ agentId: string; workspaceRoot: string }>),
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  const mock = {
+    ...actual,
+    existsSync: (target: actual.PathLike) => runtime.existing.has(String(target)),
+    readdirSync: vi.fn(() => []),
+    watch: ((target: actual.PathLike, optionsOrListener: unknown, maybeListener?: unknown) => {
+      const callback = (typeof optionsOrListener === 'function' ? optionsOrListener : maybeListener) as WatchCallback;
+      const close = vi.fn();
+      runtime.watched.push({ target: String(target), callback, close });
+      return { close } as unknown as actual.FSWatcher;
+    }) satisfies typeof actual.watch,
+  };
+  return { ...mock, default: mock };
+});
+
+vi.mock('../routes/events.js', () => ({
+  broadcast: vi.fn(),
+}));
+
+vi.mock('./config.js', () => ({
+  config: {
+    home: '/tmp/home',
+    workspaceWatchRecursive: false,
+    memoryPath: '/tmp/home/workspace/MEMORY.md',
+    memoryDir: '/tmp/home/workspace/memory',
+  },
+}));
+
+vi.mock('./agent-workspace.js', () => ({
+  resolveAgentWorkspace: (agentId?: string) => {
+    const normalized = !agentId || agentId === 'main' ? 'main' : agentId;
+    const workspaceRoot = normalized === 'main'
+      ? '/tmp/home/workspace'
+      : path.join('/tmp/home', `workspace-${normalized}`);
+    return {
+      agentId: normalized,
+      workspaceRoot,
+      memoryPath: path.join(workspaceRoot, 'MEMORY.md'),
+      memoryDir: path.join(workspaceRoot, 'memory'),
+    };
+  },
+}));
+
+vi.mock('./file-utils.js', () => ({
+  isBinary: () => false,
+  isExcluded: () => false,
+}));
+
+vi.mock('./openclaw-config.js', () => ({
+  listConfiguredAgentWorkspaces: (...args: unknown[]) => runtime.listConfiguredAgentWorkspaces(...args),
+  resolveOpenClawConfigPath: () => runtime.configPath,
+}));
+
+vi.mock('./workspace-detect.js', () => ({
+  isWorkspaceLocal: vi.fn(async () => true),
+}));
+
+async function loadWatcherModule() {
+  vi.resetModules();
+  return import('./file-watcher.js');
+}
+
+afterEach(async () => {
+  const mod = await loadWatcherModule();
+  mod.stopFileWatcher();
+  runtime.watched = [];
+  runtime.existing.clear();
+  runtime.listConfiguredAgentWorkspaces.mockReset();
+  runtime.listConfiguredAgentWorkspaces.mockReturnValue([]);
+  vi.clearAllMocks();
+});
+
+describe('startFileWatcher', () => {
+  it('watches the custom config directory when OPENCLAW_CONFIG_PATH points outside ~/.openclaw', async () => {
+    runtime.configPath = '/tmp/custom-configs/nerve-openclaw.json';
+    runtime.existing = new Set(['/tmp/home/.openclaw', '/tmp/custom-configs']);
+
+    const mod = await loadWatcherModule();
+    await mod.startFileWatcher();
+
+    expect(runtime.watched.map((entry) => entry.target).sort()).toEqual([
+      '/tmp/custom-configs',
+      '/tmp/home/.openclaw',
+    ]);
+
+    const initialCalls = runtime.listConfiguredAgentWorkspaces.mock.calls.length;
+    runtime.watched.find((entry) => entry.target === '/tmp/custom-configs')
+      ?.callback('rename', 'nerve-openclaw.json');
+
+    expect(runtime.listConfiguredAgentWorkspaces.mock.calls.length).toBeGreaterThan(initialCalls);
+  });
+
+  it('refreshes when a custom config basename changes inside ~/.openclaw', async () => {
+    runtime.configPath = '/tmp/home/.openclaw/custom-openclaw.json';
+    runtime.existing = new Set(['/tmp/home/.openclaw']);
+
+    const mod = await loadWatcherModule();
+    await mod.startFileWatcher();
+
+    expect(runtime.watched.map((entry) => entry.target)).toEqual(['/tmp/home/.openclaw']);
+
+    const initialCalls = runtime.listConfiguredAgentWorkspaces.mock.calls.length;
+    runtime.watched[0]?.callback('rename', 'custom-openclaw.json');
+
+    expect(runtime.listConfiguredAgentWorkspaces.mock.calls.length).toBeGreaterThan(initialCalls);
+  });
+
+  it('still refreshes when legacy workspace-* directories change', async () => {
+    runtime.configPath = '/tmp/custom-configs/nerve-openclaw.json';
+    runtime.existing = new Set(['/tmp/home/.openclaw', '/tmp/custom-configs']);
+
+    const mod = await loadWatcherModule();
+    await mod.startFileWatcher();
+
+    const initialCalls = runtime.listConfiguredAgentWorkspaces.mock.calls.length;
+    runtime.watched.find((entry) => entry.target === '/tmp/home/.openclaw')
+      ?.callback('rename', 'workspace-research');
+
+    expect(runtime.listConfiguredAgentWorkspaces.mock.calls.length).toBeGreaterThan(initialCalls);
+  });
+});

--- a/server/lib/file-watcher.ts
+++ b/server/lib/file-watcher.ts
@@ -19,7 +19,7 @@ import { isBinary, isExcluded } from './file-utils.js';
 import { listConfiguredAgentWorkspaces, resolveOpenClawConfigPath } from './openclaw-config.js';
 import { isWorkspaceLocal } from './workspace-detect.js';
 
-let rootDirWatcher: FSWatcher | null = null;
+const rootDirWatchers = new Map<string, FSWatcher>();
 const memoryWatchers = new Map<string, FSWatcher>();
 const memoryDirWatchers = new Map<string, FSWatcher>();
 const workspaceWatchers = new Map<string, FSWatcher>();
@@ -201,28 +201,35 @@ function refreshWorkspaceWatchers(): void {
 
 function startRootWorkspaceWatcher(): void {
   const openclawDir = path.join(config.home, '.openclaw');
-  if (rootDirWatcher) return;
+  if (rootDirWatchers.size > 0) return;
 
   try {
     const configPath = resolveOpenClawConfigPath();
-    const watchTarget = existsSync(configPath)
-      ? configPath
-      : openclawDir;
-
-    if (!existsSync(watchTarget)) return;
-
-    const watchingConfigFile = watchTarget === configPath;
+    const configDir = path.dirname(configPath);
     const configBasename = path.basename(configPath);
-    rootDirWatcher = watch(watchTarget, (_eventType, filename) => {
-      const file = getWatchFilename(filename);
-      if (
-        (watchingConfigFile && (!file || file === configBasename)) ||
-        file === 'workspace' ||
-        (file?.startsWith(WORKSPACE_PREFIX) ?? false)
-      ) {
-        refreshWorkspaceWatchers();
-      }
-    });
+    const watchTargets = new Set<string>();
+
+    if (existsSync(openclawDir)) watchTargets.add(openclawDir);
+    if (existsSync(configDir)) watchTargets.add(configDir);
+
+    for (const watchTarget of watchTargets) {
+      const watcher = watch(watchTarget, (_eventType, filename) => {
+        const file = getWatchFilename(filename);
+        if (!file) return;
+
+        const isConfigUpdate = watchTarget === configDir && file === configBasename;
+        const isWorkspaceDiscovery = watchTarget === openclawDir && (
+          file === 'workspace' ||
+          file.startsWith(WORKSPACE_PREFIX)
+        );
+
+        if (isConfigUpdate || isWorkspaceDiscovery) {
+          refreshWorkspaceWatchers();
+        }
+      });
+
+      rootDirWatchers.set(watchTarget, watcher);
+    }
   } catch (err) {
     console.warn('[file-watcher] Failed to watch workspace root for new agent workspaces:', (err as Error).message);
   }
@@ -261,8 +268,7 @@ export async function startFileWatcher(): Promise<void> {
  * Call this during graceful shutdown.
  */
 export function stopFileWatcher(): void {
-  rootDirWatcher?.close();
-  rootDirWatcher = null;
+  closeWatchers(rootDirWatchers);
   closeWatchers(memoryWatchers);
   closeWatchers(memoryDirWatchers);
   closeWatchers(workspaceWatchers);

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -73,6 +73,8 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const [agentStatus, setAgentStatus] = useState<Record<string, GranularAgentState>>({});
   const [agentName, setAgentName] = useState('Agent');
   const [defaultAgentWorkspaceRoot, setDefaultAgentWorkspaceRoot] = useState<string | null>(null);
+  const [rootIdentityNames, setRootIdentityNames] = useState<Record<string, string>>({});
+  const [rootIdentityMisses, setRootIdentityMisses] = useState<Record<string, true>>({});
   const [unreadSessionKeys, setUnreadSessionKeys] = useState<Set<string>>(new Set());
   const unreadSessionKeysRef = useRef(unreadSessionKeys);
   const soundEnabledRef = useRef(soundEnabled);


### PR DESCRIPTION
## Summary
- follow up on #261 so workspace watcher refresh also handles custom `OPENCLAW_CONFIG_PATH` directories and basenames correctly
- add regression coverage for both custom-config watcher cases plus the legacy `workspace-*` path
- restore the missing `rootIdentityNames` / `rootIdentityMisses` state in `SessionContext.tsx`, which was left undefined on current `master` and broke the related session-context tests at runtime

## Test Plan
- npm run lint
- npm test -- --run server/lib/file-watcher.test.ts server/lib/agent-workspace.test.ts server/routes/server-info.test.ts src/contexts/SessionContext.test.tsx
- npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suite for configuration file watching behavior when configuration resides in different directory locations.

* **Improvements**
  * File watcher now monitors multiple configuration directories simultaneously, improving support for custom configuration paths and locations.
  * Session identity information caching has been optimized to reduce redundant requests to the identity API endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->