### PR TITLE
feat(ui): support adaptive thinking selection

### DIFF
--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -367,6 +367,73 @@ describe('SessionContext', () => {
     expect(spawnRouteCalled).toBe(false);
   });
 
+  it('clears the root thinking override when spawnSession is called without an explicit thinking level', async () => {
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return { sessions: [{ sessionKey: 'agent:main:main', label: 'Main' }] };
+      }
+      return {};
+    });
+
+    function SpawnRootDefaultThinking() {
+      const { spawnSession } = useSessionContext();
+      return (
+        <button
+          data-testid="spawn-root-default-thinking"
+          onClick={() => spawnSession({ kind: 'root', agentName: 'DefaultThink', task: 'hi' })}
+        />
+      );
+    }
+
+    render(<SessionProvider><SpawnRootDefaultThinking /></SessionProvider>);
+    await waitFor(() => expect(rpcMock).toHaveBeenCalled());
+
+    await act(async () => {
+      screen.getByTestId('spawn-root-default-thinking').click();
+    });
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('sessions.patch', expect.objectContaining({
+        key: 'agent:defaultthink:main',
+        label: 'DefaultThink',
+        thinkingLevel: null,
+      }));
+    });
+  });
+
+  it.each(['off', 'adaptive'])('preserves explicit %s thinking when spawning a root agent', async (thinking) => {
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return { sessions: [{ sessionKey: 'agent:main:main', label: 'Main' }] };
+      }
+      return {};
+    });
+
+    function SpawnRootExplicitThinking() {
+      const { spawnSession } = useSessionContext();
+      return (
+        <button
+          data-testid={`spawn-root-${thinking}`}
+          onClick={() => spawnSession({ kind: 'root', agentName: `Think ${thinking}`, task: 'hi', thinking })}
+        />
+      );
+    }
+
+    render(<SessionProvider><SpawnRootExplicitThinking /></SessionProvider>);
+    await waitFor(() => expect(rpcMock).toHaveBeenCalled());
+
+    await act(async () => {
+      screen.getByTestId(`spawn-root-${thinking}`).click();
+    });
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('sessions.patch', expect.objectContaining({
+        label: `Think ${thinking}`,
+        thinkingLevel: thinking,
+      }));
+    });
+  });
+
   it('uses a unique config name when spawning a duplicate root agent', async () => {
     rpcMock.mockImplementation(async (method: string) => {
       if (method === 'sessions.list') {

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -873,7 +873,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         const msg = err instanceof Error ? err.message : String(err);
         if (!msg.includes('already exists')) throw err;
       }
-      const thinkingLevel = opts.thinking && opts.thinking !== 'off' ? opts.thinking : null;
+      const thinkingLevel = opts.thinking ?? null;
 
       await rpc('sessions.patch', {
         key: sessionKey,

--- a/src/features/chat/components/useModelEffort.test.ts
+++ b/src/features/chat/components/useModelEffort.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 const { mockUseGateway, mockUseSessionContext } = vi.hoisted(() => ({
   mockUseGateway: vi.fn(),
@@ -159,6 +159,50 @@ describe('useModelEffort', () => {
     });
   });
 
+  it('keeps inherited adaptive effort selected while displaying the effective default value', async () => {
+    mockUseGateway.mockReturnValue({
+      rpc: vi.fn(),
+      connectionState: 'connected',
+      model: 'zai/glm-4.7',
+      thinking: 'adaptive',
+    });
+
+    mockUseSessionContext.mockReturnValue({
+      currentSession: 'agent:main:main',
+      sessions: [
+        { key: 'agent:main:main', model: 'openai-codex/gpt-5.4', thinking: 'adaptive' },
+      ],
+      updateSession: vi.fn(),
+    });
+
+    globalThis.fetch = vi.fn((input: string | URL | Request) => {
+      const url = String(input);
+      if (url === '/api/gateway/models') {
+        return Promise.resolve(jsonResponse({
+          models: [
+            { id: 'openai/gpt-5.4', label: 'gpt-5.4', provider: 'openai', role: 'primary' },
+            { id: 'zai/glm-4.7', label: 'glm-4.7', provider: 'zai', role: 'fallback' },
+          ],
+          error: null,
+        }));
+      }
+      if (url.startsWith('/api/gateway/session-info?sessionKey=')) {
+        return Promise.resolve(jsonResponse({}));
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof globalThis.fetch;
+
+    const { result } = renderHook(() => useModelEffort());
+
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe('primary');
+      expect(result.current.selectedEffort).toBe('thinkingDefault');
+      expect(result.current.selectedEffortLabel).toBe('adaptive');
+      expect(result.current.effortOptions[0]).toEqual({ value: 'thinkingDefault', label: 'adaptive (default)' });
+      expect(result.current.effortOptions).toContainEqual({ value: 'adaptive', label: 'adaptive' });
+    });
+  });
+
   it('uses transcript runtime defaults to label inherited effort when session summaries omit thinking', async () => {
     mockUseGateway.mockReturnValue({
       rpc: vi.fn(),
@@ -215,6 +259,91 @@ describe('useModelEffort', () => {
       expect(result.current.selectedEffort).toBe('high');
       expect(result.current.selectedEffortLabel).toBe('high');
     });
+  });
+
+  it('preserves explicit adaptive effort overrides when present', async () => {
+    mockUseSessionContext.mockReturnValue({
+      currentSession: 'agent:main:subagent:explicit-adaptive',
+      sessions: [
+        { key: 'agent:main:main', model: 'zai/glm-4.7' },
+        { key: 'agent:main:subagent:explicit-adaptive', model: 'zai/glm-4.7', thinking: 'medium', thinkingLevel: 'adaptive' },
+      ],
+      updateSession: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useModelEffort());
+
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe('primary');
+      expect(result.current.selectedEffort).toBe('adaptive');
+      expect(result.current.selectedEffortLabel).toBe('adaptive');
+    });
+  });
+
+  it('sends explicit off as a real thinking override instead of collapsing it to inherited default', async () => {
+    const rpc = vi.fn().mockResolvedValue({ ok: true });
+    const updateSession = vi.fn();
+
+    mockUseGateway.mockReturnValue({
+      rpc,
+      connectionState: 'connected',
+      model: 'zai/glm-4.7',
+      thinking: 'medium',
+    });
+
+    mockUseSessionContext.mockReturnValue({
+      currentSession: 'agent:main:main',
+      sessions: [
+        { key: 'agent:main:main', model: 'zai/glm-4.7', thinking: 'medium' },
+      ],
+      updateSession,
+    });
+
+    const { result } = renderHook(() => useModelEffort());
+
+    await waitFor(() => {
+      expect(result.current.selectedEffort).toBe('thinkingDefault');
+    });
+
+    await act(async () => {
+      await result.current.handleEffortChange('off');
+    });
+
+    expect(rpc).toHaveBeenCalledWith('sessions.patch', { key: 'agent:main:main', thinkingLevel: 'off' });
+    expect(updateSession).toHaveBeenCalledWith('agent:main:main', { thinkingLevel: 'off' });
+  });
+
+  it('omits thinking overrides when the inherited default option is selected', async () => {
+    const rpc = vi.fn().mockResolvedValue({ ok: true });
+    const updateSession = vi.fn();
+
+    mockUseGateway.mockReturnValue({
+      rpc,
+      connectionState: 'connected',
+      model: 'zai/glm-4.7',
+      thinking: 'adaptive',
+    });
+
+    mockUseSessionContext.mockReturnValue({
+      currentSession: 'agent:main:main',
+      sessions: [
+        { key: 'agent:main:main', model: 'zai/glm-4.7', thinking: 'adaptive', thinkingLevel: 'off' },
+      ],
+      updateSession,
+    });
+
+    const { result } = renderHook(() => useModelEffort());
+
+    await waitFor(() => {
+      expect(result.current.selectedEffort).toBe('off');
+    });
+
+    await act(async () => {
+      await result.current.handleEffortChange('thinkingDefault');
+    });
+
+    expect(rpc).toHaveBeenCalledWith('sessions.patch', { key: 'agent:main:main', thinkingLevel: null });
+    expect(updateSession).toHaveBeenCalledWith('agent:main:main', { thinkingLevel: undefined });
   });
 });
 

--- a/src/features/chat/components/useModelEffort.ts
+++ b/src/features/chat/components/useModelEffort.ts
@@ -35,9 +35,9 @@ function getEffortKey(sessionKey?: string | null) {
 const INHERITED_MODEL_VALUE = 'primary';
 const INHERITED_EFFORT_VALUE = 'thinkingDefault';
 
-type EffortLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+type EffortLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'adaptive';
 type EffortSelection = typeof INHERITED_EFFORT_VALUE | EffortLevel;
-const EFFORT_OPTIONS: EffortLevel[] = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'];
+const EFFORT_OPTIONS: EffortLevel[] = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'adaptive'];
 
 function normalizeEffortLevel(raw: string | null | undefined): EffortLevel | null {
   const normalized = raw?.toLowerCase();
@@ -151,7 +151,7 @@ export interface UseModelEffortReturn {
   uiError: string | null;
 }
 
-/** Hook to manage the model reasoning effort level (low/medium/high). */
+/** Hook to manage the model reasoning effort level selection. */
 export function useModelEffort(): UseModelEffortReturn {
   const { rpc, connectionState, model, thinking } = useGateway();
   const { currentSession, sessions, updateSession } = useSessionContext();
@@ -545,7 +545,7 @@ export function useModelEffort(): UseModelEffortReturn {
 
     try {
       const isInheritedDefault = nextEffort === INHERITED_EFFORT_VALUE;
-      const thinkingValue = isInheritedDefault || nextEffort === 'off' ? null : nextEffort;
+      const thinkingValue = isInheritedDefault ? null : nextEffort;
       try {
         await rpc('sessions.patch', { key: currentSession, thinkingLevel: thinkingValue });
       } catch (wsErr) {

--- a/src/features/sessions/SpawnAgentDialog.test.tsx
+++ b/src/features/sessions/SpawnAgentDialog.test.tsx
@@ -141,13 +141,14 @@ describe('SpawnAgentDialog', () => {
     expect(onSpawn).not.toHaveBeenCalled();
   });
 
-  it('omits model in spawn payload when inherited primary is selected', async () => {
+  it('omits model and thinking in the spawn payload when inherited defaults are selected', async () => {
     const onSpawn = vi.fn(async () => {});
     renderDialog(onSpawn);
 
     fireEvent.click(screen.getByText('New agent'));
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Select model' })).toHaveTextContent('primary');
+      expect(screen.getByRole('button', { name: 'Select thinking level' })).toHaveTextContent('Default');
     });
     fireEvent.change(screen.getByPlaceholderText('e.g. reviewer'), { target: { value: 'research' } });
     fireEvent.change(screen.getByPlaceholderText('What should this new agent start working on?'), { target: { value: 'test task' } });
@@ -159,6 +160,36 @@ describe('SpawnAgentDialog', () => {
         agentName: 'research',
         task: 'test task',
         model: undefined,
+        thinking: undefined,
+      }));
+    });
+  });
+
+  it('offers adaptive thinking and forwards it as an explicit spawn override', async () => {
+    const onSpawn = vi.fn(async () => {});
+    renderDialog(onSpawn);
+
+    fireEvent.click(screen.getByText('New agent'));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Select model' })).toHaveTextContent('primary');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select thinking level' }));
+    expect(await screen.findByRole('option', { name: 'Default' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'adaptive' })).toBeInTheDocument();
+    fireEvent.pointerDown(screen.getByRole('option', { name: 'adaptive' }));
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. reviewer'), { target: { value: 'research' } });
+    fireEvent.change(screen.getByPlaceholderText('What should this new agent start working on?'), { target: { value: 'test task' } });
+    fireEvent.click(screen.getByText('Create agent'));
+
+    await waitFor(() => {
+      expect(onSpawn).toHaveBeenCalledWith(expect.objectContaining({
+        kind: 'root',
+        agentName: 'research',
+        task: 'test task',
+        model: undefined,
+        thinking: 'adaptive',
       }));
     });
   });

--- a/src/features/sessions/SpawnAgentDialog.tsx
+++ b/src/features/sessions/SpawnAgentDialog.tsx
@@ -19,11 +19,17 @@ import {
   getTopLevelAgentSessions,
 } from './sessionKeys';
 
+const INHERITED_THINKING_VALUE = 'thinkingDefault';
+
+type ThinkingSelection = typeof INHERITED_THINKING_VALUE | 'off' | 'low' | 'medium' | 'high' | 'adaptive';
+
 const THINKING_LEVELS: InlineSelectOption[] = [
+  { value: INHERITED_THINKING_VALUE, label: 'Default' },
   { value: 'off', label: 'off' },
   { value: 'low', label: 'low' },
   { value: 'medium', label: 'medium' },
   { value: 'high', label: 'high' },
+  { value: 'adaptive', label: 'adaptive' },
 ];
 const AFTER_RUN_OPTIONS: InlineSelectOption[] = [
   { value: 'keep', label: 'Keep' },
@@ -58,7 +64,7 @@ export function SpawnAgentDialog({ open, onOpenChange, onSpawn }: SpawnAgentDial
   const [agentNameInput, setAgentNameInput] = useState('');
   const [parentRootKey, setParentRootKey] = useState('');
   const [model, setModel] = useState<string>('');
-  const [thinking, setThinking] = useState<string>('medium');
+  const [thinking, setThinking] = useState<ThinkingSelection>(INHERITED_THINKING_VALUE);
   const [cleanup, setCleanup] = useState<SubagentCleanupMode>('keep');
   const [spawning, setSpawning] = useState(false);
   const [fetchedModels, setFetchedModels] = useState<ModelEntry[]>([]);
@@ -156,7 +162,7 @@ export function SpawnAgentDialog({ open, onOpenChange, onSpawn }: SpawnAgentDial
     setAgentNameInput('');
     setParentRootKey(currentRootKey);
     setModel(defaultModelId);
-    setThinking('medium');
+    setThinking(INHERITED_THINKING_VALUE);
     setCleanup('keep');
     setModelLoadError('');
     setSpawnError('');
@@ -170,6 +176,7 @@ export function SpawnAgentDialog({ open, onOpenChange, onSpawn }: SpawnAgentDial
     setSpawning(true);
     setSpawnError('');
     const spawnModel = model === INHERITED_MODEL_VALUE ? undefined : model;
+    const spawnThinking = thinking === INHERITED_THINKING_VALUE ? undefined : thinking;
     try {
       const spawnResult = mode === 'root'
         ? await onSpawn({
@@ -177,7 +184,7 @@ export function SpawnAgentDialog({ open, onOpenChange, onSpawn }: SpawnAgentDial
             agentName: agentNameInput.trim(),
             task: task.trim(),
             model: spawnModel,
-            thinking,
+            thinking: spawnThinking,
           })
         : await onSpawn({
             kind: 'subagent',
@@ -185,7 +192,7 @@ export function SpawnAgentDialog({ open, onOpenChange, onSpawn }: SpawnAgentDial
             task: task.trim(),
             label: label.trim() || undefined,
             model: spawnModel,
-            thinking,
+            thinking: spawnThinking,
             cleanup,
           });
 
@@ -504,7 +511,7 @@ export function SpawnAgentDialog({ open, onOpenChange, onSpawn }: SpawnAgentDial
                   <label className="cockpit-field-label mb-2 block">Thinking</label>
                   <InlineSelect
                     value={thinking}
-                    onChange={setThinking}
+                    onChange={(value) => setThinking(value as ThinkingSelection)}
                     options={THINKING_LEVELS}
                     ariaLabel="Select thinking level"
                     disabled={spawning}


### PR DESCRIPTION
Closes #272

## Summary
- add `adaptive` as a first-class thinking option in the chat effort picker
- preserve inherited/default effort behavior, while keeping explicit `off` distinct from inherited default
- update the spawn dialog to use `Default` for inherited thinking instead of forcing an explicit override
- allow explicit `adaptive` in spawn flows and preserve it through root session creation
- add regression coverage for chat effort selection, spawn dialog behavior, and root spawn plumbing

## Notes
- `adaptive` is treated as a thinking level, not as a synthetic model entry
- keeps the inherited/default behavior from #255 intact

## Test Plan
- [x] `npm run lint`
- [x] `node node_modules/vitest/vitest.mjs --run src/features/chat/components/useModelEffort.test.ts src/features/sessions/SpawnAgentDialog.test.tsx src/contexts/SessionContext.test.tsx`
- [x] `node node_modules/typescript/bin/tsc -b`
- [x] `node node_modules/vite/bin/vite.js build`
- [x] `node node_modules/typescript/bin/tsc -p config/tsconfig.server.json --outDir server-dist --noEmit false --declaration false`
- [x] `node node_modules/typescript/bin/tsc -p config/tsconfig.bin.json`
- [x] manual smoke test in local Nerve deploy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "adaptive" thinking level option for model reasoning
  * Added "Default" option to use inherited thinking settings

* **Bug Fixes**
  * Improved thinking level override behavior when reverting to inherited defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->