### PR TITLE
fix(kanban): fall back to full session list for assigned execution

### DIFF
--- a/server/routes/kanban.test.ts
+++ b/server/routes/kanban.test.ts
@@ -1442,6 +1442,57 @@ describe('POST /api/kanban/tasks/:id/execute', () => {
     expect(invokeGatewayToolMock).not.toHaveBeenCalled();
   });
 
+  it('falls back to the full session list when the assigned root is older than the recent-session window', async () => {
+    const invokeGatewayToolMock = vi.fn(async () => ({ sessionKey: 'agent:main:subagent:unexpected' }));
+    const launchMock = vi.fn(async ({ label, parentSessionKey }: { label: string; parentSessionKey: string }) => ({
+      sessionKey: buildMockRootSessionKey(label),
+      parentSessionKey,
+      knownSessionKeysBefore: [parentSessionKey],
+    }));
+
+    vi.doMock('../lib/kanban-subagent-fallback.js', () => ({
+      buildKanbanFallbackRunKey: buildMockRootSessionKey,
+      resolveKanbanFallbackParentSessionKey: vi.fn((assignee?: string) => {
+        if (!assignee || assignee === 'operator') return null;
+        const match = assignee.match(/^agent:([^:]+)/);
+        if (!match || match[1] === 'main') return null;
+        return `agent:${match[1]}:main`;
+      }),
+      launchKanbanFallbackSubagentViaRpc: launchMock,
+    }));
+
+    const gatewayRpcMock = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'sessions.list' && params?.activeMinutes === 7 * 24 * 60) {
+        return { sessions: [{ sessionKey: 'agent:reviewer:main' }] };
+      }
+      if (method === 'sessions.list' && params?.limit === 1000) {
+        return { sessions: [{ sessionKey: 'agent:reviewer:main' }, { sessionKey: 'agent:designer:main' }] };
+      }
+      return {};
+    });
+
+    const app = await buildApp({
+      executionMode: 'primary',
+      invokeGatewayToolMock,
+      gatewayRpcMock,
+    });
+    const task = await createTask(app, { status: 'todo', assignee: 'agent:designer' });
+
+    const res = await app.request(`/api/kanban/tasks/${task.id}/execute`, json({}));
+    expect(res.status).toBe(200);
+
+    expect(gatewayRpcMock).toHaveBeenCalledWith('sessions.list', {
+      activeMinutes: 7 * 24 * 60,
+      limit: 1000,
+    });
+    expect(gatewayRpcMock).toHaveBeenCalledWith('sessions.list', {
+      limit: 1000,
+    });
+    expect(launchMock).toHaveBeenCalledWith(expect.objectContaining({
+      parentSessionKey: 'agent:designer:main',
+    }));
+  });
+
   it.each([
     'agent:designer:main',
     'agent:designer:subagent:child',

--- a/server/routes/kanban.ts
+++ b/server/routes/kanban.ts
@@ -1165,12 +1165,22 @@ app.post('/api/kanban/tasks/:id/execute', rateLimitGeneral, async (c) => {
 
       const assignedParentSessionKey = resolveKanbanAssigneeRootSessionKey(existing.assignee);
       if (assignedParentSessionKey) {
-        const sessionsResponse = await gatewayRpcCall('sessions.list', {
+        const recentSessionsResponse = await gatewayRpcCall('sessions.list', {
           activeMinutes: PARENT_ROOT_LOOKUP_ACTIVE_MINUTES,
           limit: PARENT_ROOT_LOOKUP_SESSIONS_LIMIT,
         }) as { sessions?: GatewaySessionSummary[] };
-        const sessions = Array.isArray(sessionsResponse.sessions) ? sessionsResponse.sessions : [];
-        if (!sessions.some((session) => getSessionKey(session) === assignedParentSessionKey)) {
+        const recentSessions = Array.isArray(recentSessionsResponse.sessions) ? recentSessionsResponse.sessions : [];
+
+        let parentSessionExists = recentSessions.some((session) => getSessionKey(session) === assignedParentSessionKey);
+        if (!parentSessionExists) {
+          const fullSessionsResponse = await gatewayRpcCall('sessions.list', {
+            limit: PARENT_ROOT_LOOKUP_SESSIONS_LIMIT,
+          }) as { sessions?: GatewaySessionSummary[] };
+          const fullSessions = Array.isArray(fullSessionsResponse.sessions) ? fullSessionsResponse.sessions : [];
+          parentSessionExists = fullSessions.some((session) => getSessionKey(session) === assignedParentSessionKey);
+        }
+
+        if (!parentSessionExists) {
           throw new KanbanExecutionPreflightError(`Parent agent session not found: ${assignedParentSessionKey}`);
         }
 


### PR DESCRIPTION
## What
Fixes Kanban task execution for assigned worker roots when the root session is older than the recent-session preflight window.

## Why
Assigned execution currently checks only `sessions.list` with a 7-day `activeMinutes` filter before deciding whether the parent root exists. That can reject valid worker roots that are still present in the full authoritative session list, causing errors like `Parent agent session not found: agent:infra-ops:main`.

Closes #286

## How
The execute preflight in `server/routes/kanban.ts` now keeps the existing recent-session lookup first, then falls back to an unfiltered `sessions.list` only when the recent-window lookup misses the assigned root. The route still fails fast if the root is absent from both lists.

A regression test was added in `server/routes/kanban.test.ts` for the exact case where the assigned root is absent from the recent-window result but present in the full session list.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist
- [x] `npm run lint` passes
- [x] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [x] New features include tests
- [ ] UI changes include a screenshot or screen recording

## Screenshots
Not applicable. This PR only changes Kanban execution preflight logic and its route tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of task execution by implementing a more robust session validation process with automatic fallback handling.

* **Tests**
  * Added test coverage for session validation edge cases during task execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->