### PR TITLE
feat(update): show copy-paste update command

### DIFF
--- a/server/routes/version-check.test.ts
+++ b/server/routes/version-check.test.ts
@@ -1,0 +1,51 @@
+/** Tests for the GET /api/version/check endpoint. */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Hono } from 'hono';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const TEST_REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+describe('GET /api/version/check', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function buildApp() {
+    vi.doMock('../middleware/rate-limit.js', () => ({
+      rateLimitGeneral: vi.fn((_c: unknown, next: () => Promise<void>) => next()),
+    }));
+
+    vi.doMock('../lib/release-source.js', () => ({
+      compareSemver: vi.fn(() => 1),
+      resolveLatestVersion: vi.fn(async () => ({ version: '9.9.9', source: 'release' })),
+    }));
+
+    const mod = await import('./version-check.js');
+    const app = new Hono();
+    app.route('/', mod.default);
+    return app;
+  }
+
+  it('returns the resolved project directory for copy-paste update commands', async () => {
+    const app = await buildApp();
+    const res = await app.request('/api/version/check');
+
+    expect(res.status).toBe(200);
+
+    const json = await res.json() as {
+      current: string;
+      latest: string;
+      updateAvailable: boolean;
+      projectDir: string;
+    };
+
+    expect(json.latest).toBe('9.9.9');
+    expect(json.updateAvailable).toBe(true);
+    expect(json.projectDir).toBe(TEST_REPO_ROOT);
+  });
+});

--- a/server/routes/version-check.ts
+++ b/server/routes/version-check.ts
@@ -24,12 +24,12 @@ interface VersionCache {
 
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 let cache: VersionCache | null = null;
+const projectDir = resolve(__dirname, '../..');
 
 const app = new Hono();
 
 app.get('/api/version/check', rateLimitGeneral, async (c) => {
   const now = Date.now();
-  const cwd = resolve(__dirname, '../..');
 
   // Serve from cache if fresh.
   if (cache && now - cache.checkedAt < CACHE_TTL_MS) {
@@ -38,10 +38,11 @@ app.get('/api/version/check', rateLimitGeneral, async (c) => {
       latest: cache.latest,
       source: cache.source,
       updateAvailable: compareSemver(cache.latest, pkg.version) > 0,
+      projectDir,
     });
   }
 
-  const latest = await resolveLatestVersion(cwd);
+  const latest = await resolveLatestVersion(projectDir);
   if (!latest) {
     return c.json({
       current: pkg.version,
@@ -49,6 +50,7 @@ app.get('/api/version/check', rateLimitGeneral, async (c) => {
       source: null,
       updateAvailable: false,
       error: 'Could not fetch release or semver tags',
+      projectDir,
     });
   }
 
@@ -63,6 +65,7 @@ app.get('/api/version/check', rateLimitGeneral, async (c) => {
     latest: latest.version,
     source: latest.source,
     updateAvailable: compareSemver(latest.version, pkg.version) > 0,
+    projectDir,
   });
 });
 

--- a/src/components/UpdateBadge.test.tsx
+++ b/src/components/UpdateBadge.test.tsx
@@ -1,0 +1,41 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UpdateBadge } from './UpdateBadge';
+
+describe('UpdateBadge', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({
+        current: '1.5.2',
+        latest: '1.5.3',
+        updateAvailable: true,
+        projectDir: '/tmp/nerve repo',
+      }),
+    })) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('shows a copy-paste update command with the project directory', async () => {
+    const user = userEvent.setup();
+    render(<UpdateBadge />);
+
+    await user.click(await screen.findByRole('button', { name: /update available: version 1.5.3/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Project directory')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('/tmp/nerve repo')).toBeInTheDocument();
+    expect(screen.getByText("cd '/tmp/nerve repo' && npm run update -- --yes")).toBeInTheDocument();
+    expect(screen.getByText(/cd '\/tmp\/nerve repo' && npm run update -- --dry-run/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/UpdateBadge.test.tsx
+++ b/src/components/UpdateBadge.test.tsx
@@ -4,19 +4,25 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { UpdateBadge } from './UpdateBadge';
 
+function createMockResponse(payload: unknown, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
 describe('UpdateBadge', () => {
   const originalFetch = global.fetch;
 
   beforeEach(() => {
-    global.fetch = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({
-        current: '1.5.2',
-        latest: '1.5.3',
-        updateAvailable: true,
-        projectDir: '/tmp/nerve repo',
-      }),
-    })) as typeof fetch;
+    global.fetch = vi.fn<typeof fetch>(async () => createMockResponse({
+      current: '1.5.2',
+      latest: '1.5.3',
+      updateAvailable: true,
+      projectDir: '/tmp/nerve repo',
+    }));
   });
 
   afterEach(() => {
@@ -37,5 +43,22 @@ describe('UpdateBadge', () => {
     expect(screen.getByText('/tmp/nerve repo')).toBeInTheDocument();
     expect(screen.getByText("cd '/tmp/nerve repo' && npm run update -- --yes")).toBeInTheDocument();
     expect(screen.getByText(/cd '\/tmp\/nerve repo' && npm run update -- --dry-run/i)).toBeInTheDocument();
+  });
+
+  it('does not render when the server omits the project directory', async () => {
+    global.fetch = vi.fn<typeof fetch>(async () => createMockResponse({
+      current: '1.5.2',
+      latest: '1.5.3',
+      updateAvailable: true,
+      projectDir: '',
+    }));
+
+    render(<UpdateBadge />);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.queryByRole('button', { name: /update available: version 1.5.3/i })).not.toBeInTheDocument();
   });
 });

--- a/src/components/UpdateBadge.tsx
+++ b/src/components/UpdateBadge.tsx
@@ -12,9 +12,14 @@ interface VersionCheck {
   current: string;
   latest: string | null;
   updateAvailable: boolean;
+  projectDir: string;
 }
 
 const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
 
 /**
  * Shows an update badge next to the version in the status bar
@@ -44,6 +49,12 @@ export function UpdateBadge() {
 
   if (!versionInfo?.updateAvailable || !versionInfo.latest) return null;
 
+  const quotedProjectDir = shellQuote(versionInfo.projectDir);
+  const updateCommand = `cd ${quotedProjectDir} && npm run update -- --yes`;
+  const dryRunCommand = `cd ${quotedProjectDir} && npm run update -- --dry-run`;
+  const pinVersionCommand = `cd ${quotedProjectDir} && npm run update -- --version v${versionInfo.latest} --yes`;
+  const docsCommand = `cd ${quotedProjectDir} && cat docs/UPDATING.md`;
+
   return (
     <>
       <button
@@ -67,11 +78,17 @@ export function UpdateBadge() {
           </DialogHeader>
           <div className="space-y-4 pt-2">
             <div>
+              <p className="text-xs text-muted-foreground mb-1">Project directory</p>
+              <pre className="bg-secondary rounded-md px-3 py-2 text-xs font-mono text-muted-foreground select-all whitespace-pre-wrap break-all">
+                {versionInfo.projectDir}
+              </pre>
+            </div>
+            <div>
               <p className="text-sm text-muted-foreground mb-2">
-                Run this from the Nerve project directory:
+                Copy and paste this into your OpenClaw session or terminal:
               </p>
-              <pre className="bg-secondary rounded-md px-3 py-2 text-sm font-mono select-all">
-                npm run update -- --yes
+              <pre className="bg-secondary rounded-md px-3 py-2 text-sm font-mono select-all whitespace-pre-wrap break-all">
+                {updateCommand}
               </pre>
             </div>
             <div className="text-xs text-muted-foreground space-y-1">
@@ -82,13 +99,13 @@ export function UpdateBadge() {
               <p className="text-xs text-muted-foreground mb-1">Other options:</p>
               <pre className="bg-secondary rounded-md px-3 py-2 text-xs font-mono text-muted-foreground whitespace-pre-wrap">
 {`# Preview first
-npm run update -- --dry-run
+${dryRunCommand}
 
 # Pin to a specific version
-npm run update -- --version v${versionInfo.latest} --yes
+${pinVersionCommand}
 
 # See full docs
-cat docs/UPDATING.md`}
+${docsCommand}`}
               </pre>
             </div>
           </div>

--- a/src/components/UpdateBadge.tsx
+++ b/src/components/UpdateBadge.tsx
@@ -12,7 +12,7 @@ interface VersionCheck {
   current: string;
   latest: string | null;
   updateAvailable: boolean;
-  projectDir: string;
+  projectDir?: string | null;
 }
 
 const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
@@ -47,7 +47,7 @@ export function UpdateBadge() {
     return () => { ac.abort(); clearInterval(iv); };
   }, []);
 
-  if (!versionInfo?.updateAvailable || !versionInfo.latest) return null;
+  if (!versionInfo?.updateAvailable || !versionInfo.latest || !versionInfo.projectDir) return null;
 
   const quotedProjectDir = shellQuote(versionInfo.projectDir);
   const updateCommand = `cd ${quotedProjectDir} && npm run update -- --yes`;


### PR DESCRIPTION
## Summary
- return the resolved Nerve project directory from `/api/version/check`
- show that path in the update modal
- replace bare update snippets with copy-paste commands like `cd '<path>' && npm run update -- --yes`

## Testing
- `npm test -- --run src/components/UpdateBadge.test.tsx server/routes/version-check.test.ts`
- `npm run build`

Closes #208


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version check UI now shows the resolved project directory in a copyable code block.
  * Update commands include a safe change-directory step and offer dry-run and version-pinning variants.
  * Modal instructions updated to guide copying commands into your terminal/session.

* **Tests**
  * Added end-to-end tests covering the version-check endpoint and the update badge UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->