### PR TITLE
feat(chat): add CHAT_PATH_LINKS alias mapping

### DIFF
--- a/server/lib/chat-path-links-config.test.ts
+++ b/server/lib/chat-path-links-config.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  normalizeChatPathLinkAliases,
+  parseChatPathLinksConfig,
+} from './chat-path-links-config.js';
+
+describe('chat-path-links-config', () => {
+  it('rejects aliases that would shadow the built-in workspace shorthand', () => {
+    expect(normalizeChatPathLinkAliases({
+      'workspace/': '/workspace/override/',
+      'workspace/projects/': '/workspace/custom-projects/',
+      'docs/': '/workspace/docs/',
+    })).toEqual({
+      'docs/': '/workspace/docs/',
+    });
+  });
+
+  it('parsing drops reserved workspace alias keys while keeping valid aliases', () => {
+    expect(parseChatPathLinksConfig(JSON.stringify({
+      prefixes: ['/workspace/'],
+      aliases: {
+        'workspace/': '/workspace/override/',
+        'workspace/projects/': '/workspace/custom-projects/',
+        'docs/': 'workspace/docs',
+      },
+    }))).toEqual({
+      prefixes: ['/workspace/'],
+      aliases: {
+        'docs/': '/workspace/docs/',
+      },
+    });
+  });
+});

--- a/server/lib/chat-path-links-config.ts
+++ b/server/lib/chat-path-links-config.ts
@@ -1,5 +1,6 @@
 export interface ChatPathLinksConfig {
   prefixes: string[];
+  aliases: Record<string, string>;
 }
 
 export interface ChatPathLinksSeedContext {
@@ -10,6 +11,9 @@ export interface ChatPathLinksSeedContext {
 }
 
 const DEFAULT_PREFIX = '/workspace/';
+const CANONICAL_WORKSPACE_PREFIX = '/workspace/';
+const FILE_WORKSPACE_PREFIX = 'file:///workspace/';
+const SCHEME_RE = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
 
 function withTrailingSlash(value: string): string {
   return value.endsWith('/') ? value : `${value}/`;
@@ -97,10 +101,38 @@ export function createDefaultChatPathLinksConfig(context: ChatPathLinksSeedConte
 
   return {
     prefixes: dedupePrefixes(prefixes),
+    aliases: {},
   };
 }
 
 export const DEFAULT_CHAT_PATH_LINKS_CONFIG: ChatPathLinksConfig = createDefaultChatPathLinksConfig();
+
+function normalizeAliasKey(value: string): string {
+  const normalized = normalizePrefixPath(value);
+  if (!normalized) return '';
+  if (normalized.startsWith('/') || normalized.startsWith('file://') || SCHEME_RE.test(normalized)) return '';
+  return normalized;
+}
+
+function normalizeAliasValue(value: string): string {
+  const normalized = normalizePrefixPath(value);
+  if (!normalized) return '';
+
+  if (normalized.startsWith(FILE_WORKSPACE_PREFIX)) {
+    const canonical = normalized.slice('file://'.length);
+    return canonical.startsWith(CANONICAL_WORKSPACE_PREFIX) ? canonical : '';
+  }
+
+  if (normalized.startsWith(CANONICAL_WORKSPACE_PREFIX)) {
+    return normalized;
+  }
+
+  if (normalized.startsWith('workspace/')) {
+    return `${CANONICAL_WORKSPACE_PREFIX}${normalized.slice('workspace/'.length)}`;
+  }
+
+  return '';
+}
 
 export function normalizeChatPathLinkPrefixes(rawPrefixes: unknown): string[] {
   if (!Array.isArray(rawPrefixes)) return [...DEFAULT_CHAT_PATH_LINKS_CONFIG.prefixes];
@@ -112,15 +144,38 @@ export function normalizeChatPathLinkPrefixes(rawPrefixes: unknown): string[] {
   return normalized.length > 0 ? normalized : [...DEFAULT_CHAT_PATH_LINKS_CONFIG.prefixes];
 }
 
+export function normalizeChatPathLinkAliases(rawAliases: unknown): Record<string, string> {
+  if (!rawAliases || typeof rawAliases !== 'object' || Array.isArray(rawAliases)) return {};
+
+  const entries = Object.entries(rawAliases as Record<string, unknown>);
+  const normalized: Record<string, string> = {};
+
+  for (const [rawKey, rawValue] of entries) {
+    if (typeof rawValue !== 'string') continue;
+
+    const key = normalizeAliasKey(rawKey);
+    const value = normalizeAliasValue(rawValue);
+    if (!key || !value) continue;
+
+    normalized[key] = value;
+  }
+
+  return normalized;
+}
+
 export function parseChatPathLinksConfig(content: string): ChatPathLinksConfig {
-  const parsed = JSON.parse(content) as { prefixes?: unknown };
+  const parsed = JSON.parse(content) as { prefixes?: unknown; aliases?: unknown };
   return {
     prefixes: normalizeChatPathLinkPrefixes(parsed?.prefixes),
+    aliases: normalizeChatPathLinkAliases(parsed?.aliases),
   };
 }
 
 export function stringifyChatPathLinksConfig(config: ChatPathLinksConfig): string {
-  return `${JSON.stringify({ prefixes: normalizeChatPathLinkPrefixes(config.prefixes) }, null, 2)}\n`;
+  return `${JSON.stringify({
+    prefixes: normalizeChatPathLinkPrefixes(config.prefixes),
+    aliases: normalizeChatPathLinkAliases(config.aliases),
+  }, null, 2)}\n`;
 }
 
 export function createChatPathLinksTemplate(context: ChatPathLinksSeedContext = {}): string {

--- a/server/lib/chat-path-links-config.ts
+++ b/server/lib/chat-path-links-config.ts
@@ -12,6 +12,7 @@ export interface ChatPathLinksSeedContext {
 
 const DEFAULT_PREFIX = '/workspace/';
 const CANONICAL_WORKSPACE_PREFIX = '/workspace/';
+const BARE_WORKSPACE_PREFIX = 'workspace/';
 const FILE_WORKSPACE_PREFIX = 'file:///workspace/';
 const SCHEME_RE = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
 
@@ -111,6 +112,8 @@ function normalizeAliasKey(value: string): string {
   const normalized = normalizePrefixPath(value);
   if (!normalized) return '';
   if (normalized.startsWith('/') || normalized.startsWith('file://') || SCHEME_RE.test(normalized)) return '';
+  // Reserve workspace/... for the built-in product shorthand, not user-defined aliases.
+  if (normalized.startsWith(BARE_WORKSPACE_PREFIX)) return '';
   return normalized;
 }
 
@@ -127,8 +130,8 @@ function normalizeAliasValue(value: string): string {
     return normalized;
   }
 
-  if (normalized.startsWith('workspace/')) {
-    return `${CANONICAL_WORKSPACE_PREFIX}${normalized.slice('workspace/'.length)}`;
+  if (normalized.startsWith(BARE_WORKSPACE_PREFIX)) {
+    return `${CANONICAL_WORKSPACE_PREFIX}${normalized.slice(BARE_WORKSPACE_PREFIX.length)}`;
   }
 
   return '';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -340,6 +340,9 @@ export default function App({ onLogout }: AppProps) {
   const [chatPathLinkPrefixes, setChatPathLinkPrefixes] = useState<string[]>(
     DEFAULT_CHAT_PATH_LINKS_CONFIG.prefixes,
   );
+  const [chatPathLinkAliases, setChatPathLinkAliases] = useState<Record<string, string>>(
+    DEFAULT_CHAT_PATH_LINKS_CONFIG.aliases,
+  );
   const [addToChatEnabled, setAddToChatEnabled] = useState(false);
 
   useEffect(() => {
@@ -350,19 +353,23 @@ export default function App({ onLogout }: AppProps) {
       .then(async (res) => {
         if (res.status === 404) {
           setChatPathLinkPrefixes(DEFAULT_CHAT_PATH_LINKS_CONFIG.prefixes);
+          setChatPathLinkAliases(DEFAULT_CHAT_PATH_LINKS_CONFIG.aliases);
           return;
         }
         const data = await res.json() as { ok: boolean; content?: string };
         if (!data.ok || !data.content) {
           setChatPathLinkPrefixes(DEFAULT_CHAT_PATH_LINKS_CONFIG.prefixes);
+          setChatPathLinkAliases(DEFAULT_CHAT_PATH_LINKS_CONFIG.aliases);
           return;
         }
         const parsed = parseChatPathLinksConfig(data.content);
         setChatPathLinkPrefixes(parsed.prefixes);
+        setChatPathLinkAliases(parsed.aliases);
       })
       .catch(() => {
         if (!controller.signal.aborted) {
           setChatPathLinkPrefixes(DEFAULT_CHAT_PATH_LINKS_CONFIG.prefixes);
+          setChatPathLinkAliases(DEFAULT_CHAT_PATH_LINKS_CONFIG.aliases);
         }
       });
 
@@ -780,6 +787,7 @@ export default function App({ onLogout }: AppProps) {
       onOpenWorkspacePath={openWorkspacePath}
       onOpenBeadId={openBeadId}
       pathLinkPrefixes={chatPathLinkPrefixes}
+      pathLinkAliases={chatPathLinkAliases}
       chatPanel={
         <PanelErrorBoundary name="Chat">
           <ChatPanel
@@ -807,6 +815,7 @@ export default function App({ onLogout }: AppProps) {
             isMobileTopBarHidden={isMobileTopBarHidden}
             onOpenWorkspacePath={openWorkspacePath}
             pathLinkPrefixes={chatPathLinkPrefixes}
+            pathLinkAliases={chatPathLinkAliases}
             onOpenBeadId={openBeadId}
           />
         </PanelErrorBoundary>

--- a/src/features/beads/BeadViewerTab.tsx
+++ b/src/features/beads/BeadViewerTab.tsx
@@ -9,6 +9,7 @@ interface BeadViewerTabProps {
   onOpenBeadId?: (target: BeadLinkTarget) => void;
   onOpenWorkspacePath?: (path: string, basePath?: string) => void | Promise<void>;
   pathLinkPrefixes?: string[];
+  pathLinkAliases?: Record<string, string>;
 }
 
 function formatTimestamp(value: string | null): string | null {
@@ -64,7 +65,7 @@ function RelationList({
   );
 }
 
-export function BeadViewerTab({ beadTarget, onOpenBeadId, onOpenWorkspacePath, pathLinkPrefixes }: BeadViewerTabProps) {
+export function BeadViewerTab({ beadTarget, onOpenBeadId, onOpenWorkspacePath, pathLinkPrefixes, pathLinkAliases }: BeadViewerTabProps) {
   const { bead, loading, error } = useBeadDetail(beadTarget);
   const linkedPlan = bead?.linkedPlan ?? null;
 
@@ -144,6 +145,7 @@ export function BeadViewerTab({ beadTarget, onOpenBeadId, onOpenWorkspacePath, p
                 onOpenBeadId={openBeadWithContext}
                 onOpenWorkspacePath={onOpenWorkspacePath}
                 pathLinkPrefixes={pathLinkPrefixes}
+                pathLinkAliases={pathLinkAliases}
               />
             </div>
           ) : null}

--- a/src/features/chat/ChatPanel.tsx
+++ b/src/features/chat/ChatPanel.tsx
@@ -46,6 +46,8 @@ interface ChatPanelProps {
   onOpenWorkspacePath?: (path: string) => void | Promise<void>;
   /** Configured path prefixes that should render as clickable inline path links. */
   pathLinkPrefixes?: string[];
+  /** Configured shorthand aliases that should normalize to canonical workspace paths. */
+  pathLinkAliases?: Record<string, string>;
   /** Open a dedicated bead viewer tab. */
   onOpenBeadId?: (target: BeadLinkTarget) => void | Promise<void>;
 }
@@ -66,6 +68,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
   onToggleMobileTopBar, isMobileTopBarHidden = false,
   onOpenWorkspacePath,
   pathLinkPrefixes,
+  pathLinkAliases,
   onOpenBeadId,
 }, ref) {
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -345,6 +348,7 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
                 agentName={agentName}
                 onOpenWorkspacePath={onOpenWorkspacePath}
                 pathLinkPrefixes={pathLinkPrefixes}
+                pathLinkAliases={pathLinkAliases}
                 onOpenBeadId={onOpenBeadId}
               />
             </div>

--- a/src/features/chat/MessageBubble.tsx
+++ b/src/features/chat/MessageBubble.tsx
@@ -53,6 +53,7 @@ interface MessageBubbleProps {
   agentName?: string;
   onOpenWorkspacePath?: (path: string) => void | Promise<void>;
   pathLinkPrefixes?: string[];
+  pathLinkAliases?: Record<string, string>;
   onOpenBeadId?: (target: BeadLinkTarget) => void | Promise<void>;
 }
 
@@ -82,7 +83,7 @@ function RoleBadge({ role, agentName = 'Agent' }: { role: string; agentName?: st
   return <span className="cockpit-badge">System</span>;
 }
 
-function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memoryKey, onToggleCollapse, onToggleMemory, firstMessageTime, searchQuery, isCurrentMatch, agentName, onOpenWorkspacePath, pathLinkPrefixes, onOpenBeadId }: MessageBubbleProps) {
+function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memoryKey, onToggleCollapse, onToggleMemory, firstMessageTime, searchQuery, isCurrentMatch, agentName, onOpenWorkspacePath, pathLinkPrefixes, pathLinkAliases, onOpenBeadId }: MessageBubbleProps) {
   const isUser = msg.role === 'user';
   const isAssistant = msg.role === 'assistant';
   const isSystem = msg.role === 'system' || msg.role === 'event';
@@ -199,7 +200,7 @@ function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memory
         {!isCollapsed && (
           <div className="ml-3 border-l border-primary/12 px-3 pb-2 pt-1 text-[0.8rem] text-foreground/70 msg-body-intermediate">
             <Suspense fallback={<span className="text-muted-foreground text-xs">…</span>}>
-              <MarkdownRenderer content={msg.rawText} searchQuery={searchQuery} onOpenWorkspacePath={onOpenWorkspacePath} pathLinkPrefixes={pathLinkPrefixes} onOpenBeadId={onOpenBeadId} />
+              <MarkdownRenderer content={msg.rawText} searchQuery={searchQuery} onOpenWorkspacePath={onOpenWorkspacePath} pathLinkPrefixes={pathLinkPrefixes} pathLinkAliases={pathLinkAliases} onOpenBeadId={onOpenBeadId} />
             </Suspense>
           </div>
         )}
@@ -229,7 +230,7 @@ function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memory
           ) : (
             <div className="text-muted-foreground/70 text-[0.8rem] flex-1 min-w-0 msg-body-intermediate">
               <Suspense fallback={<span className="text-muted-foreground text-xs">…</span>}>
-                <MarkdownRenderer content={displayContent} searchQuery={searchQuery} suppressImages={isAssistant} onOpenWorkspacePath={onOpenWorkspacePath} pathLinkPrefixes={pathLinkPrefixes} onOpenBeadId={onOpenBeadId} />
+                <MarkdownRenderer content={displayContent} searchQuery={searchQuery} suppressImages={isAssistant} onOpenWorkspacePath={onOpenWorkspacePath} pathLinkPrefixes={pathLinkPrefixes} pathLinkAliases={pathLinkAliases} onOpenBeadId={onOpenBeadId} />
               </Suspense>
             </div>
           )}
@@ -295,7 +296,7 @@ function MessageBubbleInner({ msg, index, isCollapsed, isMemoryCollapsed, memory
             )}
             {displayContent && (
               <Suspense fallback={<div className="text-muted-foreground text-xs">Loading…</div>}>
-                <MarkdownRenderer content={displayContent} searchQuery={searchQuery} suppressImages={isAssistant} onOpenWorkspacePath={onOpenWorkspacePath} pathLinkPrefixes={pathLinkPrefixes} onOpenBeadId={onOpenBeadId} />
+                <MarkdownRenderer content={displayContent} searchQuery={searchQuery} suppressImages={isAssistant} onOpenWorkspacePath={onOpenWorkspacePath} pathLinkPrefixes={pathLinkPrefixes} pathLinkAliases={pathLinkAliases} onOpenBeadId={onOpenBeadId} />
               </Suspense>
             )}
           </div>
@@ -420,6 +421,7 @@ export const MessageBubble = memo(MessageBubbleInner, (prev, next) => {
   if (prev.agentName !== next.agentName) return false;
   if (prev.onOpenWorkspacePath !== next.onOpenWorkspacePath) return false;
   if (prev.pathLinkPrefixes !== next.pathLinkPrefixes) return false;
+  if (prev.pathLinkAliases !== next.pathLinkAliases) return false;
   if (prev.onOpenBeadId !== next.onOpenBeadId) return false;
   
   // All relevant props are equal, skip re-render

--- a/src/features/chat/chatPathLinks.test.ts
+++ b/src/features/chat/chatPathLinks.test.ts
@@ -1,28 +1,73 @@
 import { describe, expect, it } from 'vitest';
 
-import { DEFAULT_CHAT_PATH_LINKS_CONFIG, parseChatPathLinksConfig } from './chatPathLinks';
+import {
+  DEFAULT_CHAT_PATH_LINKS_CONFIG,
+  normalizeChatPathLinkAliases,
+  parseChatPathLinksConfig,
+  stringifyChatPathLinksConfig,
+} from './chatPathLinks';
 
 describe('chatPathLinks config', () => {
-  it('defaults to the canonical workspace prefix', () => {
-    expect(DEFAULT_CHAT_PATH_LINKS_CONFIG).toEqual({ prefixes: ['/workspace/'] });
+  it('defaults to the canonical workspace prefix with no aliases', () => {
+    expect(DEFAULT_CHAT_PATH_LINKS_CONFIG).toEqual({ prefixes: ['/workspace/'], aliases: {} });
   });
 
-  it('keeps configured prefixes trimmed without requiring a separate workspace shorthand entry', () => {
+  it('keeps configured prefixes trimmed while normalizing aliases to canonical workspace targets', () => {
     expect(
       parseChatPathLinksConfig(JSON.stringify({
-        prefixes: ['  /workspace/  ', '  /home/derrick/.openclaw/workspace/  '],
+        prefixes: ['  /workspace/  ', '  /home/derrick/.openclaw/workspace  '],
+        aliases: {
+          ' projects ': ' workspace/projects ',
+          'notes\\': 'file:///workspace/docs/notes',
+        },
       })),
     ).toEqual({
       prefixes: ['/workspace/', '/home/derrick/.openclaw/workspace/'],
+      aliases: {
+        'projects/': '/workspace/projects/',
+        'notes/': '/workspace/docs/notes/',
+      },
     });
   });
 
-  it('falls back to the canonical workspace prefix when prefixes are missing or empty', () => {
-    expect(parseChatPathLinksConfig('{}')).toEqual({ prefixes: ['/workspace/'] });
-    expect(parseChatPathLinksConfig(JSON.stringify({ prefixes: [] }))).toEqual({ prefixes: ['/workspace/'] });
-    expect(parseChatPathLinksConfig(JSON.stringify({ prefixes: ['   '] }))).toEqual({ prefixes: ['/workspace/'] });
-    expect(parseChatPathLinksConfig(JSON.stringify({ prefixes: [123, null, false] }))).toEqual({
+  it('falls back for missing prefixes and ignores invalid aliases', () => {
+    expect(parseChatPathLinksConfig('{}')).toEqual({ prefixes: ['/workspace/'], aliases: {} });
+    expect(parseChatPathLinksConfig(JSON.stringify({ prefixes: ['   '], aliases: [] }))).toEqual({
       prefixes: ['/workspace/'],
+      aliases: {},
     });
+
+    expect(normalizeChatPathLinkAliases({
+      '': '/workspace/projects/',
+      '/workspace/projects/': '/workspace/projects/',
+      'file://projects/': '/workspace/projects/',
+      'mailto:projects/': '/workspace/projects/',
+      'projects/': '/home/derrick/.openclaw/workspace/projects/',
+      'docs/': 'https://example.com/docs/',
+      'notes/': '',
+      'valid\\': 'workspace/docs/valid',
+      'projects\\': '/workspace/projects-override',
+    })).toEqual({
+      'valid/': '/workspace/docs/valid/',
+      'projects/': '/workspace/projects-override/',
+    });
+  });
+
+  it('serializes aliases with a trailing newline', () => {
+    expect(stringifyChatPathLinksConfig({
+      prefixes: ['/workspace', '/workspace/'],
+      aliases: {
+        'projects': 'workspace/projects',
+      },
+    })).toBe(
+      '{\n'
+      + '  "prefixes": [\n'
+      + '    "/workspace/"\n'
+      + '  ],\n'
+      + '  "aliases": {\n'
+      + '    "projects/": "/workspace/projects/"\n'
+      + '  }\n'
+      + '}\n',
+    );
   });
 });

--- a/src/features/chat/chatPathLinks.test.ts
+++ b/src/features/chat/chatPathLinks.test.ts
@@ -53,6 +53,16 @@ describe('chatPathLinks config', () => {
     });
   });
 
+  it('rejects aliases that would shadow the built-in workspace shorthand', () => {
+    expect(normalizeChatPathLinkAliases({
+      'workspace/': '/workspace/override/',
+      'workspace/projects/': '/workspace/custom-projects/',
+      'docs/': '/workspace/docs/',
+    })).toEqual({
+      'docs/': '/workspace/docs/',
+    });
+  });
+
   it('serializes aliases with a trailing newline', () => {
     expect(stringifyChatPathLinksConfig({
       prefixes: ['/workspace', '/workspace/'],

--- a/src/features/chat/chatPathLinks.ts
+++ b/src/features/chat/chatPathLinks.ts
@@ -2,6 +2,7 @@ export {
   DEFAULT_CHAT_PATH_LINKS_CONFIG,
   createChatPathLinksTemplate,
   createDefaultChatPathLinksConfig,
+  normalizeChatPathLinkAliases,
   normalizeChatPathLinkPrefixes,
   parseChatPathLinksConfig,
   stringifyChatPathLinksConfig,

--- a/src/features/chat/chatPathLinksConfig.test.ts
+++ b/src/features/chat/chatPathLinksConfig.test.ts
@@ -52,10 +52,12 @@ describe('chatPathLinksConfig', () => {
   it('normalizes, dedupes, and falls back when parsing', () => {
     expect(parseChatPathLinksConfig('{"prefixes":[" /workspace ","/workspace/","","  "]}')).toEqual({
       prefixes: ['/workspace/'],
+      aliases: {},
     });
 
     expect(parseChatPathLinksConfig('{"prefixes":[]}')).toEqual({
       prefixes: ['/workspace/'],
+      aliases: {},
     });
   });
 
@@ -72,15 +74,17 @@ describe('chatPathLinksConfig', () => {
       + '    "/workspace/",\n'
       + '    "/home/derrick/.openclaw/workspace/",\n'
       + '    "/home/derrick/workspace/"\n'
-      + '  ]\n'
+      + '  ],\n'
+      + '  "aliases": {}\n'
       + '}\n',
     );
 
-    expect(stringifyChatPathLinksConfig({ prefixes: ['/workspace', '/workspace/'] })).toBe(
+    expect(stringifyChatPathLinksConfig({ prefixes: ['/workspace', '/workspace/'], aliases: {} })).toBe(
       '{\n'
       + '  "prefixes": [\n'
       + '    "/workspace/"\n'
-      + '  ]\n'
+      + '  ],\n'
+      + '  "aliases": {}\n'
       + '}\n',
     );
   });

--- a/src/features/chat/chatPathLinksConfig.ts
+++ b/src/features/chat/chatPathLinksConfig.ts
@@ -1,5 +1,6 @@
 export interface ChatPathLinksConfig {
   prefixes: string[];
+  aliases: Record<string, string>;
 }
 
 export interface ChatPathLinksSeedContext {
@@ -10,6 +11,9 @@ export interface ChatPathLinksSeedContext {
 }
 
 const DEFAULT_PREFIX = '/workspace/';
+const CANONICAL_WORKSPACE_PREFIX = '/workspace/';
+const FILE_WORKSPACE_PREFIX = 'file:///workspace/';
+const SCHEME_RE = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
 
 function withTrailingSlash(value: string): string {
   return value.endsWith('/') ? value : `${value}/`;
@@ -97,10 +101,38 @@ export function createDefaultChatPathLinksConfig(context: ChatPathLinksSeedConte
 
   return {
     prefixes: dedupePrefixes(prefixes),
+    aliases: {},
   };
 }
 
 export const DEFAULT_CHAT_PATH_LINKS_CONFIG: ChatPathLinksConfig = createDefaultChatPathLinksConfig();
+
+function normalizeAliasKey(value: string): string {
+  const normalized = normalizePrefixPath(value);
+  if (!normalized) return '';
+  if (normalized.startsWith('/') || normalized.startsWith('file://') || SCHEME_RE.test(normalized)) return '';
+  return normalized;
+}
+
+function normalizeAliasValue(value: string): string {
+  const normalized = normalizePrefixPath(value);
+  if (!normalized) return '';
+
+  if (normalized.startsWith(FILE_WORKSPACE_PREFIX)) {
+    const canonical = normalized.slice('file://'.length);
+    return canonical.startsWith(CANONICAL_WORKSPACE_PREFIX) ? canonical : '';
+  }
+
+  if (normalized.startsWith(CANONICAL_WORKSPACE_PREFIX)) {
+    return normalized;
+  }
+
+  if (normalized.startsWith('workspace/')) {
+    return `${CANONICAL_WORKSPACE_PREFIX}${normalized.slice('workspace/'.length)}`;
+  }
+
+  return '';
+}
 
 export function normalizeChatPathLinkPrefixes(rawPrefixes: unknown): string[] {
   if (!Array.isArray(rawPrefixes)) return [...DEFAULT_CHAT_PATH_LINKS_CONFIG.prefixes];
@@ -112,15 +144,38 @@ export function normalizeChatPathLinkPrefixes(rawPrefixes: unknown): string[] {
   return normalized.length > 0 ? normalized : [...DEFAULT_CHAT_PATH_LINKS_CONFIG.prefixes];
 }
 
+export function normalizeChatPathLinkAliases(rawAliases: unknown): Record<string, string> {
+  if (!rawAliases || typeof rawAliases !== 'object' || Array.isArray(rawAliases)) return {};
+
+  const entries = Object.entries(rawAliases as Record<string, unknown>);
+  const normalized: Record<string, string> = {};
+
+  for (const [rawKey, rawValue] of entries) {
+    if (typeof rawValue !== 'string') continue;
+
+    const key = normalizeAliasKey(rawKey);
+    const value = normalizeAliasValue(rawValue);
+    if (!key || !value) continue;
+
+    normalized[key] = value;
+  }
+
+  return normalized;
+}
+
 export function parseChatPathLinksConfig(content: string): ChatPathLinksConfig {
-  const parsed = JSON.parse(content) as { prefixes?: unknown };
+  const parsed = JSON.parse(content) as { prefixes?: unknown; aliases?: unknown };
   return {
     prefixes: normalizeChatPathLinkPrefixes(parsed?.prefixes),
+    aliases: normalizeChatPathLinkAliases(parsed?.aliases),
   };
 }
 
 export function stringifyChatPathLinksConfig(config: ChatPathLinksConfig): string {
-  return `${JSON.stringify({ prefixes: normalizeChatPathLinkPrefixes(config.prefixes) }, null, 2)}\n`;
+  return `${JSON.stringify({
+    prefixes: normalizeChatPathLinkPrefixes(config.prefixes),
+    aliases: normalizeChatPathLinkAliases(config.aliases),
+  }, null, 2)}\n`;
 }
 
 export function createChatPathLinksTemplate(context: ChatPathLinksSeedContext = {}): string {

--- a/src/features/chat/chatPathLinksConfig.ts
+++ b/src/features/chat/chatPathLinksConfig.ts
@@ -12,6 +12,7 @@ export interface ChatPathLinksSeedContext {
 
 const DEFAULT_PREFIX = '/workspace/';
 const CANONICAL_WORKSPACE_PREFIX = '/workspace/';
+const BARE_WORKSPACE_PREFIX = 'workspace/';
 const FILE_WORKSPACE_PREFIX = 'file:///workspace/';
 const SCHEME_RE = /^[a-zA-Z][a-zA-Z\d+.-]*:/;
 
@@ -111,6 +112,8 @@ function normalizeAliasKey(value: string): string {
   const normalized = normalizePrefixPath(value);
   if (!normalized) return '';
   if (normalized.startsWith('/') || normalized.startsWith('file://') || SCHEME_RE.test(normalized)) return '';
+  // Reserve workspace/... for the built-in product shorthand, not user-defined aliases.
+  if (normalized.startsWith(BARE_WORKSPACE_PREFIX)) return '';
   return normalized;
 }
 
@@ -127,8 +130,8 @@ function normalizeAliasValue(value: string): string {
     return normalized;
   }
 
-  if (normalized.startsWith('workspace/')) {
-    return `${CANONICAL_WORKSPACE_PREFIX}${normalized.slice('workspace/'.length)}`;
+  if (normalized.startsWith(BARE_WORKSPACE_PREFIX)) {
+    return `${CANONICAL_WORKSPACE_PREFIX}${normalized.slice(BARE_WORKSPACE_PREFIX.length)}`;
   }
 
   return '';

--- a/src/features/file-browser/MarkdownDocumentView.tsx
+++ b/src/features/file-browser/MarkdownDocumentView.tsx
@@ -11,6 +11,7 @@ interface MarkdownDocumentViewProps {
   onRetry: (path: string) => void;
   onOpenWorkspacePath?: (path: string, basePath?: string) => void | Promise<void>;
   onOpenBeadId?: (target: import('@/features/beads').BeadLinkTarget) => void | Promise<void>;
+  pathLinkAliases?: Record<string, string>;
   workspaceAgentId?: string;
 }
 
@@ -21,6 +22,7 @@ export function MarkdownDocumentView({
   onRetry,
   onOpenWorkspacePath,
   onOpenBeadId,
+  pathLinkAliases,
   workspaceAgentId,
 }: MarkdownDocumentViewProps) {
   const [mode, setMode] = useState<'preview' | 'edit'>('preview');
@@ -96,6 +98,7 @@ export function MarkdownDocumentView({
               currentDocumentPath={file.path}
               onOpenBeadId={onOpenBeadId}
               onOpenWorkspacePath={(targetPath, basePath) => onOpenWorkspacePath?.(targetPath, basePath ?? file.path)}
+              pathLinkAliases={pathLinkAliases}
               workspaceAgentId={workspaceAgentId}
             />
           )}

--- a/src/features/file-browser/TabbedContentArea.test.tsx
+++ b/src/features/file-browser/TabbedContentArea.test.tsx
@@ -11,6 +11,7 @@ vi.mock('./MarkdownDocumentView', () => ({
     file: OpenFile;
     onOpenBeadId?: (target: { beadId: string }) => void;
     onOpenWorkspacePath?: (path: string, basePath?: string) => void;
+    pathLinkAliases?: Record<string, string>;
     workspaceAgentId?: string;
   }) => {
     markdownDocumentViewSpy(props);
@@ -32,6 +33,7 @@ vi.mock('@/features/beads', () => ({
     onOpenBeadId?: (target: { beadId: string }) => void;
     onOpenWorkspacePath?: (path: string, basePath?: string) => void;
     pathLinkPrefixes?: string[];
+    pathLinkAliases?: Record<string, string>;
   }) => {
     beadViewerTabSpy(props);
     return <div data-testid="bead-viewer-tab">{props.beadTarget.beadId}</div>;
@@ -67,6 +69,7 @@ describe('TabbedContentArea', () => {
         onRetryFile={vi.fn()}
         onOpenWorkspacePath={onOpenWorkspacePath}
         onOpenBeadId={onOpenBeadId}
+        pathLinkAliases={{ 'docs/': '/workspace/docs/' }}
         chatPanel={<div>chat</div>}
       />,
     );
@@ -76,6 +79,7 @@ describe('TabbedContentArea', () => {
     expect(props.file.path).toBe('docs/guide.md');
     expect(props.onOpenBeadId).toBe(onOpenBeadId);
     expect(props.onOpenWorkspacePath).toBe(onOpenWorkspacePath);
+    expect(props.pathLinkAliases).toEqual({ 'docs/': '/workspace/docs/' });
     expect(props.workspaceAgentId).toBe('agent-1');
   });
 
@@ -97,6 +101,7 @@ describe('TabbedContentArea', () => {
         onOpenWorkspacePath={onOpenWorkspacePath}
         onOpenBeadId={onOpenBeadId}
         pathLinkPrefixes={['/workspace/', '~/workspace/']}
+        pathLinkAliases={{ 'docs/': '/workspace/docs/' }}
         chatPanel={<div>chat</div>}
       />,
     );
@@ -112,5 +117,6 @@ describe('TabbedContentArea', () => {
     expect(props.onOpenBeadId).toBe(onOpenBeadId);
     expect(props.onOpenWorkspacePath).toBe(onOpenWorkspacePath);
     expect(props.pathLinkPrefixes).toEqual(['/workspace/', '~/workspace/']);
+    expect(props.pathLinkAliases).toEqual({ 'docs/': '/workspace/docs/' });
   });
 });

--- a/src/features/file-browser/TabbedContentArea.tsx
+++ b/src/features/file-browser/TabbedContentArea.tsx
@@ -48,6 +48,7 @@ interface TabbedContentAreaProps {
   onOpenWorkspacePath?: (path: string, basePath?: string) => void | Promise<void>;
   onOpenBeadId?: (target: BeadLinkTarget) => void;
   pathLinkPrefixes?: string[];
+  pathLinkAliases?: Record<string, string>;
   saveToast?: SaveToast | null;
   onDismissToast?: () => void;
   /** The chat panel rendered as-is (never unmounted). */
@@ -68,6 +69,7 @@ export function TabbedContentArea({
   onOpenWorkspacePath,
   onOpenBeadId,
   pathLinkPrefixes,
+  pathLinkAliases,
   saveToast,
   onDismissToast,
   chatPanel,
@@ -123,6 +125,7 @@ export function TabbedContentArea({
                 onRetry={onRetryFile}
                 onOpenWorkspacePath={onOpenWorkspacePath}
                 onOpenBeadId={onOpenBeadId}
+                pathLinkAliases={pathLinkAliases}
                 workspaceAgentId={workspaceAgentId}
               />
             ) : (
@@ -157,6 +160,7 @@ export function TabbedContentArea({
               onOpenBeadId={onOpenBeadId}
               onOpenWorkspacePath={onOpenWorkspacePath}
               pathLinkPrefixes={pathLinkPrefixes}
+              pathLinkAliases={pathLinkAliases}
             />
           </div>
         ))}

--- a/src/features/markdown/MarkdownRenderer.test.tsx
+++ b/src/features/markdown/MarkdownRenderer.test.tsx
@@ -83,6 +83,98 @@ describe('MarkdownRenderer', () => {
     expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/src/App.tsx', undefined);
   });
 
+  it('rewrites configured shorthand aliases to canonical workspace targets exactly once', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="Open projects/openclaw-nerve/src/App.tsx now"
+        onOpenWorkspacePath={onOpenWorkspacePath}
+        pathLinkPrefixes={['/workspace/', '/home/derrick/.openclaw/workspace/']}
+        pathLinkAliases={{ 'projects/': '/workspace/projects/' }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'projects/openclaw-nerve/src/App.tsx' }));
+    expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/projects/openclaw-nerve/src/App.tsx', undefined);
+  });
+
+  it('linkifies alias-only configs by normalizing rewritten targets to canonical workspace paths', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="Open projects/openclaw-nerve/src/App.tsx now"
+        onOpenWorkspacePath={onOpenWorkspacePath}
+        pathLinkPrefixes={[]}
+        pathLinkAliases={{ 'projects/': '/workspace/projects/' }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'projects/openclaw-nerve/src/App.tsx' }));
+    expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/projects/openclaw-nerve/src/App.tsx', undefined);
+  });
+
+  it('supports alias-only configs that rewrite file workspace urls to canonical workspace paths', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="Open shortcut/openclaw-nerve/src/App.tsx now"
+        onOpenWorkspacePath={onOpenWorkspacePath}
+        pathLinkPrefixes={[]}
+        pathLinkAliases={{ 'shortcut/': 'file:///workspace/projects/' }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'shortcut/openclaw-nerve/src/App.tsx' }));
+    expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/projects/openclaw-nerve/src/App.tsx', undefined);
+  });
+
+  it('supports wrapped alias shorthand without widening interior-token matching', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="Open 'projects/openclaw-nerve/README.md' and path=projects/nope.md now"
+        onOpenWorkspacePath={onOpenWorkspacePath}
+        pathLinkPrefixes={['/workspace/']}
+        pathLinkAliases={{ 'projects/': '/workspace/projects/' }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: "'projects/openclaw-nerve/README.md'" }));
+    expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/projects/openclaw-nerve/README.md', undefined);
+    expect(screen.queryByRole('link', { name: 'projects/nope.md' })).toBeNull();
+  });
+
+  it('prefers the longest matching alias prefix when aliases overlap', () => {
+    const onOpenWorkspacePath = vi.fn();
+    render(
+      <MarkdownRenderer
+        content="Open projects/openclaw-nerve/src/App.tsx now"
+        onOpenWorkspacePath={onOpenWorkspacePath}
+        pathLinkPrefixes={['/workspace/']}
+        pathLinkAliases={{
+          'projects/': '/workspace/projects-generic/',
+          'projects/openclaw-nerve/': '/workspace/projects/openclaw-nerve/',
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'projects/openclaw-nerve/src/App.tsx' }));
+    expect(onOpenWorkspacePath).toHaveBeenCalledWith('/workspace/projects/openclaw-nerve/src/App.tsx', undefined);
+  });
+
+  it('does not recurse through alias-to-alias chains', () => {
+    render(
+      <MarkdownRenderer
+        content="Open shortcut/demo.md now"
+        onOpenWorkspacePath={vi.fn()}
+        pathLinkPrefixes={['/workspace/']}
+        pathLinkAliases={{ 'shortcut/': 'projects/', 'projects/': '/workspace/projects/' }}
+      />,
+    );
+
+    expect(screen.queryByRole('link', { name: 'shortcut/demo.md' })).toBeNull();
+  });
+
   it('does not linkify /workspace paths when they only appear as an interior token slice', () => {
     render(
       <MarkdownRenderer

--- a/src/features/markdown/MarkdownRenderer.tsx
+++ b/src/features/markdown/MarkdownRenderer.tsx
@@ -16,6 +16,7 @@ interface MarkdownRendererProps {
   currentDocumentPath?: string;
   onOpenWorkspacePath?: (path: string, basePath?: string) => void | Promise<void>;
   pathLinkPrefixes?: string[];
+  pathLinkAliases?: Record<string, string>;
   onOpenBeadId?: (target: BeadLinkTarget) => void | Promise<void>;
   workspaceAgentId?: string;
 }
@@ -65,12 +66,14 @@ function InlineCodeContent({
   codeString,
   children,
   pathLinkPrefixes,
+  pathLinkAliases,
   currentDocumentPath,
   onOpenWorkspacePath,
 }: {
   codeString: string;
   children?: React.ReactNode;
   pathLinkPrefixes?: string[];
+  pathLinkAliases?: Record<string, string>;
   currentDocumentPath?: string;
   onOpenWorkspacePath?: (path: string, basePath?: string) => void | Promise<void>;
 }) {
@@ -82,6 +85,7 @@ function InlineCodeContent({
 
   return renderInlinePathReferences(codeString, {
     prefixes: pathLinkPrefixes,
+    aliases: pathLinkAliases,
     onOpenPath: onOpenWorkspacePath
       ? (path: string) => onOpenWorkspacePath(path, currentDocumentPath)
       : undefined,
@@ -161,16 +165,18 @@ function processChildren(
   options: {
     searchQuery?: string;
     pathLinkPrefixes?: string[];
+    pathLinkAliases?: Record<string, string>;
     onOpenWorkspacePath?: (path: string) => void | Promise<void>;
   } = {},
 ): React.ReactNode {
-  const { searchQuery, pathLinkPrefixes, onOpenWorkspacePath } = options;
+  const { searchQuery, pathLinkPrefixes, pathLinkAliases, onOpenWorkspacePath } = options;
   const renderPlainText = (text: string) => highlightText(text, searchQuery ?? '');
 
   return React.Children.map(children, (child) => {
     if (typeof child === 'string') {
       return renderInlinePathReferences(child, {
         prefixes: pathLinkPrefixes,
+        aliases: pathLinkAliases,
         onOpenPath: onOpenWorkspacePath,
         renderPlainText,
       });
@@ -288,6 +294,7 @@ export function MarkdownRenderer({
   currentDocumentPath,
   onOpenWorkspacePath,
   pathLinkPrefixes,
+  pathLinkAliases,
   onOpenBeadId,
   workspaceAgentId,
 }: MarkdownRendererProps) {
@@ -296,10 +303,11 @@ export function MarkdownRenderer({
   const childOptions = useMemo(() => ({
     searchQuery,
     pathLinkPrefixes,
+    pathLinkAliases,
     onOpenWorkspacePath: onOpenWorkspacePath
       ? (path: string) => onOpenWorkspacePath(path, currentDocumentPath)
       : undefined,
-  }), [searchQuery, pathLinkPrefixes, onOpenWorkspacePath, currentDocumentPath]);
+  }), [searchQuery, pathLinkPrefixes, pathLinkAliases, onOpenWorkspacePath, currentDocumentPath]);
 
   const scrollToAnchorId = useCallback((anchorId: string, behavior: ScrollBehavior = 'smooth') => {
     const root = containerRef.current;
@@ -405,6 +413,7 @@ export function MarkdownRenderer({
             <InlineCodeContent
               codeString={codeString}
               pathLinkPrefixes={pathLinkPrefixes}
+              pathLinkAliases={pathLinkAliases}
               currentDocumentPath={currentDocumentPath}
               onOpenWorkspacePath={onOpenWorkspacePath}
             >
@@ -520,6 +529,7 @@ export function MarkdownRenderer({
     onOpenBeadId,
     onOpenWorkspacePath,
     pathLinkPrefixes,
+    pathLinkAliases,
     scrollToAnchor,
     suppressImages,
     updateLocationHash,

--- a/src/features/markdown/inlineReferences.tsx
+++ b/src/features/markdown/inlineReferences.tsx
@@ -32,19 +32,36 @@ function decodeWorkspaceCandidate(value: string): string {
   }
 }
 
-function normalizeWorkspaceCandidate(candidate: string, prefixes: string[]): string | null {
-  if (candidate.startsWith(FILE_WORKSPACE_PREFIX)) {
-    const normalized = decodeWorkspaceCandidate(candidate.slice('file://'.length));
+function rewriteAliasPrefix(candidate: string, aliases: Record<string, string>): string {
+  const matchingAlias = Object.entries(aliases)
+    .filter(([aliasPrefix, targetPrefix]) => aliasPrefix && targetPrefix && candidate.startsWith(aliasPrefix))
+    .sort(([leftAlias], [rightAlias]) => rightAlias.length - leftAlias.length)[0];
+
+  if (!matchingAlias) return candidate;
+
+  const [aliasPrefix, targetPrefix] = matchingAlias;
+  return `${targetPrefix}${candidate.slice(aliasPrefix.length)}`;
+}
+
+function normalizeWorkspaceCandidate(
+  candidate: string,
+  prefixes: string[],
+  aliases: Record<string, string> = {},
+): string | null {
+  const rewrittenCandidate = rewriteAliasPrefix(candidate, aliases);
+
+  if (rewrittenCandidate.startsWith(FILE_WORKSPACE_PREFIX)) {
+    const normalized = decodeWorkspaceCandidate(rewrittenCandidate.slice('file://'.length));
     return normalized.length > CANONICAL_WORKSPACE_PREFIX.length ? normalized : null;
   }
 
-  if (candidate.startsWith(CANONICAL_WORKSPACE_PREFIX)) {
-    const normalized = decodeWorkspaceCandidate(candidate);
+  if (rewrittenCandidate.startsWith(CANONICAL_WORKSPACE_PREFIX)) {
+    const normalized = decodeWorkspaceCandidate(rewrittenCandidate);
     return normalized.length > CANONICAL_WORKSPACE_PREFIX.length ? normalized : null;
   }
 
-  if (candidate.startsWith(BARE_WORKSPACE_PREFIX)) {
-    const suffix = candidate.slice(BARE_WORKSPACE_PREFIX.length);
+  if (rewrittenCandidate.startsWith(BARE_WORKSPACE_PREFIX)) {
+    const suffix = rewrittenCandidate.slice(BARE_WORKSPACE_PREFIX.length);
     if (!suffix) return null;
 
     return decodeWorkspaceCandidate(`${CANONICAL_WORKSPACE_PREFIX}${suffix}`);
@@ -52,9 +69,9 @@ function normalizeWorkspaceCandidate(candidate: string, prefixes: string[]): str
 
   for (const prefix of prefixes) {
     if (!prefix || prefix === CANONICAL_WORKSPACE_PREFIX) continue;
-    if (!candidate.startsWith(prefix)) continue;
+    if (!rewrittenCandidate.startsWith(prefix)) continue;
 
-    const suffix = candidate.slice(prefix.length);
+    const suffix = rewrittenCandidate.slice(prefix.length);
     if (!suffix) return null;
 
     return decodeWorkspaceCandidate(`${CANONICAL_WORKSPACE_PREFIX}${suffix.replace(/^\/+/, '')}`);
@@ -66,12 +83,13 @@ function normalizeWorkspaceCandidate(candidate: string, prefixes: string[]): str
 function extractWrappedPathSlice(
   core: string,
   prefixes: string[],
+  aliases: Record<string, string>,
 ): { display: string; candidate: string } | null {
   for (const { opener, closer } of WRAPPER_PAIRS) {
     if (!core.startsWith(opener) || !core.endsWith(closer)) continue;
 
     const inner = core.slice(opener.length, core.length - closer.length);
-    const candidate = normalizeWorkspaceCandidate(inner, prefixes);
+    const candidate = normalizeWorkspaceCandidate(inner, prefixes, aliases);
     if (!candidate) return null;
 
     return {
@@ -86,6 +104,7 @@ function extractWrappedPathSlice(
 function findConfiguredPathSlice(
   token: string,
   prefixes: string[],
+  aliases: Record<string, string>,
 ): { before: string; display: string; candidate: string; after: string } | null {
   if (!token) return null;
   if (token.startsWith('//')) return null;
@@ -93,12 +112,12 @@ function findConfiguredPathSlice(
   const { core, trailing } = stripTrailingPunctuation(token);
   if (!core) return null;
 
-  const plainCandidate = normalizeWorkspaceCandidate(core, prefixes);
+  const plainCandidate = normalizeWorkspaceCandidate(core, prefixes, aliases);
   if (plainCandidate) {
     return { before: '', display: core, candidate: plainCandidate, after: trailing };
   }
 
-  const wrapped = extractWrappedPathSlice(core, prefixes);
+  const wrapped = extractWrappedPathSlice(core, prefixes, aliases);
   if (wrapped) {
     return {
       before: '',
@@ -117,12 +136,13 @@ export function renderInlinePathReferences(
   text: string,
   options: {
     prefixes?: string[];
+    aliases?: Record<string, string>;
     onOpenPath?: (path: string) => void | Promise<void>;
     renderPlainText?: (text: string) => React.ReactNode;
   } = {},
 ): React.ReactNode {
-  const { prefixes = [], onOpenPath, renderPlainText = (value: string) => value } = options;
-  if (!text || prefixes.length === 0 || !onOpenPath) {
+  const { prefixes = [], aliases = {}, onOpenPath, renderPlainText = (value: string) => value } = options;
+  if (!text || !onOpenPath || (prefixes.length === 0 && Object.keys(aliases).length === 0)) {
     return renderPlainText(text);
   }
 
@@ -135,7 +155,7 @@ export function renderInlinePathReferences(
       return <React.Fragment key={`ws-${index}-${token}`}>{renderPlainText(token)}</React.Fragment>;
     }
 
-    const pathSlice = findConfiguredPathSlice(token, prefixes);
+    const pathSlice = findConfiguredPathSlice(token, prefixes, aliases);
     if (!pathSlice) {
       return <React.Fragment key={`txt-${index}-${token}`}>{renderPlainText(token)}</React.Fragment>;
     }


### PR DESCRIPTION
## Summary

This replaces #270 with the same alias-mapping feature rebased onto current `master`.

`CHAT_PATH_LINKS.json` can now declare shorthand aliases like:

- `projects/...` → `/workspace/projects/...`

The replacement keeps the original feature, but resolves the stale-branch conflicts safely and preserves the newer seeded `CHAT_PATH_LINKS.json` create flow added after the original branch diverged.

## What changed

- rebased the alias-mapping feature onto current `master`
- preserved the current `ConfigTab` seeded template flow from #267 instead of regressing it
- added alias-aware normalization/parsing for `CHAT_PATH_LINKS.json`
- threaded alias support through chat, markdown, document preview, and bead viewer rendering paths
- updated the shared server-side `chat-path-links-config` helper so browser/server template behavior stays in sync

## Why this replaces #270

The original PR branch is heavily stale and conflicts with newer workspace/chat changes. More importantly, resolving it naively would regress `CHAT_PATH_LINKS.json` creation back to:

```json
{ "prefixes": ["/workspace/"], "aliases": {} }
```

which drops the seeded local prefixes added on current `master`.

This replacement keeps the intended alias feature without reintroducing that regression.

Closes #269.
Supersedes #270.

## Test Plan

- [x] `npm test -- --run src/features/chat/chatPathLinks.test.ts src/features/chat/chatPathLinksConfig.test.ts src/features/markdown/MarkdownRenderer.test.tsx src/features/workspace/tabs/ConfigTab.test.tsx src/features/file-browser/TabbedContentArea.test.tsx server/routes/workspace.test.ts`
- [x] `npm run build`
- [x] Prior isolated preview smoke confirmed alias config like `{"aliases":{"docs/":"/workspace/"}}` makes `docs/AGENTS.md` clickable while preserving built-in `workspace/...` behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configurable path link aliases — shorthand mappings are normalized and applied across chat, markdown rendering, and file views for consistent link resolution.

* **Tests**
  * Added and updated tests to validate alias normalization, parsing, serialization, precedence, and integration with existing path-link behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->