### PR TITLE
fix(sessions): keep orphaned agent sessions visible

### DIFF
--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -585,6 +585,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
             existing.thinkingLevel !== newSession.thinkingLevel ||
             existing.label !== newSession.label ||
             existing.displayName !== newSession.displayName ||
+            existing.parentSessionKey !== newSession.parentSessionKey ||
             existing.parentId !== newSession.parentId
           );
           

--- a/src/features/sessions/SessionList.test.tsx
+++ b/src/features/sessions/SessionList.test.tsx
@@ -34,6 +34,20 @@ describe('SessionList empty state', () => {
     expect(screen.getByText('No active sessions')).toBeInTheDocument();
   });
 
+  it('shows orphaned agent descendants instead of the empty state when cleanup removed the root row', () => {
+    const sessions: Session[] = [
+      { sessionKey: 'agent:main:telegram:direct:123', displayName: 'Telegram DM' },
+      { sessionKey: 'agent:reviewer:subagent:abc123', label: 'Worker' },
+      { sessionKey: 'discord:sean', label: 'Discord Root' },
+    ];
+
+    renderSessionList({ sessions });
+
+    expect(screen.getByText('Telegram DM')).toBeInTheDocument();
+    expect(screen.getByText('Worker')).toBeInTheDocument();
+    expect(screen.queryByText('No active sessions')).not.toBeInTheDocument();
+  });
+
   it('shows the loading skeleton when loading and all sessions are filtered out', () => {
     const sessions: Session[] = [
       { sessionKey: 'discord:sean', label: 'Discord Root' },

--- a/src/features/sessions/sessionKeys.test.ts
+++ b/src/features/sessions/sessionKeys.test.ts
@@ -121,4 +121,10 @@ describe('sessionKeys', () => {
     const child = session('agent:reviewer:subagent:child', { parentId: 'agent:missing:main' });
     expect(resolveParentSessionKey(child, knownKeys)).toBe('agent:reviewer:main');
   });
+
+  it('uses parentSessionKey when the gateway provides it', () => {
+    const knownKeys = new Set(['agent:main:main', 'custom-direct-key']);
+    const child = session('custom-direct-key', { parentSessionKey: 'agent:main:main' });
+    expect(resolveParentSessionKey(child, knownKeys)).toBe('agent:main:main');
+  });
 });

--- a/src/features/sessions/sessionKeys.test.ts
+++ b/src/features/sessions/sessionKeys.test.ts
@@ -127,4 +127,13 @@ describe('sessionKeys', () => {
     const child = session('custom-direct-key', { parentSessionKey: 'agent:main:main' });
     expect(resolveParentSessionKey(child, knownKeys)).toBe('agent:main:main');
   });
+
+  it('falls back to parentId when parentSessionKey is stale', () => {
+    const knownKeys = new Set(['agent:main:main', 'custom-direct-key']);
+    const child = session('custom-direct-key', {
+      parentSessionKey: 'stale-parent-key',
+      parentId: ' agent:main:main ',
+    });
+    expect(resolveParentSessionKey(child, knownKeys)).toBe('agent:main:main');
+  });
 });

--- a/src/features/sessions/sessionKeys.ts
+++ b/src/features/sessions/sessionKeys.ts
@@ -88,17 +88,27 @@ export function inferParentSessionKey(sessionKey: string): string | null {
   return null;
 }
 
+export function getExplicitParentCandidates(session: Session | undefined): string[] {
+  const candidates: string[] = [];
+
+  const parentSessionKey = typeof session?.parentSessionKey === 'string'
+    ? session.parentSessionKey.trim()
+    : '';
+  if (parentSessionKey) candidates.push(parentSessionKey);
+
+  const parentId = typeof session?.parentId === 'string'
+    ? session.parentId.trim()
+    : '';
+  if (parentId && parentId !== parentSessionKey) candidates.push(parentId);
+
+  return candidates;
+}
+
 export function resolveParentSessionKey(session: Session, knownKeys?: Set<string>): string | null {
   const sessionKey = getSessionKey(session);
   if (!sessionKey) return null;
 
-  const explicitParent = typeof session.parentSessionKey === 'string' && session.parentSessionKey.trim()
-    ? session.parentSessionKey
-    : typeof session.parentId === 'string' && session.parentId.trim()
-      ? session.parentId
-      : null;
-
-  if (explicitParent) {
+  for (const explicitParent of getExplicitParentCandidates(session)) {
     if (!knownKeys || knownKeys.has(explicitParent)) return explicitParent;
   }
 

--- a/src/features/sessions/sessionKeys.ts
+++ b/src/features/sessions/sessionKeys.ts
@@ -92,8 +92,14 @@ export function resolveParentSessionKey(session: Session, knownKeys?: Set<string
   const sessionKey = getSessionKey(session);
   if (!sessionKey) return null;
 
-  if (session.parentId) {
-    if (!knownKeys || knownKeys.has(session.parentId)) return session.parentId;
+  const explicitParent = typeof session.parentSessionKey === 'string' && session.parentSessionKey.trim()
+    ? session.parentSessionKey
+    : typeof session.parentId === 'string' && session.parentId.trim()
+      ? session.parentId
+      : null;
+
+  if (explicitParent) {
+    if (!knownKeys || knownKeys.has(explicitParent)) return explicitParent;
   }
 
   const inferred = inferParentSessionKey(sessionKey);

--- a/src/features/sessions/sessionTree.test.ts
+++ b/src/features/sessions/sessionTree.test.ts
@@ -256,6 +256,28 @@ describe('buildAgentSidebarTree', () => {
     ]);
   });
 
+  it('falls back to parentId when parentSessionKey is stale and still keeps the orphan chain visible', () => {
+    const sessions = [
+      session('custom-cron-key', {
+        parentSessionKey: 'stale-parent-key',
+        parentId: ' agent:main:main ',
+        label: 'Explicit Cron',
+      }),
+      session('custom-cron-run-key', {
+        parentSessionKey: 'custom-cron-key',
+        label: 'Explicit Run',
+      }),
+      session('discord:sean', { label: 'Discord Root' }),
+    ];
+
+    const tree = buildAgentSidebarTree(sessions);
+    const flat = flattenTree(tree, {});
+    expect(flat.map((node) => node.key)).toEqual([
+      'custom-cron-key',
+      'custom-cron-run-key',
+    ]);
+  });
+
   it('nests direct and channel delivery sessions under their agent root', () => {
     const sessions = [
       session('agent:reviewer:main', { label: 'Reviewer' }),

--- a/src/features/sessions/sessionTree.test.ts
+++ b/src/features/sessions/sessionTree.test.ts
@@ -177,17 +177,34 @@ describe('buildAgentSidebarTree', () => {
     ]);
   });
 
-  it('hides orphan descendants whose lineage does not resolve to a real agent root', () => {
+  it('hides orphan chains that have no agent root affinity at all', () => {
     const sessions = [
-      session('agent:main:subagent:orphan'),
-      session('agent:main:cron:nightly:run:run123'),
-      session('agent:main:cron:nightly'),
+      session('custom-orphan-root', { label: 'Orphan Root' }),
+      session('custom-orphan-child', {
+        parentSessionKey: 'custom-orphan-root',
+        label: 'Orphan Child',
+      }),
       session('discord:sean'),
     ];
 
     const tree = buildAgentSidebarTree(sessions);
     const flat = flattenTree(tree, {});
     expect(flat.map((node) => node.key)).toEqual([]);
+  });
+
+  it('surfaces orphan descendants with inferable agent roots when cleanup removed the root row', () => {
+    const sessions = [
+      session('agent:main:telegram:direct:123', { displayName: 'Telegram DM' }),
+      session('agent:reviewer:subagent:abc123', { label: 'Worker' }),
+      session('discord:sean', { label: 'Discord Root' }),
+    ];
+
+    const tree = buildAgentSidebarTree(sessions);
+    const flat = flattenTree(tree, {});
+    expect(flat.map((node) => node.key)).toEqual([
+      'agent:main:telegram:direct:123',
+      'agent:reviewer:subagent:abc123',
+    ]);
   });
 
   it('supports explicit parentId chains while still filtering out unrelated roots', () => {
@@ -213,6 +230,27 @@ describe('buildAgentSidebarTree', () => {
     expect(flat.map((node) => node.key)).toEqual([
       'agent:main:main',
       'custom-subagent-key',
+      'custom-cron-key',
+      'custom-cron-run-key',
+    ]);
+  });
+
+  it('supports explicit parentSessionKey chains even when cleanup removed the agent root row', () => {
+    const sessions = [
+      session('custom-cron-key', {
+        parentSessionKey: 'agent:main:main',
+        label: 'Explicit Cron',
+      }),
+      session('custom-cron-run-key', {
+        parentSessionKey: 'custom-cron-key',
+        label: 'Explicit Run',
+      }),
+      session('discord:sean', { label: 'Discord Root' }),
+    ];
+
+    const tree = buildAgentSidebarTree(sessions);
+    const flat = flattenTree(tree, {});
+    expect(flat.map((node) => node.key)).toEqual([
       'custom-cron-key',
       'custom-cron-run-key',
     ]);

--- a/src/features/sessions/sessionTree.ts
+++ b/src/features/sessions/sessionTree.ts
@@ -1,6 +1,6 @@
 import type { Session } from '@/types';
 import { getSessionKey } from '@/types';
-import { getRootAgentSessionKey, getSessionType, isTopLevelAgentSessionKey, resolveParentSessionKey } from './sessionKeys';
+import { getExplicitParentCandidates, getRootAgentSessionKey, getSessionType, isTopLevelAgentSessionKey, resolveParentSessionKey } from './sessionKeys';
 
 export interface TreeNode {
   session: Session;
@@ -49,22 +49,9 @@ function hasAgentSidebarEligibleLineage(
   const parentKey = parentMap.get(sessionKey) ?? null;
   const session = sessionMap.get(sessionKey);
   const result = parentKey === null
-    ? (() => {
-        if (isAgentSidebarRootSessionKey(sessionKey)) return true;
-
-        const explicitParent = typeof session?.parentSessionKey === 'string' && session.parentSessionKey.trim()
-          ? session.parentSessionKey
-          : typeof session?.parentId === 'string' && session.parentId.trim()
-            ? session.parentId
-            : null;
-
-        if (explicitParent) {
-          if (isAgentSidebarRootSessionKey(explicitParent)) return true;
-          if (getRootAgentSessionKey(explicitParent)) return true;
-        }
-
-        return getRootAgentSessionKey(sessionKey) !== null;
-      })()
+    ? isAgentSidebarRootSessionKey(sessionKey)
+      || getExplicitParentCandidates(session).some((explicitParent) => getRootAgentSessionKey(explicitParent) !== null)
+      || getRootAgentSessionKey(sessionKey) !== null
     : parentMap.has(parentKey) && hasAgentSidebarEligibleLineage(parentKey, parentMap, sessionMap, memo, visiting);
 
   visiting.delete(sessionKey);

--- a/src/features/sessions/sessionTree.ts
+++ b/src/features/sessions/sessionTree.ts
@@ -1,6 +1,6 @@
 import type { Session } from '@/types';
 import { getSessionKey } from '@/types';
-import { getSessionType, isTopLevelAgentSessionKey, resolveParentSessionKey } from './sessionKeys';
+import { getRootAgentSessionKey, getSessionType, isTopLevelAgentSessionKey, resolveParentSessionKey } from './sessionKeys';
 
 export interface TreeNode {
   session: Session;
@@ -37,6 +37,7 @@ function buildParentMap(sessions: Session[]): Map<string, string | null> {
 function hasAgentSidebarEligibleLineage(
   sessionKey: string,
   parentMap: Map<string, string | null>,
+  sessionMap: Map<string, Session>,
   memo: Map<string, boolean>,
   visiting = new Set<string>(),
 ): boolean {
@@ -46,9 +47,25 @@ function hasAgentSidebarEligibleLineage(
   visiting.add(sessionKey);
 
   const parentKey = parentMap.get(sessionKey) ?? null;
+  const session = sessionMap.get(sessionKey);
   const result = parentKey === null
-    ? isAgentSidebarRootSessionKey(sessionKey)
-    : parentMap.has(parentKey) && hasAgentSidebarEligibleLineage(parentKey, parentMap, memo, visiting);
+    ? (() => {
+        if (isAgentSidebarRootSessionKey(sessionKey)) return true;
+
+        const explicitParent = typeof session?.parentSessionKey === 'string' && session.parentSessionKey.trim()
+          ? session.parentSessionKey
+          : typeof session?.parentId === 'string' && session.parentId.trim()
+            ? session.parentId
+            : null;
+
+        if (explicitParent) {
+          if (isAgentSidebarRootSessionKey(explicitParent)) return true;
+          if (getRootAgentSessionKey(explicitParent)) return true;
+        }
+
+        return getRootAgentSessionKey(sessionKey) !== null;
+      })()
+    : parentMap.has(parentKey) && hasAgentSidebarEligibleLineage(parentKey, parentMap, sessionMap, memo, visiting);
 
   visiting.delete(sessionKey);
   memo.set(sessionKey, result);
@@ -59,8 +76,9 @@ function filterAgentSidebarSessions(
   sessions: Session[],
   parentMap: Map<string, string | null>,
 ): Session[] {
+  const sessionMap = new Map(sessions.map((session) => [getSessionKey(session), session]));
   const memo = new Map<string, boolean>();
-  return sessions.filter((session) => hasAgentSidebarEligibleLineage(getSessionKey(session), parentMap, memo));
+  return sessions.filter((session) => hasAgentSidebarEligibleLineage(getSessionKey(session), parentMap, sessionMap, memo));
 }
 
 function buildTreeNodes(
@@ -137,7 +155,7 @@ function buildTreeNodes(
  * Build a hierarchical tree from a flat list of sessions.
  *
  * Dual strategy:
- * 1. If sessions have `parentId` (gateway v2026.2.9+), use that.
+ * 1. If sessions have `parentSessionKey`/`parentId`, use that.
  * 2. Fallback: parse session key structure to infer parent-child relationships.
  *
  * Returns an array of root-level TreeNodes (usually just one).

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface Session {
   thinkingLevel?: string;
   totalTokens?: number;
   contextTokens?: number;
+  parentSessionKey?: string; // from gateway API (newer session row shape)
   parentId?: string;  // from gateway API (v2026.2.9+)
   inputTokens?: number;
   outputTokens?: number;


### PR DESCRIPTION
Title: fix(sessions): keep orphaned agent sessions visible

Body:
## Summary
- honor `parentSessionKey` as well as `parentId` when reconstructing session lineage for the AGENTS sidebar
- keep valid agent descendants visible even when `openclaw sessions cleanup --fix-missing --enforce` removed the root session row but the agent root is still inferable from the session key
- add regression coverage for explicit parent-session chains, orphaned-but-valid agent descendants, and the sidebar empty-state behavior

Fixes #249.

## Test Plan
- [x] `npm test -- --run src/features/sessions/sessionTree.test.ts src/features/sessions/sessionKeys.test.ts src/features/sessions/SessionList.test.tsx src/contexts/SessionContext.test.tsx`
- [x] `npm run lint -- src/features/sessions/sessionTree.ts src/features/sessions/sessionTree.test.ts src/features/sessions/sessionKeys.ts src/features/sessions/sessionKeys.test.ts src/features/sessions/SessionList.test.tsx src/contexts/SessionContext.tsx src/types.ts`
- [x] `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for explicit gateway-provided parent session keys to improve parent resolution and sidebar grouping.

* **Bug Fixes**
  * Sessions with changed parent relationships now refresh correctly (avoiding stale references).
  * Descendant sessions and orphan chains are displayed appropriately when parent rows are removed or stale.

* **Tests**
  * Added tests covering parent-key resolution, reconciliation behavior, sidebar tree, and empty-state descendant display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->