### PR TITLE
feat(file-browser): open compact drawer from edge swipe

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -899,6 +899,87 @@ describe('App kanban visibility gating', () => {
     expect(screen.getByTestId('command-palette-state')).toHaveTextContent('open');
   });
 
+  it('opens the compact file browser from a left-edge touch swipe', async () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === '(max-width: 900px)',
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    render(<App />);
+
+    expect(screen.queryByTestId('file-tree-panel')).not.toBeInTheDocument();
+
+    const swipeZone = screen.getByTestId('file-browser-swipe-zone');
+    await act(async () => {
+      fireEvent.pointerDown(swipeZone, {
+        pointerType: 'touch',
+        pointerId: 11,
+        clientX: 8,
+        clientY: 120,
+      });
+      fireEvent.pointerMove(swipeZone, {
+        pointerType: 'touch',
+        pointerId: 11,
+        clientX: 92,
+        clientY: 126,
+      });
+    });
+
+    expect(await screen.findByTestId('file-tree-panel')).toBeInTheDocument();
+  });
+
+  it('does not open the compact file browser when a left-edge touch gesture turns into a vertical move', async () => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === '(max-width: 900px)',
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    render(<App />);
+    await act(async () => {});
+
+    const swipeZone = screen.getByTestId('file-browser-swipe-zone');
+    await act(async () => {
+      fireEvent.pointerDown(swipeZone, {
+        pointerType: 'touch',
+        pointerId: 12,
+        clientX: 10,
+        clientY: 100,
+      });
+      fireEvent.pointerMove(swipeZone, {
+        pointerType: 'touch',
+        pointerId: 12,
+        clientX: 24,
+        clientY: 154,
+      });
+      fireEvent.pointerUp(swipeZone, {
+        pointerType: 'touch',
+        pointerId: 12,
+        clientX: 24,
+        clientY: 154,
+      });
+    });
+
+    expect(screen.queryByTestId('file-tree-panel')).not.toBeInTheDocument();
+  });
+
   it('hides the chatbox command trigger when the appearance toggle is disabled', () => {
     settingsContext.commandPaletteButtonVisible = false;
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -918,7 +918,7 @@ describe('App kanban visibility gating', () => {
 
     expect(screen.queryByTestId('file-tree-panel')).not.toBeInTheDocument();
 
-    const swipeZone = screen.getByTestId('file-browser-swipe-zone');
+    const swipeZone = screen.getByTestId('app-shell');
     await act(async () => {
       fireEvent.pointerDown(swipeZone, {
         pointerType: 'touch',
@@ -955,7 +955,7 @@ describe('App kanban visibility gating', () => {
     render(<App />);
     await act(async () => {});
 
-    const swipeZone = screen.getByTestId('file-browser-swipe-zone');
+    const swipeZone = screen.getByTestId('app-shell');
     await act(async () => {
       fireEvent.pointerDown(swipeZone, {
         pointerType: 'touch',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -921,7 +921,15 @@ export default function App({ onLogout }: AppProps) {
   });
 
   return (
-    <div className="scan-lines relative h-screen flex flex-col overflow-hidden" data-booted={booted}>
+    <div
+      className="scan-lines relative h-screen flex flex-col overflow-hidden"
+      data-booted={booted}
+      data-testid="app-shell"
+      onPointerDownCapture={compactFileBrowserSwipe.bind.onPointerDown}
+      onPointerMoveCapture={compactFileBrowserSwipe.bind.onPointerMove}
+      onPointerUpCapture={compactFileBrowserSwipe.bind.onPointerUp}
+      onPointerCancelCapture={compactFileBrowserSwipe.bind.onPointerCancel}
+    >
       {/* Skip to main content link for keyboard navigation */}
       <a 
         href="#main-chat" 
@@ -1056,19 +1064,6 @@ export default function App({ onLogout }: AppProps) {
               />
             </PanelErrorBoundary>
           </div>
-        )}
-
-        {compactFileBrowserSwipeEnabled && (
-          <div
-            data-testid="file-browser-swipe-zone"
-            aria-hidden="true"
-            className="fixed inset-y-0 left-0 z-20 hidden w-6 max-[900px]:block"
-            style={{ touchAction: 'pan-y' }}
-            onPointerDown={compactFileBrowserSwipe.bind.onPointerDown}
-            onPointerMove={compactFileBrowserSwipe.bind.onPointerMove}
-            onPointerUp={compactFileBrowserSwipe.bind.onPointerUp}
-            onPointerCancel={compactFileBrowserSwipe.bind.onPointerCancel}
-          />
         )}
 
         {showCompactFileBrowser && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -908,13 +908,16 @@ export default function App({ onLogout }: AppProps) {
   );
 
   const showCompactFileBrowser = isCompactLayout && viewMode !== 'kanban' && !fileBrowserCollapsed;
+  const handleOpenCompactFileBrowserFromSwipe = useCallback(() => {
+    setFileBrowserCollapsed(false);
+  }, [setFileBrowserCollapsed]);
   const compactFileBrowserSwipeEnabled =
     isCompactLayout &&
     viewMode !== 'kanban' &&
     fileBrowserCollapsed;
   const compactFileBrowserSwipe = useEdgeSwipeToOpen({
     enabled: compactFileBrowserSwipeEnabled,
-    onOpen: () => setFileBrowserCollapsed(false),
+    onOpen: handleOpenCompactFileBrowserFromSwipe,
   });
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ import { PanelErrorBoundary } from '@/components/PanelErrorBoundary';
 import { SpawnAgentDialog } from '@/features/sessions/SpawnAgentDialog';
 import { DEFAULT_CHAT_PATH_LINKS_CONFIG, parseChatPathLinksConfig } from '@/features/chat/chatPathLinks';
 import { FileTreePanel, TabbedContentArea, useOpenFiles, type FileTreeChangeEvent } from '@/features/file-browser';
+import { useEdgeSwipeToOpen } from '@/features/file-browser/hooks/useEdgeSwipeToOpen';
 import { type BeadLinkTarget, type OpenBeadTab, buildBeadTabId } from '@/features/beads';
 import { isImageFile } from '@/features/file-browser/utils/fileTypes';
 import { buildAgentRootSessionKey, getSessionDisplayLabel } from '@/features/sessions/sessionKeys';
@@ -907,6 +908,14 @@ export default function App({ onLogout }: AppProps) {
   );
 
   const showCompactFileBrowser = isCompactLayout && viewMode !== 'kanban' && !fileBrowserCollapsed;
+  const compactFileBrowserSwipeEnabled =
+    isCompactLayout &&
+    viewMode !== 'kanban' &&
+    fileBrowserCollapsed;
+  const compactFileBrowserSwipe = useEdgeSwipeToOpen({
+    enabled: compactFileBrowserSwipeEnabled,
+    onOpen: () => setFileBrowserCollapsed(false),
+  });
 
   return (
     <div className="scan-lines relative h-screen flex flex-col overflow-hidden" data-booted={booted}>
@@ -1044,6 +1053,19 @@ export default function App({ onLogout }: AppProps) {
               />
             </PanelErrorBoundary>
           </div>
+        )}
+
+        {compactFileBrowserSwipeEnabled && (
+          <div
+            data-testid="file-browser-swipe-zone"
+            aria-hidden="true"
+            className="fixed inset-y-0 left-0 z-20 hidden w-6 max-[900px]:block"
+            style={{ touchAction: 'pan-y' }}
+            onPointerDown={compactFileBrowserSwipe.bind.onPointerDown}
+            onPointerMove={compactFileBrowserSwipe.bind.onPointerMove}
+            onPointerUp={compactFileBrowserSwipe.bind.onPointerUp}
+            onPointerCancel={compactFileBrowserSwipe.bind.onPointerCancel}
+          />
         )}
 
         {showCompactFileBrowser && (

--- a/src/features/file-browser/hooks/useEdgeSwipeToOpen.test.ts
+++ b/src/features/file-browser/hooks/useEdgeSwipeToOpen.test.ts
@@ -1,0 +1,115 @@
+import type React from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useEdgeSwipeToOpen } from './useEdgeSwipeToOpen';
+
+function createPointerEvent(overrides: Partial<React.PointerEvent<HTMLDivElement>> = {}) {
+  return {
+    pointerType: 'touch',
+    pointerId: 1,
+    clientX: 0,
+    clientY: 0,
+    currentTarget: {
+      setPointerCapture: vi.fn(),
+      releasePointerCapture: vi.fn(),
+    },
+    ...overrides,
+  } as unknown as React.PointerEvent<HTMLDivElement>;
+}
+
+describe('useEdgeSwipeToOpen', () => {
+  it('opens after a touch swipe that starts inside the left edge zone and crosses the threshold', () => {
+    const onOpen = vi.fn();
+    const { result } = renderHook(() => useEdgeSwipeToOpen({ enabled: true, onOpen }));
+
+    act(() => {
+      result.current.bind.onPointerDown(createPointerEvent({
+        clientX: 12,
+        clientY: 40,
+      }));
+    });
+
+    act(() => {
+      result.current.bind.onPointerMove(createPointerEvent({
+        clientX: 92,
+        clientY: 44,
+      }));
+    });
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not open when the gesture starts away from the left edge', () => {
+    const onOpen = vi.fn();
+    const { result } = renderHook(() => useEdgeSwipeToOpen({ enabled: true, onOpen }));
+
+    act(() => {
+      result.current.bind.onPointerDown(createPointerEvent({
+        clientX: 48,
+        clientY: 40,
+      }));
+    });
+
+    act(() => {
+      result.current.bind.onPointerMove(createPointerEvent({
+        clientX: 140,
+        clientY: 44,
+      }));
+    });
+
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('cancels the gesture when vertical drift exceeds tolerance', () => {
+    const onOpen = vi.fn();
+    const { result } = renderHook(() => useEdgeSwipeToOpen({ enabled: true, onOpen }));
+
+    act(() => {
+      result.current.bind.onPointerDown(createPointerEvent({
+        clientX: 10,
+        clientY: 20,
+      }));
+    });
+
+    act(() => {
+      result.current.bind.onPointerMove(createPointerEvent({
+        clientX: 45,
+        clientY: 72,
+      }));
+    });
+
+    act(() => {
+      result.current.bind.onPointerMove(createPointerEvent({
+        clientX: 110,
+        clientY: 74,
+      }));
+    });
+
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(result.current.swipeActive).toBe(false);
+    expect(result.current.swipeOffsetPx).toBe(0);
+  });
+
+  it('ignores non-touch pointers', () => {
+    const onOpen = vi.fn();
+    const { result } = renderHook(() => useEdgeSwipeToOpen({ enabled: true, onOpen }));
+
+    act(() => {
+      result.current.bind.onPointerDown(createPointerEvent({
+        pointerType: 'mouse',
+        clientX: 8,
+        clientY: 30,
+      }));
+    });
+
+    act(() => {
+      result.current.bind.onPointerMove(createPointerEvent({
+        pointerType: 'mouse',
+        clientX: 120,
+        clientY: 30,
+      }));
+    });
+
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/file-browser/hooks/useEdgeSwipeToOpen.test.ts
+++ b/src/features/file-browser/hooks/useEdgeSwipeToOpen.test.ts
@@ -86,8 +86,6 @@ describe('useEdgeSwipeToOpen', () => {
     });
 
     expect(onOpen).not.toHaveBeenCalled();
-    expect(result.current.swipeActive).toBe(false);
-    expect(result.current.swipeOffsetPx).toBe(0);
   });
 
   it('ignores non-touch pointers', () => {
@@ -111,5 +109,36 @@ describe('useEdgeSwipeToOpen', () => {
     });
 
     expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it('does not cancel an active swipe when a second touch starts', () => {
+    const onOpen = vi.fn();
+    const { result } = renderHook(() => useEdgeSwipeToOpen({ enabled: true, onOpen }));
+
+    act(() => {
+      result.current.bind.onPointerDown(createPointerEvent({
+        pointerId: 1,
+        clientX: 10,
+        clientY: 20,
+      }));
+    });
+
+    act(() => {
+      result.current.bind.onPointerDown(createPointerEvent({
+        pointerId: 2,
+        clientX: 12,
+        clientY: 22,
+      }));
+    });
+
+    act(() => {
+      result.current.bind.onPointerMove(createPointerEvent({
+        pointerId: 1,
+        clientX: 96,
+        clientY: 24,
+      }));
+    });
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/features/file-browser/hooks/useEdgeSwipeToOpen.test.ts
+++ b/src/features/file-browser/hooks/useEdgeSwipeToOpen.test.ts
@@ -141,4 +141,40 @@ describe('useEdgeSwipeToOpen', () => {
 
     expect(onOpen).toHaveBeenCalledTimes(1);
   });
+
+  it('releases pointer capture and clears gesture state when disabled mid-swipe', () => {
+    const onOpen = vi.fn();
+    const releasePointerCapture = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useEdgeSwipeToOpen({ enabled, onOpen }),
+      { initialProps: { enabled: true } },
+    );
+
+    act(() => {
+      result.current.bind.onPointerDown(createPointerEvent({
+        pointerId: 7,
+        clientX: 10,
+        clientY: 20,
+        currentTarget: {
+          setPointerCapture: vi.fn(),
+          releasePointerCapture,
+        },
+      }));
+    });
+
+    act(() => {
+      rerender({ enabled: false });
+    });
+
+    act(() => {
+      result.current.bind.onPointerMove(createPointerEvent({
+        pointerId: 7,
+        clientX: 100,
+        clientY: 24,
+      }));
+    });
+
+    expect(releasePointerCapture).toHaveBeenCalledWith(7);
+    expect(onOpen).not.toHaveBeenCalled();
+  });
 });

--- a/src/features/file-browser/hooks/useEdgeSwipeToOpen.ts
+++ b/src/features/file-browser/hooks/useEdgeSwipeToOpen.ts
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 const EDGE_SWIPE_ZONE_PX = 24;
 const OPEN_THRESHOLD_PX = 72;
@@ -27,11 +27,28 @@ export function useEdgeSwipeToOpen({
 }: UseEdgeSwipeToOpenOptions): UseEdgeSwipeToOpenResult {
   const pointerIdRef = useRef<number | null>(null);
   const startRef = useRef<{ x: number; y: number } | null>(null);
+  const capturedTargetRef = useRef<HTMLDivElement | null>(null);
 
   const reset = useCallback(() => {
+    if (pointerIdRef.current !== null && capturedTargetRef.current) {
+      try {
+        capturedTargetRef.current.releasePointerCapture(pointerIdRef.current);
+      } catch {
+        // Pointer capture may already be released or unavailable.
+      }
+    }
     pointerIdRef.current = null;
     startRef.current = null;
+    capturedTargetRef.current = null;
   }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      reset();
+    }
+  }, [enabled, reset]);
+
+  useEffect(() => reset, [reset]);
 
   const onPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     if (!enabled || event.pointerType !== 'touch' || event.clientX > EDGE_SWIPE_ZONE_PX) return;
@@ -44,6 +61,7 @@ export function useEdgeSwipeToOpen({
 
     try {
       event.currentTarget.setPointerCapture(event.pointerId);
+      capturedTargetRef.current = event.currentTarget;
     } catch {
       // Pointer capture is unavailable in some test environments.
     }

--- a/src/features/file-browser/hooks/useEdgeSwipeToOpen.ts
+++ b/src/features/file-browser/hooks/useEdgeSwipeToOpen.ts
@@ -1,0 +1,98 @@
+import type React from 'react';
+import { useCallback, useRef, useState } from 'react';
+
+const EDGE_SWIPE_ZONE_PX = 24;
+const OPEN_THRESHOLD_PX = 72;
+const MAX_VERTICAL_DRIFT_PX = 36;
+
+interface EdgeSwipeBindings {
+  onPointerDown: (event: React.PointerEvent<HTMLDivElement>) => void;
+  onPointerMove: (event: React.PointerEvent<HTMLDivElement>) => void;
+  onPointerUp: (event: React.PointerEvent<HTMLDivElement>) => void;
+  onPointerCancel: (event: React.PointerEvent<HTMLDivElement>) => void;
+}
+
+interface UseEdgeSwipeToOpenOptions {
+  enabled: boolean;
+  onOpen: () => void;
+}
+
+interface UseEdgeSwipeToOpenResult {
+  bind: EdgeSwipeBindings;
+  swipeOffsetPx: number;
+  swipeActive: boolean;
+}
+
+export function useEdgeSwipeToOpen({
+  enabled,
+  onOpen,
+}: UseEdgeSwipeToOpenOptions): UseEdgeSwipeToOpenResult {
+  const pointerIdRef = useRef<number | null>(null);
+  const startRef = useRef<{ x: number; y: number } | null>(null);
+  const openedRef = useRef(false);
+  const [swipeOffsetPx, setSwipeOffsetPx] = useState(0);
+  const [swipeActive, setSwipeActive] = useState(false);
+
+  const reset = useCallback(() => {
+    pointerIdRef.current = null;
+    startRef.current = null;
+    openedRef.current = false;
+    setSwipeOffsetPx(0);
+    setSwipeActive(false);
+  }, []);
+
+  const onPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    reset();
+    if (!enabled || event.pointerType !== 'touch' || event.clientX > EDGE_SWIPE_ZONE_PX) return;
+
+    pointerIdRef.current = event.pointerId;
+    startRef.current = { x: event.clientX, y: event.clientY };
+    setSwipeActive(true);
+
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    } catch {
+      // Pointer capture is unavailable in some test environments.
+    }
+  }, [enabled, reset]);
+
+  const onPointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (!enabled || event.pointerType !== 'touch') return;
+    if (pointerIdRef.current !== event.pointerId || !startRef.current || openedRef.current) return;
+
+    const dx = event.clientX - startRef.current.x;
+    const dy = event.clientY - startRef.current.y;
+
+    if (Math.abs(dy) > MAX_VERTICAL_DRIFT_PX) {
+      reset();
+      return;
+    }
+
+    const nextOffset = Math.max(0, dx);
+    setSwipeOffsetPx(Math.min(nextOffset, OPEN_THRESHOLD_PX));
+
+    if (nextOffset >= OPEN_THRESHOLD_PX) {
+      openedRef.current = true;
+      onOpen();
+      reset();
+    }
+  }, [enabled, onOpen, reset]);
+
+  const onPointerUp = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (pointerIdRef.current === event.pointerId) {
+      reset();
+    }
+  }, [reset]);
+
+  const onPointerCancel = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (pointerIdRef.current === event.pointerId) {
+      reset();
+    }
+  }, [reset]);
+
+  return {
+    bind: { onPointerDown, onPointerMove, onPointerUp, onPointerCancel },
+    swipeOffsetPx,
+    swipeActive,
+  };
+}

--- a/src/features/file-browser/hooks/useEdgeSwipeToOpen.ts
+++ b/src/features/file-browser/hooks/useEdgeSwipeToOpen.ts
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
 const EDGE_SWIPE_ZONE_PX = 24;
 const OPEN_THRESHOLD_PX = 72;
@@ -19,8 +19,6 @@ interface UseEdgeSwipeToOpenOptions {
 
 interface UseEdgeSwipeToOpenResult {
   bind: EdgeSwipeBindings;
-  swipeOffsetPx: number;
-  swipeActive: boolean;
 }
 
 export function useEdgeSwipeToOpen({
@@ -29,25 +27,20 @@ export function useEdgeSwipeToOpen({
 }: UseEdgeSwipeToOpenOptions): UseEdgeSwipeToOpenResult {
   const pointerIdRef = useRef<number | null>(null);
   const startRef = useRef<{ x: number; y: number } | null>(null);
-  const openedRef = useRef(false);
-  const [swipeOffsetPx, setSwipeOffsetPx] = useState(0);
-  const [swipeActive, setSwipeActive] = useState(false);
 
   const reset = useCallback(() => {
     pointerIdRef.current = null;
     startRef.current = null;
-    openedRef.current = false;
-    setSwipeOffsetPx(0);
-    setSwipeActive(false);
   }, []);
 
   const onPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-    reset();
     if (!enabled || event.pointerType !== 'touch' || event.clientX > EDGE_SWIPE_ZONE_PX) return;
+    if (pointerIdRef.current !== null) return;
+
+    reset();
 
     pointerIdRef.current = event.pointerId;
     startRef.current = { x: event.clientX, y: event.clientY };
-    setSwipeActive(true);
 
     try {
       event.currentTarget.setPointerCapture(event.pointerId);
@@ -58,7 +51,7 @@ export function useEdgeSwipeToOpen({
 
   const onPointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     if (!enabled || event.pointerType !== 'touch') return;
-    if (pointerIdRef.current !== event.pointerId || !startRef.current || openedRef.current) return;
+    if (pointerIdRef.current !== event.pointerId || !startRef.current) return;
 
     const dx = event.clientX - startRef.current.x;
     const dy = event.clientY - startRef.current.y;
@@ -68,11 +61,7 @@ export function useEdgeSwipeToOpen({
       return;
     }
 
-    const nextOffset = Math.max(0, dx);
-    setSwipeOffsetPx(Math.min(nextOffset, OPEN_THRESHOLD_PX));
-
-    if (nextOffset >= OPEN_THRESHOLD_PX) {
-      openedRef.current = true;
+    if (dx >= OPEN_THRESHOLD_PX) {
       onOpen();
       reset();
     }
@@ -90,9 +79,14 @@ export function useEdgeSwipeToOpen({
     }
   }, [reset]);
 
+  const bind = useMemo<EdgeSwipeBindings>(() => ({
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel,
+  }), [onPointerCancel, onPointerDown, onPointerMove, onPointerUp]);
+
   return {
-    bind: { onPointerDown, onPointerMove, onPointerUp, onPointerCancel },
-    swipeOffsetPx,
-    swipeActive,
+    bind,
   };
 }


### PR DESCRIPTION
## What

Add a compact-layout left-edge touch swipe gesture that opens the file explorer drawer.

## Why

This gives touchscreen users a second way to open the compact file browser without removing or changing the existing button-based toggle.

## How

- add a `useEdgeSwipeToOpen` hook in `src/features/file-browser/hooks/` to detect a narrow left-edge touch swipe and call the drawer opener only after a deliberate horizontal threshold
- wire that hook into `src/App.tsx`, where compact layout and drawer visibility already live, and render a compact-only swipe zone when the drawer is collapsed
- keep the existing header button toggle unchanged
- add hook-level and App-level regression tests for swipe-open, vertical-cancel, and secondary-touch behavior

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [x] New features include tests
- [ ] UI changes include a screenshot or screen recording

## Screenshots

Not included. The change is a touch gesture opener and was verified through automated tests and live service validation.

## Test Evidence

- `npm run lint`
- `npm run build`
- `npm run build:server`
- `npm test -- --run`

Full test result from the latest run:
- `139` test files passed
- `1814` tests passed

Notes:
- Existing unrelated React `act(...)` warnings still appear in the suite, but the run exits successfully.
- Contributor guide item about opening an issue first for non-trivial changes was not satisfied in this workflow; no issue was linked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Left-edge swipe to open the file browser in compact layout (disabled in kanban view). Swipe must start at the left edge and be predominantly horizontal.

* **Tests**
  * Added end-to-end and unit tests covering swipe opening, vertical-drift cancellation, non-touch ignoring, multi-touch handling, disabling mid-swipe, and app-level visibility gating for compact layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->