### PR TITLE
refine(ui): make the chatbox Commands button the only launcher

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -34,8 +34,7 @@ const {
 } = vi.hoisted(() => {
   const settingsContext = {
     kanbanVisible: true,
-    topBarCommandPaletteButtonVisible: true,
-    floatingCommandPaletteButtonVisible: true,
+    commandPaletteButtonVisible: true,
   };
   const uploadConfigState = {
     fileReferenceEnabled: true,
@@ -187,8 +186,7 @@ vi.mock('@/contexts/SettingsContext', () => ({
     setTheme: vi.fn(),
     setFont: vi.fn(),
     kanbanVisible: settingsContext.kanbanVisible,
-    topBarCommandPaletteButtonVisible: settingsContext.topBarCommandPaletteButtonVisible,
-    floatingCommandPaletteButtonVisible: settingsContext.floatingCommandPaletteButtonVisible,
+    commandPaletteButtonVisible: settingsContext.commandPaletteButtonVisible,
   }),
 }));
 
@@ -288,22 +286,15 @@ vi.mock('@/components/TopBar', () => ({
   TopBar: ({
     showKanbanView,
     viewMode,
-    onOpenCommandPalette,
-    showCommandPaletteButton = true,
   }: {
     showKanbanView?: boolean;
     viewMode?: string;
-    onOpenCommandPalette?: () => void;
-    showCommandPaletteButton?: boolean;
   }) => {
-    topBarRenderSnapshots.push({ showKanbanView, viewMode, showCommandPaletteButton } as { showKanbanView?: boolean; viewMode?: string; showCommandPaletteButton?: boolean });
+    topBarRenderSnapshots.push({ showKanbanView, viewMode } as { showKanbanView?: boolean; viewMode?: string });
     return (
       <div>
         <div data-testid="topbar-show-kanban">{String(showKanbanView ?? true)}</div>
         <div data-testid="topbar-view-mode">{viewMode ?? 'chat'}</div>
-        {showCommandPaletteButton && (
-          <button type="button" onClick={() => onOpenCommandPalette?.()}>Open Commands From TopBar</button>
-        )}
       </div>
     );
   },
@@ -329,7 +320,7 @@ vi.mock('@/features/chat/ChatPanel', () => ({
     }));
 
     return props.showCommandPaletteButton
-      ? <button type="button" data-testid="compact-command-trigger" aria-label="Open command palette" onClick={() => props.onOpenCommandPalette?.()}>Open Commands From Composer</button>
+      ? <button type="button" data-testid="chatbox-command-trigger" aria-label="Open command palette" onClick={() => props.onOpenCommandPalette?.()}>Open Commands From Composer</button>
       : null;
   }),
 }));
@@ -852,8 +843,7 @@ describe('App kanban visibility gating', () => {
   beforeEach(() => {
     localStorage.clear();
     settingsContext.kanbanVisible = true;
-    settingsContext.topBarCommandPaletteButtonVisible = true;
-    settingsContext.floatingCommandPaletteButtonVisible = true;
+    settingsContext.commandPaletteButtonVisible = true;
     topBarRenderSnapshots.length = 0;
   });
 
@@ -875,25 +865,17 @@ describe('App kanban visibility gating', () => {
     expect(screen.getByTestId('topbar-view-mode')).toHaveTextContent('chat');
   });
 
-  it('passes the top-bar command palette trigger through App state', () => {
+  it('opens the command palette from the chatbox trigger in desktop layout', () => {
     render(<App />);
 
     expect(screen.getByTestId('command-palette-state')).toHaveTextContent('closed');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Open Commands From TopBar' }));
+    fireEvent.click(screen.getByTestId('chatbox-command-trigger'));
 
     expect(screen.getByTestId('command-palette-state')).toHaveTextContent('open');
   });
 
-  it('hides the top-bar command palette trigger when the appearance toggle is disabled', () => {
-    settingsContext.topBarCommandPaletteButtonVisible = false;
-
-    render(<App />);
-
-    expect(screen.queryByRole('button', { name: 'Open Commands From TopBar' })).not.toBeInTheDocument();
-  });
-
-  it('shows a compact commands trigger inside the composer in compact layout', () => {
+  it('shows the chatbox command trigger in compact layout too', () => {
     Object.defineProperty(window, 'matchMedia', {
       writable: true,
       value: vi.fn().mockImplementation((query: string) => ({
@@ -912,32 +894,17 @@ describe('App kanban visibility gating', () => {
 
     expect(screen.getByTestId('command-palette-state')).toHaveTextContent('closed');
 
-    const compactButton = screen.getByTestId('compact-command-trigger');
-
-    fireEvent.click(compactButton);
+    fireEvent.click(screen.getByTestId('chatbox-command-trigger'));
 
     expect(screen.getByTestId('command-palette-state')).toHaveTextContent('open');
   });
 
-  it('hides the mobile commands FAB when the appearance toggle is disabled', () => {
-    settingsContext.floatingCommandPaletteButtonVisible = false;
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: vi.fn().mockImplementation((query: string) => ({
-        matches: query === '(max-width: 900px)',
-        media: query,
-        onchange: null,
-        addEventListener: vi.fn(),
-        removeEventListener: vi.fn(),
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-        dispatchEvent: vi.fn(),
-      })),
-    });
+  it('hides the chatbox command trigger when the appearance toggle is disabled', () => {
+    settingsContext.commandPaletteButtonVisible = false;
 
     render(<App />);
 
-    expect(screen.getByRole('button', { name: 'Open Commands From TopBar' })).toBeInTheDocument();
+    expect(screen.queryByTestId('chatbox-command-trigger')).not.toBeInTheDocument();
     expect(screen.queryAllByRole('button', { name: /open command palette/i })).toHaveLength(0);
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -125,8 +125,7 @@ export default function App({ onLogout }: AppProps) {
     toggleEvents, toggleLog, toggleTelemetry,
     setTheme, setFont,
     kanbanVisible,
-    topBarCommandPaletteButtonVisible,
-    floatingCommandPaletteButtonVisible,
+    commandPaletteButtonVisible,
   } = useSettings();
 
   // Connection management (extracted hook)
@@ -819,7 +818,7 @@ export default function App({ onLogout }: AppProps) {
             pathLinkPrefixes={chatPathLinkPrefixes}
             pathLinkAliases={chatPathLinkAliases}
             onOpenBeadId={openBeadId}
-            showCommandPaletteButton={isCompactLayout && floatingCommandPaletteButtonVisible && !paletteOpen && !settingsOpen && viewMode === 'chat'}
+            showCommandPaletteButton={commandPaletteButtonVisible && !paletteOpen && !settingsOpen && viewMode === 'chat'}
             onOpenCommandPalette={handleOpenPalette}
           />
         </PanelErrorBoundary>
@@ -974,7 +973,6 @@ export default function App({ onLogout }: AppProps) {
       
       {(!isCompactLayout || !isMobileTopBarHidden) && (
         <TopBar
-          onOpenCommandPalette={handleOpenPalette}
           onSettings={openSettings}
           agentLogEntries={agentLogEntries}
           tokenData={tokenData}
@@ -988,7 +986,6 @@ export default function App({ onLogout }: AppProps) {
           viewMode={viewMode}
           onViewModeChange={setViewMode}
           showKanbanView={kanbanVisible}
-          showCommandPaletteButton={topBarCommandPaletteButtonVisible}
         />
       )}
 

--- a/src/components/TopBar.test.tsx
+++ b/src/components/TopBar.test.tsx
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { TopBar } from './TopBar';
 
@@ -11,7 +10,6 @@ vi.mock('./NerveLogo', () => ({
 function renderTopBar(props: Partial<React.ComponentProps<typeof TopBar>> = {}) {
   return render(
     <TopBar
-      onOpenCommandPalette={vi.fn()}
       onSettings={vi.fn()}
       agentLogEntries={[]}
       tokenData={null}
@@ -40,20 +38,8 @@ describe('TopBar', () => {
     expect(screen.getByRole('button', { name: /switch to chat view/i })).toBeInTheDocument();
   });
 
-  it('opens the command palette from the visible Commands trigger', async () => {
-    const user = userEvent.setup();
-    const onOpenCommandPalette = vi.fn();
-
-    renderTopBar({ onOpenCommandPalette });
-
-    await user.click(screen.getByRole('button', { name: /open command palette/i }));
-
-    expect(onOpenCommandPalette).toHaveBeenCalledTimes(1);
-    expect(screen.getByRole('button', { name: /open command palette/i })).toHaveTextContent(/commands/i);
-  });
-
-  it('hides the Commands trigger when explicitly disabled', () => {
-    renderTopBar({ onOpenCommandPalette: vi.fn(), showCommandPaletteButton: false });
+  it('does not render a top-bar Commands trigger', () => {
+    renderTopBar();
 
     expect(screen.queryByRole('button', { name: /open command palette/i })).not.toBeInTheDocument();
   });

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -11,7 +11,6 @@ import {
 import {
   Activity,
   BarChart3,
-  Command,
   Settings,
   Radio,
   Users,
@@ -85,8 +84,6 @@ const PANEL_CONFIG: Record<Exclude<PanelId, null> | "default", PanelConfig> = {
 
 /** Props for {@link TopBar}. */
 interface TopBarProps {
-  /** Callback to open the command palette. */
-  onOpenCommandPalette: () => void;
   /** Callback to open the settings modal. */
   onSettings: () => void;
   /** Agent log entries rendered in the dropdown log panel. */
@@ -113,8 +110,6 @@ interface TopBarProps {
   onViewModeChange?: (mode: ViewMode) => void;
   /** Whether the Tasks/Kanban view toggle should be shown. */
   showKanbanView?: boolean;
-  /** Whether the top-bar Commands button should be shown. */
-  showCommandPaletteButton?: boolean;
 }
 
 /**
@@ -125,7 +120,6 @@ interface TopBarProps {
  * Workspace panels.
  */
 export function TopBar({
-  onOpenCommandPalette,
   onSettings,
   agentLogEntries,
   tokenData,
@@ -139,7 +133,6 @@ export function TopBar({
   viewMode = "chat",
   onViewModeChange,
   showKanbanView = true,
-  showCommandPaletteButton = true,
 }: TopBarProps) {
   const [activePanel, setActivePanel] = useState<PanelId>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -364,19 +357,6 @@ export function TopBar({
                   {eventEntries.length}
                 </span>
               )}
-            </button>
-          )}
-
-          {showCommandPaletteButton && (
-            <button
-              type="button"
-              onClick={onOpenCommandPalette}
-              title="Open command palette"
-              aria-label="Open command palette"
-              className={buttonBase}
-            >
-              <Command size={14} aria-hidden="true" />
-              <span className="hidden sm:inline">Commands</span>
             </button>
           )}
 

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -38,10 +38,8 @@ interface SettingsContextValue {
   toggleLog: () => void;
   showHiddenWorkspaceEntries: boolean;
   toggleShowHiddenWorkspaceEntries: () => void;
-  topBarCommandPaletteButtonVisible: boolean;
-  toggleTopBarCommandPaletteButtonVisible: () => void;
-  floatingCommandPaletteButtonVisible: boolean;
-  toggleFloatingCommandPaletteButtonVisible: () => void;
+  commandPaletteButtonVisible: boolean;
+  toggleCommandPaletteButtonVisible: () => void;
   theme: ThemeName;
   setTheme: (theme: ThemeName) => void;
   font: FontName;
@@ -57,6 +55,9 @@ interface SettingsContextValue {
 const SettingsContext = createContext<SettingsContextValue | null>(null);
 const FONT_REFRESH_STORAGE_KEY = 'nerve:font-refresh-20260312';
 const KANBAN_VISIBILITY_STORAGE_KEY = 'nerve:workspace:kanban-visible';
+const COMMAND_PALETTE_BUTTON_STORAGE_KEY = 'nerve:showChatboxCommandPaletteButton';
+const LEGACY_TOPBAR_COMMAND_PALETTE_BUTTON_STORAGE_KEY = 'nerve:showTopBarCommandPaletteButton';
+const LEGACY_COMPACT_COMMAND_PALETTE_BUTTON_STORAGE_KEY = 'nerve:showFloatingCommandPaletteButton';
 
 const ALLOWED_FONT_SIZES = new Set([10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 22, 24]);
 const ALLOWED_EDITOR_FONT_SIZES = new Set([10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 22, 24]);
@@ -67,6 +68,19 @@ function normalizeFontSize(size: number): number {
 
 function normalizeEditorFontSize(size: number): number {
   return Number.isFinite(size) && ALLOWED_EDITOR_FONT_SIZES.has(size) ? size : 13;
+}
+
+function resolveInitialCommandPaletteButtonVisible(): boolean {
+  const saved = localStorage.getItem(COMMAND_PALETTE_BUTTON_STORAGE_KEY);
+  if (saved !== null) return saved !== 'false';
+
+  const legacyCompactSaved = localStorage.getItem(LEGACY_COMPACT_COMMAND_PALETTE_BUTTON_STORAGE_KEY);
+  if (legacyCompactSaved !== null) return legacyCompactSaved !== 'false';
+
+  const legacyTopbarSaved = localStorage.getItem(LEGACY_TOPBAR_COMMAND_PALETTE_BUTTON_STORAGE_KEY);
+  if (legacyTopbarSaved !== null) return legacyTopbarSaved !== 'false';
+
+  return true;
 }
 
 function resolveInitialFont(): FontName {
@@ -130,14 +144,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [showHiddenWorkspaceEntries, setShowHiddenWorkspaceEntries] = useState(() => {
     return localStorage.getItem('nerve:showHiddenWorkspaceEntries') === 'true';
   });
-  const [topBarCommandPaletteButtonVisible, setTopBarCommandPaletteButtonVisible] = useState(() => {
-    const saved = localStorage.getItem('nerve:showTopBarCommandPaletteButton');
-    return saved !== 'false';
-  });
-  const [floatingCommandPaletteButtonVisible, setFloatingCommandPaletteButtonVisible] = useState(() => {
-    const saved = localStorage.getItem('nerve:showFloatingCommandPaletteButton');
-    return saved !== 'false';
-  });
+  const [commandPaletteButtonVisible, setCommandPaletteButtonVisible] = useState(resolveInitialCommandPaletteButtonVisible);
   const [theme, setThemeState] = useState<ThemeName>(() => {
     const saved = localStorage.getItem('oc-theme') as ThemeName | null;
     return saved && themeNames.includes(saved) ? saved : 'ayu-dark';
@@ -320,18 +327,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
-  const toggleTopBarCommandPaletteButtonVisible = useCallback(() => {
-    setTopBarCommandPaletteButtonVisible(prev => {
+  const toggleCommandPaletteButtonVisible = useCallback(() => {
+    setCommandPaletteButtonVisible(prev => {
       const next = !prev;
-      localStorage.setItem('nerve:showTopBarCommandPaletteButton', String(next));
-      return next;
-    });
-  }, []);
-
-  const toggleFloatingCommandPaletteButtonVisible = useCallback(() => {
-    setFloatingCommandPaletteButtonVisible(prev => {
-      const next = !prev;
-      localStorage.setItem('nerve:showFloatingCommandPaletteButton', String(next));
+      localStorage.setItem(COMMAND_PALETTE_BUTTON_STORAGE_KEY, String(next));
       return next;
     });
   }, []);
@@ -397,10 +396,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     toggleLog,
     showHiddenWorkspaceEntries,
     toggleShowHiddenWorkspaceEntries,
-    topBarCommandPaletteButtonVisible,
-    toggleTopBarCommandPaletteButtonVisible,
-    floatingCommandPaletteButtonVisible,
-    toggleFloatingCommandPaletteButtonVisible,
+    commandPaletteButtonVisible,
+    toggleCommandPaletteButtonVisible,
     theme,
     setTheme,
     font,
@@ -418,8 +415,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     liveTranscriptionPreview, toggleLiveTranscriptionPreview,
     speak, panelRatio, setPanelRatio, telemetryVisible, toggleTelemetry,
     eventsVisible, toggleEvents, logVisible, toggleLog, showHiddenWorkspaceEntries, toggleShowHiddenWorkspaceEntries,
-    topBarCommandPaletteButtonVisible, toggleTopBarCommandPaletteButtonVisible,
-    floatingCommandPaletteButtonVisible, toggleFloatingCommandPaletteButtonVisible,
+    commandPaletteButtonVisible, toggleCommandPaletteButtonVisible,
     theme, setTheme, font, setFont,
     fontSize, setFontSize, editorFontSize, setEditorFontSize, kanbanVisible, toggleKanbanVisible,
   ]);

--- a/src/features/settings/AppearanceSettings.tsx
+++ b/src/features/settings/AppearanceSettings.tsx
@@ -49,10 +49,8 @@ export function AppearanceSettings() {
     toggleLog,
     showHiddenWorkspaceEntries,
     toggleShowHiddenWorkspaceEntries,
-    topBarCommandPaletteButtonVisible,
-    toggleTopBarCommandPaletteButtonVisible,
-    floatingCommandPaletteButtonVisible,
-    toggleFloatingCommandPaletteButtonVisible,
+    commandPaletteButtonVisible,
+    toggleCommandPaletteButtonVisible,
     kanbanVisible,
     toggleKanbanVisible,
     theme,
@@ -214,35 +212,19 @@ export function AppearanceSettings() {
         />
       </div>
 
-      {/* Top bar command palette visibility */}
+      {/* Chatbox command palette visibility */}
       <div className="cockpit-row items-start justify-between">
         <div className="flex items-center gap-3">
-          <Command size={14} className={topBarCommandPaletteButtonVisible ? 'text-primary' : 'text-muted-foreground'} aria-hidden="true" />
+          <Command size={14} className={commandPaletteButtonVisible ? 'text-primary' : 'text-muted-foreground'} aria-hidden="true" />
           <div className="flex flex-col">
-            <span className="text-sm font-medium text-foreground" id="topbar-commands-label">Show top bar Commands button</span>
-            <span className="text-xs text-muted-foreground">Keep the Commands launcher visible in the top chrome.</span>
+            <span className="text-sm font-medium text-foreground" id="chatbox-commands-label">Show chatbox Commands button</span>
+            <span className="text-xs text-muted-foreground">Keep the Commands launcher visible in the chat composer.</span>
           </div>
         </div>
         <Switch
-          checked={topBarCommandPaletteButtonVisible}
-          onCheckedChange={toggleTopBarCommandPaletteButtonVisible}
-          aria-labelledby="topbar-commands-label"
-        />
-      </div>
-
-      {/* Compact command palette visibility */}
-      <div className="cockpit-row items-start justify-between">
-        <div className="flex items-center gap-3">
-          <Command size={14} className={floatingCommandPaletteButtonVisible ? 'text-primary' : 'text-muted-foreground'} aria-hidden="true" />
-          <div className="flex flex-col">
-            <span className="text-sm font-medium text-foreground" id="floating-commands-label">Show compact Commands button</span>
-            <span className="text-xs text-muted-foreground">Keep the compact-layout Commands launcher anchored inside the composer.</span>
-          </div>
-        </div>
-        <Switch
-          checked={floatingCommandPaletteButtonVisible}
-          onCheckedChange={toggleFloatingCommandPaletteButtonVisible}
-          aria-labelledby="floating-commands-label"
+          checked={commandPaletteButtonVisible}
+          onCheckedChange={toggleCommandPaletteButtonVisible}
+          aria-labelledby="chatbox-commands-label"
         />
       </div>
 


### PR DESCRIPTION
## Summary

This follows the earlier command-palette polish and finishes the intended UX: Commands now lives in the chatbox/composer instead of the top bar.

Changes:
- remove the topbar Commands trigger entirely
- keep the Commands launcher in the chatbox/composer as the only entry point
- replace the separate topbar + compact/mobile appearance toggles with a single `Show chatbox Commands button` setting
- preserve existing user preference state by falling back from the legacy compact/topbar localStorage keys

## Why

PR #292 moved the floating mobile Commands pill into the composer, but the topbar trigger still remained. That left the app in a mixed state, especially on mobile.

This patch makes the UI consistent with the intended behavior: if Commands should live in the chatbox, it should live there only.

## Testing

- `npm run lint -- src/App.tsx src/App.test.tsx src/components/TopBar.tsx src/components/TopBar.test.tsx src/contexts/SettingsContext.tsx src/features/settings/AppearanceSettings.tsx`
- `npm test -- --run src/App.test.tsx src/components/TopBar.test.tsx`
- `npm run build`

Manual smoke:
- verified there is no topbar Commands button
- verified the composer launcher is present and opens the command palette


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated command palette visibility settings by merging separate top bar and compact layout options into a single unified setting. Removed the command palette button from the top bar. Updated the settings interface to reflect this simplification while automatically migrating previous preferences to the new consolidated setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->