### PR TITLE
refine(ui): align the composer prompt glyph

### DIFF
--- a/src/features/chat/InputBar.test.tsx
+++ b/src/features/chat/InputBar.test.tsx
@@ -266,12 +266,6 @@ describe('InputBar', () => {
     expect(screen.queryByText(/Ctrl\+F search/i)).not.toBeInTheDocument();
   });
 
-  it('keeps the prompt glyph aligned to the first line of the composer', () => {
-    render(<InputBar onSend={vi.fn()} isGenerating={false} />);
-
-    expect(screen.getByText('›')).toHaveClass('self-start', 'pt-3', 'leading-none');
-  });
-
   it('uses the paperclip as the single primary attachment affordance', async () => {
     render(<InputBar onSend={vi.fn()} isGenerating={false} />);
 

--- a/src/features/chat/InputBar.test.tsx
+++ b/src/features/chat/InputBar.test.tsx
@@ -266,6 +266,12 @@ describe('InputBar', () => {
     expect(screen.queryByText(/Ctrl\+F search/i)).not.toBeInTheDocument();
   });
 
+  it('keeps the prompt glyph aligned to the first line of the composer', () => {
+    render(<InputBar onSend={vi.fn()} isGenerating={false} />);
+
+    expect(screen.getByText('›')).toHaveClass('self-start', 'pt-3', 'leading-none');
+  });
+
   it('uses the paperclip as the single primary attachment affordance', async () => {
     render(<InputBar onSend={vi.fn()} isGenerating={false} />);
 

--- a/src/features/chat/InputBar.tsx
+++ b/src/features/chat/InputBar.tsx
@@ -1248,23 +1248,23 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
       />
       {/* Input row */}
       <div
-        className={`flex items-center gap-0 border-t shrink-0 bg-card focus-within:border-t-primary/40 focus-within:shadow-[0_-1px_8px_rgba(232,168,56,0.1)] ${voiceState === 'recording' ? 'border-t-red-500 shadow-[0_-1px_12px_rgba(239,68,68,0.3)]' : 'border-border'}`}
+        className={`flex items-start gap-0 border-t shrink-0 bg-card focus-within:border-t-primary/40 focus-within:shadow-[0_-1px_8px_rgba(232,168,56,0.1)] ${voiceState === 'recording' ? 'border-t-red-500 shadow-[0_-1px_12px_rgba(239,68,68,0.3)]' : 'border-border'}`}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
       >
         {voiceState === 'recording' ? (
-          <span className="pl-3.5 shrink-0 flex items-center gap-1.5">
+          <span className="self-start pl-3.5 pt-3 shrink-0 flex items-center gap-1.5">
             <span className="w-2 h-2 rounded-full bg-red-500 animate-pulse" />
             <Mic size={14} className="text-red-500" />
           </span>
         ) : voiceState === 'transcribing' ? (
-          <span className="pl-3.5 shrink-0 flex items-center gap-1.5">
+          <span className="self-start pl-3.5 pt-3 shrink-0 flex items-center gap-1.5">
             <span className="w-2 h-2 rounded-full bg-primary animate-pulse" />
             <Mic size={14} className="text-primary" />
           </span>
         ) : (
-          <span className="text-primary text-base font-bold pl-3.5 shrink-0 animate-prompt-pulse">›</span>
+          <span className="self-start text-primary text-base leading-none font-bold pl-3.5 pt-3 shrink-0 animate-prompt-pulse">›</span>
         )}
         {/* Uncontrolled textarea — value is read/written via inputRef.
             This is intentional: useTabCompletion and history navigation


### PR DESCRIPTION
## Summary
- align the composer prompt glyph with the first line of the textarea instead of vertically centering it against the whole growing input
- keep the recording/transcribing adornments aligned the same way for consistency

## Testing
- npm test -- --run src/features/chat/InputBar.test.tsx
- npm run lint -- src/features/chat/InputBar.tsx src/features/chat/InputBar.test.tsx
- npm run build

Fixes #165


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the vertical alignment of voice status indicators in the chat input bar for improved visual positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->