### PR TITLE
feat(file-browser): open touch context menu from long press

### DIFF
--- a/src/features/file-browser/FileTreeNode.tsx
+++ b/src/features/file-browser/FileTreeNode.tsx
@@ -1,7 +1,11 @@
+import { useEffect, useRef } from 'react';
 import { ChevronRight, ChevronDown, Loader2 } from 'lucide-react';
 import { FileIcon, FolderIcon } from './utils/fileIcons';
 import { isImageFile, isPdfFile } from './utils/fileTypes';
 import type { TreeEntry } from './types';
+
+const LONG_PRESS_MS = 450;
+const MOVE_TOLERANCE_PX = 10;
 
 interface FileTreeNodeProps {
   entry: TreeEntry;
@@ -11,6 +15,7 @@ interface FileTreeNodeProps {
   loadingPaths: Set<string>;
   onToggleDir: (path: string) => void;
   onOpenFile: (path: string) => void;
+  onTouchLongPress?: (entry: TreeEntry, touchPoint: { x: number; y: number }) => void;
   onSelect: (path: string) => void;
   onContextMenu: (entry: TreeEntry, event: React.MouseEvent) => void;
   dragSourcePath: string | null;
@@ -35,6 +40,7 @@ export function FileTreeNode({
   loadingPaths,
   onToggleDir,
   onOpenFile,
+  onTouchLongPress,
   onSelect,
   onContextMenu,
   dragSourcePath,
@@ -50,6 +56,11 @@ export function FileTreeNode({
   onRenameCommit,
   onRenameCancel,
 }: FileTreeNodeProps) {
+  const longPressTimerRef = useRef<number | null>(null);
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
+  const activeTouchPointerIdRef = useRef<number | null>(null);
+  const longPressTriggeredRef = useRef(false);
+
   const isDir = entry.type === 'directory';
   const isExpanded = expandedPaths.has(entry.path);
   const isSelected = selectedPath === entry.path;
@@ -59,7 +70,22 @@ export function FileTreeNode({
   const isDropTarget = isDir && dropTargetPath === entry.path;
   const isDragSource = dragSourcePath === entry.path;
 
+  const clearLongPress = () => {
+    if (longPressTimerRef.current !== null) {
+      window.clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+    touchStartRef.current = null;
+    activeTouchPointerIdRef.current = null;
+  };
+
+  useEffect(() => () => clearLongPress(), []);
+
   const handleClick = () => {
+    if (longPressTriggeredRef.current) {
+      longPressTriggeredRef.current = false;
+      return;
+    }
     if (isRenaming) return;
     onSelect(entry.path);
     if (isDir) {
@@ -86,6 +112,43 @@ export function FileTreeNode({
     }
   };
 
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    longPressTriggeredRef.current = false;
+    clearLongPress();
+    if (event.pointerType !== 'touch' || isRenaming || !onTouchLongPress) return;
+    activeTouchPointerIdRef.current = event.pointerId;
+    touchStartRef.current = { x: event.clientX, y: event.clientY };
+    longPressTimerRef.current = window.setTimeout(() => {
+      longPressTriggeredRef.current = true;
+      longPressTimerRef.current = null;
+    }, LONG_PRESS_MS);
+  };
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.pointerType !== 'touch' || !touchStartRef.current || activeTouchPointerIdRef.current !== event.pointerId) return;
+    const dx = Math.abs(event.clientX - touchStartRef.current.x);
+    const dy = Math.abs(event.clientY - touchStartRef.current.y);
+    if (dx > MOVE_TOLERANCE_PX || dy > MOVE_TOLERANCE_PX) {
+      longPressTriggeredRef.current = false;
+      clearLongPress();
+    }
+  };
+
+  const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.pointerType !== 'touch' || activeTouchPointerIdRef.current !== event.pointerId) return;
+    if (longPressTriggeredRef.current && onTouchLongPress) {
+      onTouchLongPress(entry, { x: event.clientX, y: event.clientY });
+    }
+    clearLongPress();
+  };
+
+  const handlePointerCancel = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.pointerType === 'touch' && activeTouchPointerIdRef.current === event.pointerId) {
+      longPressTriggeredRef.current = false;
+      clearLongPress();
+    }
+  };
+
   return (
     <div role="treeitem" aria-expanded={isDir ? isExpanded : undefined} aria-selected={isSelected}>
       <div
@@ -94,11 +157,28 @@ export function FileTreeNode({
         } ${entry.binary && !canOpen ? 'opacity-50' : ''} ${
           isDropTarget ? 'bg-primary/15 ring-1 ring-primary/40' : ''
         } ${isDragSource ? 'opacity-50' : ''}`}
-        style={{ paddingLeft: depth * 16 + 8 }}
+        style={{
+          paddingLeft: depth * 16 + 8,
+          userSelect: 'none',
+          WebkitUserSelect: 'none',
+          WebkitTouchCallout: 'none' as const,
+        }}
         onClick={handleClick}
         onDoubleClick={handleDoubleClick}
         onKeyDown={handleKeyDown}
-        onContextMenu={(e) => onContextMenu(entry, e)}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
+        onContextMenu={(e) => {
+          if (longPressTriggeredRef.current) {
+            // Keep the flag set here so a follow-up synthetic click is still swallowed.
+            // The next pointerdown or the real click handler clears stale suppression.
+            e.preventDefault();
+            return;
+          }
+          onContextMenu(entry, e);
+        }}
         onDragStart={(e) => onDragStart(entry, e)}
         onDragEnd={onDragEnd}
         onDragOver={isDir ? (e) => onDragOverDirectory(entry, e) : undefined}
@@ -160,6 +240,7 @@ export function FileTreeNode({
               loadingPaths={loadingPaths}
               onToggleDir={onToggleDir}
               onOpenFile={onOpenFile}
+              onTouchLongPress={onTouchLongPress}
               onSelect={onSelect}
               onContextMenu={onContextMenu}
               dragSourcePath={dragSourcePath}

--- a/src/features/file-browser/FileTreePanel.test.tsx
+++ b/src/features/file-browser/FileTreePanel.test.tsx
@@ -84,6 +84,7 @@ const defaultMockHook = {
 
 describe('FileTreePanel', () => {
   let mockUseFileTree: vi.MockedFunction<typeof useFileTree>;
+  const originalVisualViewportDescriptor = Object.getOwnPropertyDescriptor(window, 'visualViewport');
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -103,7 +104,14 @@ describe('FileTreePanel', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
+    if (originalVisualViewportDescriptor) {
+      Object.defineProperty(window, 'visualViewport', originalVisualViewportDescriptor);
+    } else {
+      // @ts-expect-error test cleanup for ad-hoc property definition
+      delete window.visualViewport;
+    }
     vi.restoreAllMocks();
   });
 
@@ -202,6 +210,303 @@ describe('FileTreePanel', () => {
   });
 
   describe('context menu add to chat', () => {
+    it('opens the shared row menu on touch release after a long press without triggering file open', async () => {
+      vi.useFakeTimers();
+
+      render(
+        <FileTreePanel
+          workspaceAgentId="agent-a"
+          onOpenFile={mockOnOpenFile}
+          onAddToChat={mockOnAddToChat}
+          addToChatEnabled={true}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+          collapsed={false}
+          onCollapseChange={vi.fn()}
+        />
+      );
+
+      const row = screen.getByTitle('package.json');
+      fireEvent.pointerDown(row, { pointerType: 'touch', clientX: 24, clientY: 32, pointerId: 0 });
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(screen.queryByText('Add to chat')).not.toBeInTheDocument();
+
+      fireEvent.pointerUp(row, { pointerType: 'touch', clientX: 24, clientY: 32, pointerId: 0 });
+
+      expect(screen.getByText('Add to chat')).toBeInTheDocument();
+      expect(mockOnOpenFile).not.toHaveBeenCalled();
+    });
+
+    it('anchors the touch menu with its bottom-left corner at the touch point', async () => {
+      vi.useFakeTimers();
+      const visualViewportMock = {
+        width: 220,
+        height: 280,
+        offsetLeft: 40,
+        offsetTop: 80,
+      };
+      const originalOffsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
+      Object.defineProperty(window, 'visualViewport', {
+        configurable: true,
+        value: visualViewportMock,
+      });
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+        configurable: true,
+        get() {
+          return this.classList.contains('shell-panel') ? 40 : 0;
+        },
+      });
+
+      try {
+        render(
+          <FileTreePanel
+            workspaceAgentId="agent-a"
+            onOpenFile={mockOnOpenFile}
+            onAddToChat={mockOnAddToChat}
+            addToChatEnabled={true}
+            onRemapOpenPaths={mockOnRemapOpenPaths}
+            onCloseOpenPaths={mockOnCloseOpenPaths}
+            collapsed={false}
+            onCollapseChange={vi.fn()}
+          />
+        );
+
+        const row = screen.getByTitle('package.json');
+        fireEvent.pointerDown(row, { pointerType: 'touch', clientX: 210, clientY: 300, pointerId: 1 });
+        await act(async () => {
+          vi.advanceTimersByTime(500);
+        });
+        fireEvent.pointerUp(row, { pointerType: 'touch', clientX: 210, clientY: 300, pointerId: 1 });
+
+        const menu = screen.getByText('Add to chat').closest('.shell-panel') as HTMLElement;
+        expect(menu).toHaveStyle({ left: '210px', top: '260px' });
+      } finally {
+        if (originalOffsetHeight) {
+          Object.defineProperty(HTMLElement.prototype, 'offsetHeight', originalOffsetHeight);
+        } else {
+          // @ts-expect-error test cleanup for ad-hoc property definition
+          delete HTMLElement.prototype.offsetHeight;
+        }
+      }
+    });
+
+    it('keeps a touch-opened menu visible when the browser emits a synthetic mousedown after release', async () => {
+      vi.useFakeTimers();
+
+      render(
+        <FileTreePanel
+          workspaceAgentId="agent-a"
+          onOpenFile={mockOnOpenFile}
+          onAddToChat={mockOnAddToChat}
+          addToChatEnabled={true}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+          collapsed={false}
+          onCollapseChange={vi.fn()}
+        />
+      );
+
+      const row = screen.getByTitle('package.json');
+      fireEvent.pointerDown(row, { pointerType: 'touch', clientX: 24, clientY: 32, pointerId: 7 });
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+      fireEvent.pointerUp(row, { pointerType: 'touch', clientX: 24, clientY: 32, pointerId: 7 });
+      fireEvent.mouseDown(document.body);
+
+      expect(screen.getByText('Add to chat')).toBeInTheDocument();
+    });
+
+    it('keeps the follow-up click suppressed after a touch long press on a directory', async () => {
+      vi.useFakeTimers();
+
+      render(
+        <FileTreePanel
+          workspaceAgentId="agent-a"
+          onOpenFile={mockOnOpenFile}
+          onAddToChat={mockOnAddToChat}
+          addToChatEnabled={true}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+          collapsed={false}
+          onCollapseChange={vi.fn()}
+        />
+      );
+
+      const row = screen.getByTitle('src');
+      fireEvent.pointerDown(row, { pointerType: 'touch', clientX: 24, clientY: 32, pointerId: 2 });
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+
+      fireEvent.pointerUp(row, { pointerType: 'touch', clientX: 24, clientY: 32, pointerId: 2 });
+      fireEvent.contextMenu(row, new MouseEvent('contextmenu', { bubbles: true }));
+      fireEvent.click(row);
+
+      expect(screen.getByText('Add to chat')).toBeInTheDocument();
+      expect(defaultMockHook.toggleDirectory).not.toHaveBeenCalled();
+    });
+
+    it('clears stale long-press suppression on the next non-touch pointerdown', async () => {
+      vi.useFakeTimers();
+
+      render(
+        <FileTreePanel
+          workspaceAgentId="agent-a"
+          onOpenFile={mockOnOpenFile}
+          onAddToChat={mockOnAddToChat}
+          addToChatEnabled={true}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+          collapsed={false}
+          onCollapseChange={vi.fn()}
+        />
+      );
+
+      const row = screen.getByTitle('src');
+      fireEvent.pointerDown(row, { pointerType: 'touch', clientX: 24, clientY: 32, pointerId: 3 });
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+      fireEvent.pointerCancel(row, { pointerType: 'touch', pointerId: 3 });
+
+      fireEvent.pointerDown(row, { pointerType: 'mouse', clientX: 24, clientY: 32 });
+      fireEvent.click(row);
+
+      expect(defaultMockHook.toggleDirectory).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not leave the next interaction suppressed when contextmenu fires without a follow-up click', async () => {
+      vi.useFakeTimers();
+
+      render(
+        <FileTreePanel
+          workspaceAgentId="agent-a"
+          onOpenFile={mockOnOpenFile}
+          onAddToChat={mockOnAddToChat}
+          addToChatEnabled={true}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+          collapsed={false}
+          onCollapseChange={vi.fn()}
+        />
+      );
+
+      const row = screen.getByTitle('src');
+      fireEvent.pointerDown(row, { pointerType: 'touch', clientX: 24, clientY: 32, pointerId: 5 });
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+      fireEvent.pointerUp(row, { pointerType: 'touch', clientX: 24, clientY: 32, pointerId: 5 });
+      fireEvent.contextMenu(row, new MouseEvent('contextmenu', { bubbles: true }));
+
+      fireEvent.pointerDown(row, { pointerType: 'mouse', clientX: 24, clientY: 32 });
+      fireEvent.click(row);
+
+      expect(defaultMockHook.toggleDirectory).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels touch long press when the pointer moves beyond tolerance', () => {
+      vi.useFakeTimers();
+
+      render(
+        <FileTreePanel
+          workspaceAgentId="agent-a"
+          onOpenFile={mockOnOpenFile}
+          onAddToChat={mockOnAddToChat}
+          addToChatEnabled={true}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+          collapsed={false}
+          onCollapseChange={vi.fn()}
+        />
+      );
+
+      const row = screen.getByTitle('package.json');
+      fireEvent.pointerDown(row, { pointerType: 'touch', clientX: 10, clientY: 10, pointerId: 4 });
+      fireEvent.pointerMove(row, { pointerType: 'touch', clientX: 40, clientY: 40, pointerId: 4 });
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(screen.queryByText('Add to chat')).not.toBeInTheDocument();
+    });
+
+    it('cancels a triggered long press if the finger moves beyond tolerance before release', async () => {
+      vi.useFakeTimers();
+
+      render(
+        <FileTreePanel
+          workspaceAgentId="agent-a"
+          onOpenFile={mockOnOpenFile}
+          onAddToChat={mockOnAddToChat}
+          addToChatEnabled={true}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+          collapsed={false}
+          onCollapseChange={vi.fn()}
+        />
+      );
+
+      const row = screen.getByTitle('package.json');
+      fireEvent.pointerDown(row, { pointerType: 'touch', clientX: 20, clientY: 20, pointerId: 6 });
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+      fireEvent.pointerMove(row, { pointerType: 'touch', clientX: 40, clientY: 45, pointerId: 6 });
+      fireEvent.pointerUp(row, { pointerType: 'touch', clientX: 40, clientY: 45, pointerId: 6 });
+
+      expect(screen.queryByText('Add to chat')).not.toBeInTheDocument();
+    });
+
+    it('does not open the menu from a mouse pointer long hold', () => {
+      vi.useFakeTimers();
+
+      render(
+        <FileTreePanel
+          workspaceAgentId="agent-a"
+          onOpenFile={mockOnOpenFile}
+          onAddToChat={mockOnAddToChat}
+          addToChatEnabled={true}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+          collapsed={false}
+          onCollapseChange={vi.fn()}
+        />
+      );
+
+      const row = screen.getByTitle('package.json');
+      fireEvent.pointerDown(row, { pointerType: 'mouse', clientX: 24, clientY: 32 });
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+
+      expect(screen.queryByText('Add to chat')).not.toBeInTheDocument();
+    });
+
+    it('renders menu actions from the shared action builder for files', async () => {
+      render(
+        <FileTreePanel
+          workspaceAgentId="agent-a"
+          onOpenFile={mockOnOpenFile}
+          onAddToChat={mockOnAddToChat}
+          addToChatEnabled={true}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+          collapsed={false}
+          onCollapseChange={vi.fn()}
+        />
+      );
+
+      fireEvent.contextMenu(screen.getByText('package.json'), new MouseEvent('contextmenu', { bubbles: true }));
+
+      expect(await screen.findByText('Add to chat')).toBeInTheDocument();
+      expect(screen.getByText('Rename')).toBeInTheDocument();
+      expect(screen.getByText('Move to Trash')).toBeInTheDocument();
+    });
+
     it('shows "Add to chat" for files when file references are enabled, and calls the callback with the workspace agent', async () => {
       render(
         <FileTreePanel

--- a/src/features/file-browser/FileTreePanel.tsx
+++ b/src/features/file-browser/FileTreePanel.tsx
@@ -6,8 +6,9 @@
  */
 
 import { useRef, useState, useCallback, useEffect } from 'react';
-import { PanelLeftClose, RefreshCw, Pencil, Trash2, RotateCcw, X, Paperclip } from 'lucide-react';
+import { PanelLeftClose, RefreshCw, X } from 'lucide-react';
 import { FileTreeNode } from './FileTreeNode';
+import { buildFileTreeMenuActions } from './fileTreeMenuActions';
 import { useFileTree } from './hooks/useFileTree';
 import { ConfirmDialog } from '../../components/ConfirmDialog';
 import { useSettings } from '@/contexts/SettingsContext';
@@ -23,6 +24,8 @@ const WIDTH_STORAGE_KEY = 'nerve-file-tree-width';
 const MENU_VIEWPORT_PADDING = 8;
 const MENU_CURSOR_OFFSET = 6;
 const MENU_ROW_TOP_OFFSET = 2;
+const TOUCH_MENU_OFFSET_X = 0;
+const TOUCH_MENU_OFFSET_Y = 0;
 const UNDO_TOAST_TTL_MS = 10_000;
 
 /** Load persisted file tree width from localStorage. */
@@ -43,11 +46,6 @@ function getParentDir(filePath: string): string {
 function basename(filePath: string): string {
   const idx = filePath.lastIndexOf('/');
   return idx === -1 ? filePath : filePath.slice(idx + 1);
-}
-
-/** Check if a path points to a trash item. */
-function isTrashItemPath(filePath: string): boolean {
-  return filePath.startsWith('.trash/') && filePath !== '.trash';
 }
 
 export interface FileTreeChangeEvent {
@@ -89,7 +87,14 @@ type FileTreeToastPayload =
 
 type FileTreeToast = FileTreeToastPayload & { agentId: string };
 type ScopedSessionState = { agentId: string; sessionId: number };
-type ScopedContextMenu = ScopedSessionState & { x: number; y: number; entry: TreeEntry };
+type ScopedContextMenu = ScopedSessionState & {
+  x: number;
+  y: number;
+  entry: TreeEntry;
+  source: 'mouse' | 'touch';
+  touchAnchorX?: number;
+  touchAnchorY?: number;
+};
 type ScopedDeleteConfirmation = ScopedSessionState & { entry: TreeEntry };
 type ScopedRenameState = ScopedSessionState & { path: string; value: string };
 type ScopedDragSource = { agentId: string; entry: TreeEntry };
@@ -156,6 +161,7 @@ export function FileTreePanel({
   const [contextMenu, setContextMenu] = useState<ScopedContextMenu | null>(null);
   const contextMenuRef = useRef<HTMLDivElement>(null);
   const contextMenuSessionIdRef = useRef(0);
+  const suppressMouseDownUntilRef = useRef(0);
 
   const [renameState, setRenameState] = useState<ScopedRenameState | null>(null);
   const renameSessionIdRef = useRef(0);
@@ -261,6 +267,7 @@ export function FileTreePanel({
     if (!visibleContextMenu) return;
 
     const onMouseDown = (event: MouseEvent) => {
+      if (visibleContextMenu.source === 'touch' && Date.now() < suppressMouseDownUntilRef.current) return;
       const target = event.target as Node;
       if (contextMenuRef.current?.contains(target)) return;
       setContextMenu(null);
@@ -288,18 +295,38 @@ export function FileTreePanel({
     const width = menuEl.offsetWidth;
     const height = menuEl.offsetHeight;
     const panelRect = panelRef.current?.getBoundingClientRect();
+    const visualViewport = window.visualViewport;
+    const viewportLeft = visualViewport?.offsetLeft ?? 0;
+    const viewportTop = visualViewport?.offsetTop ?? 0;
+    const viewportWidth = visualViewport?.width ?? window.innerWidth;
+    const viewportHeight = visualViewport?.height ?? window.innerHeight;
 
-    const minX = panelRect ? panelRect.left + MENU_VIEWPORT_PADDING : MENU_VIEWPORT_PADDING;
-    const minY = panelRect ? panelRect.top + MENU_VIEWPORT_PADDING : MENU_VIEWPORT_PADDING;
-    const maxX = panelRect
-      ? Math.max(minX, panelRect.right - width - MENU_VIEWPORT_PADDING)
-      : Math.max(MENU_VIEWPORT_PADDING, window.innerWidth - width - MENU_VIEWPORT_PADDING);
-    const maxY = panelRect
-      ? Math.max(minY, panelRect.bottom - height - MENU_VIEWPORT_PADDING)
-      : Math.max(MENU_VIEWPORT_PADDING, window.innerHeight - height - MENU_VIEWPORT_PADDING);
+    const minX = visibleContextMenu.source === 'touch'
+      ? viewportLeft + MENU_VIEWPORT_PADDING
+      : (panelRect ? panelRect.left + MENU_VIEWPORT_PADDING : MENU_VIEWPORT_PADDING);
+    const minY = visibleContextMenu.source === 'touch'
+      ? viewportTop + MENU_VIEWPORT_PADDING
+      : (panelRect ? panelRect.top + MENU_VIEWPORT_PADDING : MENU_VIEWPORT_PADDING);
+    const maxX = visibleContextMenu.source === 'touch'
+      ? Math.max(minX, viewportLeft + viewportWidth - width - MENU_VIEWPORT_PADDING)
+      : (panelRect
+        ? Math.max(minX, panelRect.right - width - MENU_VIEWPORT_PADDING)
+        : Math.max(MENU_VIEWPORT_PADDING, window.innerWidth - width - MENU_VIEWPORT_PADDING));
+    const maxY = visibleContextMenu.source === 'touch'
+      ? Math.max(minY, viewportTop + viewportHeight - height - MENU_VIEWPORT_PADDING)
+      : (panelRect
+        ? Math.max(minY, panelRect.bottom - height - MENU_VIEWPORT_PADDING)
+        : Math.max(MENU_VIEWPORT_PADDING, window.innerHeight - height - MENU_VIEWPORT_PADDING));
 
-    const nextX = Math.min(Math.max(visibleContextMenu.x, minX), maxX);
-    const nextY = Math.min(Math.max(visibleContextMenu.y, minY), maxY);
+    const targetX = visibleContextMenu.source === 'touch'
+      ? (visibleContextMenu.touchAnchorX ?? visibleContextMenu.x)
+      : visibleContextMenu.x;
+    const targetY = visibleContextMenu.source === 'touch'
+      ? ((visibleContextMenu.touchAnchorY ?? visibleContextMenu.y) - height)
+      : visibleContextMenu.y;
+
+    const nextX = Math.min(Math.max(targetX, minX), maxX);
+    const nextY = Math.min(Math.max(targetY, minY), maxY);
 
     if (nextX !== visibleContextMenu.x || nextY !== visibleContextMenu.y) {
       setContextMenu((prev) => (prev ? { ...prev, x: nextX, y: nextY } : prev));
@@ -453,6 +480,23 @@ export function FileTreePanel({
       x: nextX,
       y: nextY,
       entry,
+      source: 'mouse',
+    });
+  }, [selectFile, workspaceAgentId]);
+
+  const openTouchContextMenu = useCallback((entry: TreeEntry, touchPoint: { x: number; y: number }) => {
+    selectFile(entry.path);
+    contextMenuSessionIdRef.current += 1;
+    suppressMouseDownUntilRef.current = Date.now() + 500;
+    setContextMenu({
+      agentId: workspaceAgentId,
+      sessionId: contextMenuSessionIdRef.current,
+      x: touchPoint.x + TOUCH_MENU_OFFSET_X,
+      y: touchPoint.y + TOUCH_MENU_OFFSET_Y,
+      entry,
+      source: 'touch',
+      touchAnchorX: touchPoint.x,
+      touchAnchorY: touchPoint.y,
     });
   }, [selectFile, workspaceAgentId]);
 
@@ -669,22 +713,30 @@ export function FileTreePanel({
     return null;
   }
 
-  const menuEntry = visibleContextMenu?.entry;
-  const menuPath = menuEntry?.path || '';
-  const menuInTrash = isTrashItemPath(menuPath);
-  const showRestore = menuInTrash;
-  const showAddToChat = Boolean(
-    onAddToChat
-    && menuEntry
-    && !menuPath.startsWith('.trash')
-    && menuPath !== '.trash'
-    && (
-      menuEntry.type === 'directory'
-      || (menuEntry.type === 'file' && addToChatEnabled)
-    ),
-  );
-  const showRename = Boolean(menuEntry && menuPath !== '.trash');
-  const showTrashAction = Boolean(menuEntry && !menuPath.startsWith('.trash') && menuPath !== '.trash');
+  const menuEntry = visibleContextMenu?.entry ?? null;
+  const menuActions = menuEntry
+    ? buildFileTreeMenuActions(menuEntry, {
+        addToChatEnabled,
+        canAddToChat: Boolean(onAddToChat),
+        isCustomWorkspace: Boolean(workspaceInfo?.isCustomWorkspace),
+        onRestore: () => { void restoreEntry(menuEntry.path); },
+        onAddToChat: () => {
+          const itemKind = menuEntry.type === 'directory' ? 'directory' : 'file';
+          void Promise
+            .resolve(onAddToChat?.(menuEntry.path, itemKind, workspaceAgentId))
+            .catch((error: unknown) => {
+              const fallbackMessage = itemKind === 'directory'
+                ? 'Failed to add directory to chat'
+                : 'Failed to add file to chat';
+              const message = error instanceof Error ? error.message : fallbackMessage;
+              console.error('[FileTreePanel] add-to-chat failed:', error);
+              showToastForAgent(workspaceAgentId, { type: 'error', message }, 4500);
+            });
+        },
+        onRename: () => startRename(menuEntry),
+        onTrash: () => { void moveToTrash(menuEntry); },
+      })
+    : [];
 
   return (
     <div
@@ -767,6 +819,7 @@ export function FileTreePanel({
                 loadingPaths={loadingPaths}
                 onToggleDir={toggleDirectory}
                 onOpenFile={onOpenFile}
+                onTouchLongPress={openTouchContextMenu}
                 onSelect={selectFile}
                 onContextMenu={handleContextMenu}
                 dragSourcePath={visibleDragSource?.path || null}
@@ -791,66 +844,37 @@ export function FileTreePanel({
       {visibleContextMenu && menuEntry && (
         <div
           ref={contextMenuRef}
-          className="shell-panel fixed z-50 min-w-[180px] rounded-2xl py-1.5"
-          style={{ left: visibleContextMenu.x, top: visibleContextMenu.y }}
+          className="shell-panel fixed z-50 min-w-[180px] rounded-2xl py-1.5 select-none touch-manipulation"
+          style={{
+            left: visibleContextMenu.x,
+            top: visibleContextMenu.y,
+            userSelect: 'none',
+            WebkitUserSelect: 'none',
+            WebkitTouchCallout: 'none',
+          }}
         >
-          {showRestore && (
-            <button
-              className="w-full px-3 py-1.5 text-left text-xs text-foreground hover:bg-muted/60 flex items-center gap-2"
-              onClick={() => {
-                setContextMenu(null);
-                void restoreEntry(menuEntry.path);
-              }}
-            >
-              <RotateCcw size={12} />
-              Restore
-            </button>
-          )}
-
-          {showAddToChat && (
-            <button
-              className="w-full px-3 py-1.5 text-left text-xs text-foreground hover:bg-muted/60 flex items-center gap-2"
-              onClick={() => {
-                setContextMenu(null);
-                const itemKind = menuEntry.type === 'directory' ? 'directory' : 'file';
-                void Promise
-                  .resolve(onAddToChat?.(menuEntry.path, itemKind, workspaceAgentId))
-                  .catch((error: unknown) => {
-                    const fallbackMessage = itemKind === 'directory'
-                      ? 'Failed to add directory to chat'
-                      : 'Failed to add file to chat';
-                    const message = error instanceof Error ? error.message : fallbackMessage;
-                    console.error('[FileTreePanel] add-to-chat failed:', error);
-                    showToastForAgent(workspaceAgentId, { type: 'error', message }, 4500);
-                  });
-              }}
-            >
-              <Paperclip size={12} />
-              Add to chat
-            </button>
-          )}
-
-          {showRename && (
-            <button
-              className="w-full px-3 py-1.5 text-left text-xs text-foreground hover:bg-muted/60 flex items-center gap-2"
-              onClick={() => startRename(menuEntry)}
-            >
-              <Pencil size={12} />
-              Rename
-            </button>
-          )}
-
-          {showTrashAction && (
-            <button
-              className="w-full px-3 py-1.5 text-left text-xs text-destructive hover:bg-destructive/10 flex items-center gap-2"
-              onClick={() => { void moveToTrash(menuEntry); }}
-            >
-              <Trash2 size={12} />
-              {workspaceInfo?.isCustomWorkspace ? 'Permanently Delete' : 'Move to Trash'}
-            </button>
-          )}
-
-          {!showRestore && !showAddToChat && !showRename && !showTrashAction && (
+          {menuActions.length > 0 ? (
+            menuActions.map((action) => {
+              const Icon = action.icon;
+              return (
+                <button
+                  key={action.id}
+                  className={`w-full px-3 py-1.5 text-left text-xs flex items-center gap-2 ${
+                    action.destructive
+                      ? 'text-destructive hover:bg-destructive/10'
+                      : 'text-foreground hover:bg-muted/60'
+                  }`}
+                  onClick={() => {
+                    setContextMenu(null);
+                    action.onSelect();
+                  }}
+                >
+                  <Icon size={12} />
+                  {action.label}
+                </button>
+              );
+            })
+          ) : (
             <div className="px-3 py-1.5 text-xs text-muted-foreground">
               No actions
             </div>

--- a/src/features/file-browser/fileTreeMenuActions.test.ts
+++ b/src/features/file-browser/fileTreeMenuActions.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildFileTreeMenuActions } from './fileTreeMenuActions';
+import type { TreeEntry } from './types';
+
+const fileEntry: TreeEntry = {
+  name: 'package.json',
+  path: 'package.json',
+  type: 'file',
+  children: null,
+};
+
+const trashedFileEntry: TreeEntry = {
+  name: 'package.json',
+  path: '.trash/package.json',
+  type: 'file',
+  children: null,
+};
+
+const trashPrefixedFileEntry: TreeEntry = {
+  name: '.trash-config',
+  path: '.trash-config',
+  type: 'file',
+  children: null,
+};
+
+describe('buildFileTreeMenuActions', () => {
+  it('returns add-to-chat, rename, and trash actions for a normal file', () => {
+    const actions = buildFileTreeMenuActions(fileEntry, {
+      addToChatEnabled: true,
+      canAddToChat: true,
+      isCustomWorkspace: false,
+      onRestore: vi.fn(),
+      onAddToChat: vi.fn(),
+      onRename: vi.fn(),
+      onTrash: vi.fn(),
+    });
+
+    expect(actions.map((action) => action.id)).toEqual(['add-to-chat', 'rename', 'trash']);
+    expect(actions.map((action) => action.label)).toEqual(['Add to chat', 'Rename', 'Move to Trash']);
+  });
+
+  it('keeps restore and rename actions for files already in trash', () => {
+    const actions = buildFileTreeMenuActions(trashedFileEntry, {
+      addToChatEnabled: true,
+      canAddToChat: true,
+      isCustomWorkspace: false,
+      onRestore: vi.fn(),
+      onAddToChat: vi.fn(),
+      onRename: vi.fn(),
+      onTrash: vi.fn(),
+    });
+
+    expect(actions.map((action) => action.id)).toEqual(['restore', 'rename']);
+    expect(actions.map((action) => action.label)).toEqual(['Restore', 'Rename']);
+  });
+
+  it('does not expose add-to-chat for entries whose path starts with .trash', () => {
+    const actions = buildFileTreeMenuActions(trashPrefixedFileEntry, {
+      addToChatEnabled: true,
+      canAddToChat: true,
+      isCustomWorkspace: false,
+      onRestore: vi.fn(),
+      onAddToChat: vi.fn(),
+      onRename: vi.fn(),
+      onTrash: vi.fn(),
+    });
+
+    expect(actions.map((action) => action.id)).toEqual(['rename', 'trash']);
+  });
+});

--- a/src/features/file-browser/fileTreeMenuActions.ts
+++ b/src/features/file-browser/fileTreeMenuActions.ts
@@ -1,0 +1,73 @@
+import type { LucideIcon } from 'lucide-react';
+import { Paperclip, Pencil, RotateCcw, Trash2 } from 'lucide-react';
+import type { TreeEntry } from './types';
+
+export interface FileTreeMenuAction {
+  id: 'restore' | 'add-to-chat' | 'rename' | 'trash';
+  label: string;
+  icon: LucideIcon;
+  destructive?: boolean;
+  onSelect: () => void;
+}
+
+export interface FileTreeMenuActionOptions {
+  addToChatEnabled: boolean;
+  canAddToChat: boolean;
+  isCustomWorkspace: boolean;
+  onRestore: () => void;
+  onAddToChat: () => void;
+  onRename: () => void;
+  onTrash: () => void;
+}
+
+function isTrashItemPath(filePath: string): boolean {
+  return filePath.startsWith('.trash/');
+}
+
+export function buildFileTreeMenuActions(
+  entry: TreeEntry,
+  options: FileTreeMenuActionOptions,
+): FileTreeMenuAction[] {
+  const path = entry.path;
+  const inTrash = isTrashItemPath(path);
+  const actions: FileTreeMenuAction[] = [];
+
+  if (inTrash) {
+    actions.push({
+      id: 'restore',
+      label: 'Restore',
+      icon: RotateCcw,
+      onSelect: options.onRestore,
+    });
+  }
+
+  if (!path.startsWith('.trash') && options.canAddToChat && (entry.type === 'directory' || options.addToChatEnabled)) {
+    actions.push({
+      id: 'add-to-chat',
+      label: 'Add to chat',
+      icon: Paperclip,
+      onSelect: options.onAddToChat,
+    });
+  }
+
+  if (path !== '.trash') {
+    actions.push({
+      id: 'rename',
+      label: 'Rename',
+      icon: Pencil,
+      onSelect: options.onRename,
+    });
+  }
+
+  if (!inTrash && path !== '.trash') {
+    actions.push({
+      id: 'trash',
+      label: options.isCustomWorkspace ? 'Permanently Delete' : 'Move to Trash',
+      icon: Trash2,
+      destructive: true,
+      onSelect: options.onTrash,
+    });
+  }
+
+  return actions;
+}


### PR DESCRIPTION
## What

- add shared file-tree context menu action building so desktop right-click and touch long-press use the same action list
- add touch long-press handling for file-tree rows, including cancellation, follow-up suppression, and touch-specific menu positioning
- add regression coverage for shared menu parity and touch interaction edge cases

## Why

- mobile and touch users need access to the same file-tree actions that desktop users already get from right click
- the touch menu needed to behave correctly around long-press release timing, zoomed viewports, and synthetic post-touch events
- relates to #300

## How

- introduce `buildFileTreeMenuActions()` in the file-browser feature and render the context menu from that shared builder
- add pointer-based long-press handling in `FileTreeNode` and route touch openings through `FileTreePanel`
- clamp touch-opened menus using touch-anchor positioning and cover the interaction contract with focused tests

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [x] New features include tests
- [ ] UI changes include a screenshot or screen recording

## Screenshots

<!-- If applicable, add screenshots of the change. Delete this section if not relevant. -->
