### PR TITLE
refine mobile command palette entry point

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -318,13 +318,19 @@ vi.mock('@/components/ConfirmDialog', () => ({
 }));
 
 vi.mock('@/features/chat/ChatPanel', () => ({
-  ChatPanel: forwardRef((_props: { onOpenBeadId?: (target: { beadId: string; workspaceAgentId?: string }) => void }, ref) => {
+  ChatPanel: forwardRef((props: {
+    onOpenBeadId?: (target: { beadId: string; workspaceAgentId?: string }) => void;
+    showCommandPaletteButton?: boolean;
+    onOpenCommandPalette?: () => void;
+  }, ref) => {
     useImperativeHandle(ref, () => ({
       focusInput: vi.fn(),
       addWorkspacePath: addWorkspacePathSpy,
     }));
 
-    return null;
+    return props.showCommandPaletteButton
+      ? <button type="button" data-testid="compact-command-trigger" aria-label="Open command palette" onClick={() => props.onOpenCommandPalette?.()}>Open Commands From Composer</button>
+      : null;
   }),
 }));
 
@@ -887,7 +893,7 @@ describe('App kanban visibility gating', () => {
     expect(screen.queryByRole('button', { name: 'Open Commands From TopBar' })).not.toBeInTheDocument();
   });
 
-  it('shows a mobile-only commands FAB above the composer in compact layout', () => {
+  it('shows a compact commands trigger inside the composer in compact layout', () => {
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
       value: vi.fn().mockImplementation((query: string) => ({
@@ -906,10 +912,9 @@ describe('App kanban visibility gating', () => {
 
     expect(screen.getByTestId('command-palette-state')).toHaveTextContent('closed');
 
-    const floatingButton = screen.getAllByRole('button', { name: /open command palette/i }).at(-1)!;
-    expect(floatingButton.className).toContain('bottom-40');
+    const compactButton = screen.getByTestId('compact-command-trigger');
 
-    fireEvent.click(floatingButton);
+    fireEvent.click(compactButton);
 
     expect(screen.getByTestId('command-palette-state')).toHaveTextContent('open');
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ import {
   lazy,
   Suspense,
 } from 'react';
-import { AlertTriangle, CheckCircle2, Command, RotateCw } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, RotateCw } from 'lucide-react';
 import { useGateway } from '@/contexts/GatewayContext';
 import { useSessionContext, type SpawnSessionOpts } from '@/contexts/SessionContext';
 import { useChat } from '@/contexts/ChatContext';
@@ -819,6 +819,8 @@ export default function App({ onLogout }: AppProps) {
             pathLinkPrefixes={chatPathLinkPrefixes}
             pathLinkAliases={chatPathLinkAliases}
             onOpenBeadId={openBeadId}
+            showCommandPaletteButton={isCompactLayout && floatingCommandPaletteButtonVisible && !paletteOpen && !settingsOpen && viewMode === 'chat'}
+            onOpenCommandPalette={handleOpenPalette}
           />
         </PanelErrorBoundary>
       }
@@ -990,19 +992,6 @@ export default function App({ onLogout }: AppProps) {
         />
       )}
 
-      {isCompactLayout && floatingCommandPaletteButtonVisible && !paletteOpen && !settingsOpen && viewMode === 'chat' && (
-        <button
-          type="button"
-          onClick={handleOpenPalette}
-          title="Open command palette"
-          aria-label="Open command palette"
-          className="fixed bottom-40 right-3 z-40 inline-flex items-center gap-2 rounded-2xl border border-primary/25 bg-card/94 px-4 py-3 text-sm font-medium text-foreground shadow-[0_20px_48px_rgba(0,0,0,0.28)] backdrop-blur-xl transition-transform hover:-translate-y-px"
-        >
-          <Command size={16} aria-hidden="true" />
-          <span>Commands</span>
-        </button>
-      )}
-      
       <PanelErrorBoundary name="Settings">
         <Suspense fallback={null}>
           <SettingsDrawer

--- a/src/features/chat/ChatPanel.tsx
+++ b/src/features/chat/ChatPanel.tsx
@@ -50,6 +50,10 @@ interface ChatPanelProps {
   pathLinkAliases?: Record<string, string>;
   /** Open a dedicated bead viewer tab. */
   onOpenBeadId?: (target: BeadLinkTarget) => void | Promise<void>;
+  /** Whether to show the compact Commands launcher inside the composer. */
+  showCommandPaletteButton?: boolean;
+  /** Open the command palette from the compact composer launcher. */
+  onOpenCommandPalette?: () => void;
 }
 
 export interface ChatPanelHandle {
@@ -70,6 +74,8 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
   pathLinkPrefixes,
   pathLinkAliases,
   onOpenBeadId,
+  showCommandPaletteButton = false,
+  onOpenCommandPalette,
 }, ref) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const messageRefs = useRef<Map<number, HTMLDivElement>>(new Map());
@@ -393,6 +399,8 @@ export const ChatPanel = forwardRef<ChatPanelHandle, ChatPanelProps>(function Ch
         isGenerating={isGenerating}
         onWakeWordState={onWakeWordState}
         agentName={agentName}
+        showCommandPaletteButton={showCommandPaletteButton}
+        onOpenCommandPalette={onOpenCommandPalette}
       />
 
     </div>

--- a/src/features/chat/InputBar.tsx
+++ b/src/features/chat/InputBar.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect, useState, useCallback, useImperativeHandle, forwardRef, useMemo } from 'react';
-import { Mic, Paperclip, X, Loader2, ArrowUp, FileText, FolderOpen } from 'lucide-react';
+import { Mic, Paperclip, X, Loader2, ArrowUp, FileText, FolderOpen, Command } from 'lucide-react';
 import type { TreeEntry } from '@/features/file-browser';
 import { useVoiceInput } from '@/features/voice/useVoiceInput';
 import { useTabCompletion } from '@/hooks/useTabCompletion';
@@ -40,6 +40,10 @@ interface InputBarProps {
   onWakeWordState?: (enabled: boolean, toggle: () => void) => void;
   /** Agent name for dynamic wake phrase (e.g., "Hey Helena") */
   agentName?: string;
+  /** Whether to show the compact command-palette launcher inside the composer. */
+  showCommandPaletteButton?: boolean;
+  /** Open the command palette from the compact composer launcher. */
+  onOpenCommandPalette?: () => void;
 }
 
 export interface InputBarHandle {
@@ -261,7 +265,14 @@ async function resolveWorkspacePathToCanonicalReference(
 }
 
 /** Chat input bar with file attachments, voice input, and model effort selector. */
-export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function InputBar({ onSend, isGenerating, onWakeWordState, agentName = 'Agent' }, ref) {
+export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function InputBar({
+  onSend,
+  isGenerating,
+  onWakeWordState,
+  agentName = 'Agent',
+  showCommandPaletteButton = false,
+  onOpenCommandPalette,
+}, ref) {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const deferredResizeFrameRef = useRef<number | null>(null);
@@ -1269,6 +1280,17 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
           rows={1}
           className="flex-1 font-mono text-[13px] bg-transparent text-foreground border-none px-2.5 py-3 resize-none outline-none min-h-[42px] max-h-[160px]"
         />
+        {showCommandPaletteButton && onOpenCommandPalette && (
+          <button
+            type="button"
+            onClick={onOpenCommandPalette}
+            className="bg-transparent border-none text-muted-foreground hover:text-primary cursor-pointer px-2.5 self-stretch h-full flex items-center justify-center"
+            title="Open command palette"
+            aria-label="Open command palette"
+          >
+            <Command size={16} aria-hidden="true" />
+          </button>
+        )}
         <button
           type="button"
           onClick={openUploadFilesPicker}

--- a/src/features/settings/AppearanceSettings.tsx
+++ b/src/features/settings/AppearanceSettings.tsx
@@ -230,13 +230,13 @@ export function AppearanceSettings() {
         />
       </div>
 
-      {/* Floating command palette visibility */}
+      {/* Compact command palette visibility */}
       <div className="cockpit-row items-start justify-between">
         <div className="flex items-center gap-3">
           <Command size={14} className={floatingCommandPaletteButtonVisible ? 'text-primary' : 'text-muted-foreground'} aria-hidden="true" />
           <div className="flex flex-col">
-            <span className="text-sm font-medium text-foreground" id="floating-commands-label">Show floating Commands button</span>
-            <span className="text-xs text-muted-foreground">Keep the compact-layout floating Commands launcher visible above the composer.</span>
+            <span className="text-sm font-medium text-foreground" id="floating-commands-label">Show compact Commands button</span>
+            <span className="text-xs text-muted-foreground">Keep the compact-layout Commands launcher anchored inside the composer.</span>
           </div>
         </div>
         <Switch


### PR DESCRIPTION
## Summary
- move the compact/mobile Commands launcher out of the chat stream and into the composer
- keep the existing desktop top-bar Commands button behavior unchanged
- update the Appearance copy to describe the compact composer-anchored launcher

## Test Plan
- [x] npm run lint -- src/App.tsx src/App.test.tsx src/features/chat/ChatPanel.tsx src/features/chat/InputBar.tsx src/features/settings/AppearanceSettings.tsx
- [x] npm test -- --run src/App.test.tsx src/components/TopBar.test.tsx
- [x] npm run build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Repositioned Commands button in compact layout from floating above the composer to being integrated inside the composer input area
* Updated settings UI labels and descriptions to accurately reflect the button's new placement position

<!-- end of auto-generated comment: release notes by coderabbit.ai -->