### PR TITLE
tweak(ui): surface command palette shortcut in composer hint

### DIFF
--- a/src/features/chat/InputBar.test.tsx
+++ b/src/features/chat/InputBar.test.tsx
@@ -259,6 +259,13 @@ describe('InputBar', () => {
     });
   });
 
+  it('shows the command palette shortcut in the composer helper copy', () => {
+    render(<InputBar onSend={vi.fn()} isGenerating={false} />);
+
+    expect(screen.getByText(/⌘K command palette/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Ctrl\+F search/i)).not.toBeInTheDocument();
+  });
+
   it('uses the paperclip as the single primary attachment affordance', async () => {
     render(<InputBar onSend={vi.fn()} isGenerating={false} />);
 

--- a/src/features/chat/InputBar.tsx
+++ b/src/features/chat/InputBar.tsx
@@ -1317,7 +1317,7 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
             ? 'Recording… Left Shift to send · Double Left Shift to discard'
             : voiceState === 'transcribing'
             ? 'Transcribing…'
-            : 'Enter or ⌘Enter to send · Shift+Enter for newline · Double Left Shift for voice · Ctrl+F search'}
+            : 'Enter or ⌘Enter to send · Shift+Enter for newline · Double Left Shift for voice · ⌘K command palette'}
         </span>
       </div>
       {voiceError && (


### PR DESCRIPTION
## Summary

This updates the helper text under the chatbox input to make the command palette discoverable.

Changes:
- replace `Ctrl+F search` with `⌘K command palette` in the composer hint
- keep the helper copy aligned with the current UI, where the command palette is launched from the chatbox/composer
- add regression coverage in `src/features/chat/InputBar.test.tsx`

## Why

`Ctrl+F` is already a familiar shortcut and doesn't need extra help text here.

The command palette, on the other hand, no longer has a topbar launcher, so it benefits from an explicit hint in the composer.

## Testing

- `npm test -- --run src/features/chat/InputBar.test.tsx`
- `npm run build`

Manual smoke:
- verified the updated hint in a live branch deploy on port 3080


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Updated keyboard shortcut hint in the input area from "Ctrl+F search" to "⌘K command palette"

* **Tests**
  * Added test coverage to verify the updated shortcut text

<!-- end of auto-generated comment: release notes by coderabbit.ai -->