### PR TITLE
feat(file-browser): move compact actions to kebab buttons

### DIFF
--- a/src/features/file-browser/FileTreeNode.test.tsx
+++ b/src/features/file-browser/FileTreeNode.test.tsx
@@ -30,6 +30,7 @@ type RenderNodeOverrides = Partial<{
   entry: TreeEntry;
   compact: boolean;
   onOpenActions: (entry: TreeEntry, anchorRect: DOMRect) => void;
+  onContextMenu: (entry: TreeEntry, event: React.MouseEvent) => void;
   onSelect: (path: string) => void;
   onToggleDir: (path: string) => void;
 }>;
@@ -143,6 +144,20 @@ describe('FileTreeNode', () => {
 
     const label = `Open actions for ${entry.name}`;
     expect(screen.queryByRole('button', { name: label })).toBeNull();
+  });
+
+  it('suppresses the browser context menu on the compact actions button', () => {
+    const onContextMenu = vi.fn();
+    renderNode({
+      compact: true,
+      onOpenActions: vi.fn(),
+      onContextMenu,
+    });
+
+    const button = screen.getByRole('button', { name: `Open actions for ${entry.name}` });
+
+    expect(fireEvent.contextMenu(button)).toBe(false);
+    expect(onContextMenu).not.toHaveBeenCalled();
   });
 
   it('uses a shrinkable filename region so compact actions remain accessible on narrow rows', () => {

--- a/src/features/file-browser/FileTreeNode.test.tsx
+++ b/src/features/file-browser/FileTreeNode.test.tsx
@@ -160,6 +160,22 @@ describe('FileTreeNode', () => {
     expect(onContextMenu).not.toHaveBeenCalled();
   });
 
+  it('does not let Enter on the compact actions button trigger the row key handler', () => {
+    const onToggleDir = vi.fn();
+    renderNode({
+      entry: directoryEntry,
+      compact: true,
+      onOpenActions: vi.fn(),
+      onToggleDir,
+    });
+
+    const button = screen.getByRole('button', { name: `Open actions for ${directoryEntry.name}` });
+
+    fireEvent.keyDown(button, { key: 'Enter' });
+
+    expect(onToggleDir).not.toHaveBeenCalled();
+  });
+
   it('uses a shrinkable filename region so compact actions remain accessible on narrow rows', () => {
     renderNode({
       compact: true,

--- a/src/features/file-browser/FileTreeNode.test.tsx
+++ b/src/features/file-browser/FileTreeNode.test.tsx
@@ -21,6 +21,12 @@ const entry: TreeEntry = {
   children: null,
 };
 
+const directoryEntry: TreeEntry = {
+  ...entry,
+  type: 'directory',
+  children: [],
+};
+
 function renderNode(overrides: Partial<React.ComponentProps<typeof FileTreeNode>> = {}) {
   return render(
     <FileTreeNode
@@ -86,5 +92,49 @@ describe('FileTreeNode', () => {
     });
 
     expect(row.setPointerCapture).not.toHaveBeenCalled();
+  });
+
+  it('renders compact actions button that opens actions without selecting the row', () => {
+    const onSelect = vi.fn();
+    const onToggleDir = vi.fn();
+    const onOpenActions = vi.fn();
+    renderNode({
+      entry: directoryEntry,
+      compact: true,
+      onSelect,
+      onToggleDir,
+      onOpenActions,
+    });
+
+    const label = `Open actions for ${directoryEntry.name}`;
+    const button = screen.getByRole('button', { name: label });
+    const anchorRect = {
+      x: 1,
+      y: 2,
+      width: 3,
+      height: 4,
+      top: 1,
+      left: 2,
+      bottom: 5,
+      right: 6,
+      toJSON: () => ({}),
+    } as DOMRect;
+    Object.defineProperty(button, 'getBoundingClientRect', {
+      value: () => anchorRect,
+    });
+
+    fireEvent.click(button);
+
+    expect(onOpenActions).toHaveBeenCalledWith(directoryEntry, anchorRect);
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(onToggleDir).not.toHaveBeenCalled();
+  });
+
+  it('does not render compact actions button outside compact mode', () => {
+    const onOpenActions = vi.fn();
+    renderNode({ onOpenActions });
+
+    const label = `Open actions for ${entry.name}`;
+    expect(screen.queryByRole('button', { name: label })).toBeNull();
   });
 });

--- a/src/features/file-browser/FileTreeNode.test.tsx
+++ b/src/features/file-browser/FileTreeNode.test.tsx
@@ -1,4 +1,3 @@
-import type React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { FileTreeNode } from './FileTreeNode';
@@ -27,7 +26,15 @@ const directoryEntry: TreeEntry = {
   children: [],
 };
 
-function renderNode(overrides: Partial<React.ComponentProps<typeof FileTreeNode>> = {}) {
+type RenderNodeOverrides = Partial<{
+  entry: TreeEntry;
+  compact: boolean;
+  onOpenActions: (entry: TreeEntry, anchorRect: DOMRect) => void;
+  onSelect: (path: string) => void;
+  onToggleDir: (path: string) => void;
+}>;
+
+function renderNode(overrides: RenderNodeOverrides = {}) {
   return render(
     <FileTreeNode
       entry={entry}

--- a/src/features/file-browser/FileTreeNode.test.tsx
+++ b/src/features/file-browser/FileTreeNode.test.tsx
@@ -144,4 +144,13 @@ describe('FileTreeNode', () => {
     const label = `Open actions for ${entry.name}`;
     expect(screen.queryByRole('button', { name: label })).toBeNull();
   });
+
+  it('uses a shrinkable filename region so compact actions remain accessible on narrow rows', () => {
+    renderNode({
+      compact: true,
+      onOpenActions: vi.fn(),
+    });
+
+    expect(screen.getByText(entry.name)).toHaveClass('flex-1', 'min-w-0', 'truncate');
+  });
 });

--- a/src/features/file-browser/FileTreeNode.tsx
+++ b/src/features/file-browser/FileTreeNode.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { ChevronRight, ChevronDown, Loader2 } from 'lucide-react';
+import { ChevronRight, ChevronDown, EllipsisVertical, Loader2 } from 'lucide-react';
 import { FileIcon, FolderIcon } from './utils/fileIcons';
 import { isImageFile, isPdfFile } from './utils/fileTypes';
 import type { TreeEntry } from './types';
@@ -30,6 +30,8 @@ interface FileTreeNodeProps {
   onRenameChange: (value: string) => void;
   onRenameCommit: () => void;
   onRenameCancel: () => void;
+  compact?: boolean;
+  onOpenActions?: (entry: TreeEntry, anchorRect: DOMRect) => void;
 }
 
 export function FileTreeNode({
@@ -55,6 +57,8 @@ export function FileTreeNode({
   onRenameChange,
   onRenameCommit,
   onRenameCancel,
+  compact,
+  onOpenActions,
 }: FileTreeNodeProps) {
   const longPressTimerRef = useRef<number | null>(null);
   const touchStartRef = useRef<{ x: number; y: number } | null>(null);
@@ -69,6 +73,7 @@ export function FileTreeNode({
   const canDrag = entry.path !== '.trash' && !isRenaming;
   const isDropTarget = isDir && dropTargetPath === entry.path;
   const isDragSource = dragSourcePath === entry.path;
+  const showCompactActions = compact && onOpenActions && !isRenaming;
 
   const clearLongPress = () => {
     if (longPressTimerRef.current !== null) {
@@ -154,6 +159,19 @@ export function FileTreeNode({
     }
   };
 
+  const handleActionsClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onOpenActions?.(entry, event.currentTarget.getBoundingClientRect());
+  };
+
+  const handleActionsPointerDown = (event: React.PointerEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+  };
+
+  const handleActionsContextMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+  };
+
   return (
     <div role="treeitem" aria-expanded={isDir ? isExpanded : undefined} aria-selected={isSelected}>
       <div
@@ -230,6 +248,20 @@ export function FileTreeNode({
         ) : (
           <span className="truncate">{entry.name}</span>
         )}
+        {showCompactActions && (
+          <button
+            type="button"
+            className="ml-auto flex-shrink-0 p-0 text-muted-foreground hover:text-foreground"
+            aria-label={`Open actions for ${entry.name}`}
+            title={`Open actions for ${entry.name}`}
+            draggable={false}
+            onClick={handleActionsClick}
+            onPointerDown={handleActionsPointerDown}
+            onContextMenu={handleActionsContextMenu}
+          >
+            <EllipsisVertical size={16} />
+          </button>
+        )}
       </div>
 
       {/* Children */}
@@ -260,6 +292,8 @@ export function FileTreeNode({
               onRenameChange={onRenameChange}
               onRenameCommit={onRenameCommit}
               onRenameCancel={onRenameCancel}
+              compact={compact}
+              onOpenActions={onOpenActions}
             />
           ))}
         </div>

--- a/src/features/file-browser/FileTreeNode.tsx
+++ b/src/features/file-browser/FileTreeNode.tsx
@@ -169,6 +169,7 @@ export function FileTreeNode({
   };
 
   const handleActionsContextMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
     event.stopPropagation();
   };
 

--- a/src/features/file-browser/FileTreeNode.tsx
+++ b/src/features/file-browser/FileTreeNode.tsx
@@ -172,6 +172,10 @@ export function FileTreeNode({
     event.stopPropagation();
   };
 
+  const handleActionsKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+  };
+
   const handleActionsContextMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
@@ -263,6 +267,7 @@ export function FileTreeNode({
             onClick={handleActionsClick}
             onPointerDown={handleActionsPointerDown}
             onMouseDown={handleActionsMouseDown}
+            onKeyDown={handleActionsKeyDown}
             onContextMenu={handleActionsContextMenu}
           >
             <EllipsisVertical size={16} />

--- a/src/features/file-browser/FileTreeNode.tsx
+++ b/src/features/file-browser/FileTreeNode.tsx
@@ -168,6 +168,10 @@ export function FileTreeNode({
     event.stopPropagation();
   };
 
+  const handleActionsMouseDown = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+  };
+
   const handleActionsContextMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
@@ -258,6 +262,7 @@ export function FileTreeNode({
             draggable={false}
             onClick={handleActionsClick}
             onPointerDown={handleActionsPointerDown}
+            onMouseDown={handleActionsMouseDown}
             onContextMenu={handleActionsContextMenu}
           >
             <EllipsisVertical size={16} />

--- a/src/features/file-browser/FileTreeNode.tsx
+++ b/src/features/file-browser/FileTreeNode.tsx
@@ -246,7 +246,7 @@ export function FileTreeNode({
             className="flex-1 min-w-0 bg-background border border-border/60 px-1 py-0 text-[0.8rem] leading-5 text-foreground focus:outline-none focus:border-primary"
           />
         ) : (
-          <span className="truncate">{entry.name}</span>
+          <span className="flex-1 min-w-0 truncate">{entry.name}</span>
         )}
         {showCompactActions && (
           <button

--- a/src/features/file-browser/FileTreePanel.test.tsx
+++ b/src/features/file-browser/FileTreePanel.test.tsx
@@ -210,6 +210,76 @@ describe('FileTreePanel', () => {
   });
 
   describe('context menu add to chat', () => {
+    it('opens the shared row menu from a compact actions button without selecting the row', async () => {
+      render(
+        <FileTreePanel
+          workspaceAgentId="agent-a"
+          onOpenFile={mockOnOpenFile}
+          onAddToChat={mockOnAddToChat}
+          addToChatEnabled={true}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+          isCompactLayout={true}
+          collapsed={false}
+          onCollapseChange={vi.fn()}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Open actions for package.json' }));
+
+      expect(await screen.findByText('Rename')).toBeInTheDocument();
+      expect(defaultMockHook.selectFile).not.toHaveBeenCalled();
+    });
+
+    it('does not toggle a directory when its compact actions button is clicked', async () => {
+      render(
+        <FileTreePanel
+          workspaceAgentId="agent-a"
+          onOpenFile={mockOnOpenFile}
+          onAddToChat={mockOnAddToChat}
+          addToChatEnabled={true}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+          isCompactLayout={true}
+          collapsed={false}
+          onCollapseChange={vi.fn()}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Open actions for src' }));
+
+      expect(await screen.findByText('Rename')).toBeInTheDocument();
+      expect(defaultMockHook.toggleDirectory).not.toHaveBeenCalled();
+    });
+
+    it('does not open the shared row menu from touch long press in compact layout', async () => {
+      vi.useFakeTimers();
+
+      render(
+        <FileTreePanel
+          workspaceAgentId="agent-a"
+          onOpenFile={mockOnOpenFile}
+          onAddToChat={mockOnAddToChat}
+          addToChatEnabled={true}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+          isCompactLayout={true}
+          collapsed={false}
+          onCollapseChange={vi.fn()}
+        />
+      );
+
+      const row = screen.getByTitle('package.json');
+      fireEvent.pointerDown(row, { pointerType: 'touch', clientX: 24, clientY: 32, pointerId: 11 });
+      await act(async () => {
+        vi.advanceTimersByTime(500);
+      });
+      fireEvent.pointerUp(row, { pointerType: 'touch', clientX: 24, clientY: 32, pointerId: 11 });
+
+      expect(screen.queryByText('Add to chat')).not.toBeInTheDocument();
+      expect(screen.queryByText('Rename')).not.toBeInTheDocument();
+    });
+
     it('opens the shared row menu on touch release after a long press without triggering file open', async () => {
       vi.useFakeTimers();
 

--- a/src/features/file-browser/FileTreePanel.test.tsx
+++ b/src/features/file-browser/FileTreePanel.test.tsx
@@ -280,6 +280,34 @@ describe('FileTreePanel', () => {
       expect(screen.queryByText('Rename')).not.toBeInTheDocument();
     });
 
+    it('closes the shared row menu when the same compact actions button is clicked again', async () => {
+      render(
+        <FileTreePanel
+          workspaceAgentId="agent-a"
+          onOpenFile={mockOnOpenFile}
+          onAddToChat={mockOnAddToChat}
+          addToChatEnabled={true}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+          isCompactLayout={true}
+          collapsed={false}
+          onCollapseChange={vi.fn()}
+        />
+      );
+
+      const button = screen.getByRole('button', { name: 'Open actions for package.json' });
+
+      fireEvent.click(button);
+      expect(await screen.findByText('Rename')).toBeInTheDocument();
+
+      fireEvent.mouseDown(button);
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Rename')).not.toBeInTheDocument();
+      });
+    });
+
     it('opens the shared row menu on touch release after a long press without triggering file open', async () => {
       vi.useFakeTimers();
 

--- a/src/features/file-browser/FileTreePanel.tsx
+++ b/src/features/file-browser/FileTreePanel.tsx
@@ -501,14 +501,25 @@ export function FileTreePanel({
   }, [selectFile, workspaceAgentId]);
 
   const openCompactActionsMenu = useCallback((entry: TreeEntry, anchorRect: DOMRect) => {
-    contextMenuSessionIdRef.current += 1;
-    setContextMenu({
-      agentId: workspaceAgentId,
-      sessionId: contextMenuSessionIdRef.current,
-      x: anchorRect.right - MENU_CURSOR_OFFSET,
-      y: anchorRect.bottom + MENU_VIEWPORT_PADDING,
-      entry,
-      source: 'mouse',
+    setContextMenu((currentContextMenu) => {
+      if (
+        currentContextMenu
+        && currentContextMenu.agentId === workspaceAgentId
+        && currentContextMenu.source === 'mouse'
+        && currentContextMenu.entry.path === entry.path
+      ) {
+        return null;
+      }
+
+      contextMenuSessionIdRef.current += 1;
+      return {
+        agentId: workspaceAgentId,
+        sessionId: contextMenuSessionIdRef.current,
+        x: anchorRect.right - MENU_CURSOR_OFFSET,
+        y: anchorRect.bottom + MENU_VIEWPORT_PADDING,
+        entry,
+        source: 'mouse',
+      };
     });
   }, [workspaceAgentId]);
 

--- a/src/features/file-browser/FileTreePanel.tsx
+++ b/src/features/file-browser/FileTreePanel.tsx
@@ -500,6 +500,18 @@ export function FileTreePanel({
     });
   }, [selectFile, workspaceAgentId]);
 
+  const openCompactActionsMenu = useCallback((entry: TreeEntry, anchorRect: DOMRect) => {
+    contextMenuSessionIdRef.current += 1;
+    setContextMenu({
+      agentId: workspaceAgentId,
+      sessionId: contextMenuSessionIdRef.current,
+      x: anchorRect.right - MENU_CURSOR_OFFSET,
+      y: anchorRect.top + MENU_ROW_TOP_OFFSET,
+      entry,
+      source: 'mouse',
+    });
+  }, [workspaceAgentId]);
+
   const startRename = useCallback((entry: TreeEntry) => {
     if (entry.path === '.trash') {
       showToastForAgent(workspaceAgentId, { type: 'error', message: 'Cannot rename .trash root' }, 3500);
@@ -819,7 +831,7 @@ export function FileTreePanel({
                 loadingPaths={loadingPaths}
                 onToggleDir={toggleDirectory}
                 onOpenFile={onOpenFile}
-                onTouchLongPress={openTouchContextMenu}
+                onTouchLongPress={isCompactLayout ? undefined : openTouchContextMenu}
                 onSelect={selectFile}
                 onContextMenu={handleContextMenu}
                 dragSourcePath={visibleDragSource?.path || null}
@@ -834,6 +846,8 @@ export function FileTreePanel({
                 onRenameChange={handleRenameChange}
                 onRenameCommit={() => { void commitRename(); }}
                 onRenameCancel={cancelRename}
+                compact={isCompactLayout}
+                onOpenActions={openCompactActionsMenu}
               />
             ))
           )}

--- a/src/features/file-browser/FileTreePanel.tsx
+++ b/src/features/file-browser/FileTreePanel.tsx
@@ -506,7 +506,7 @@ export function FileTreePanel({
       agentId: workspaceAgentId,
       sessionId: contextMenuSessionIdRef.current,
       x: anchorRect.right - MENU_CURSOR_OFFSET,
-      y: anchorRect.top + MENU_ROW_TOP_OFFSET,
+      y: anchorRect.bottom + MENU_VIEWPORT_PADDING,
       entry,
       source: 'mouse',
     });


### PR DESCRIPTION
## Summary
- add explicit kebab action buttons for compact file tree rows and keep row labels shrinkable on narrow widths
- route compact file tree actions through the shared menu from the kebab button instead of compact row long-press
- toggle the compact actions menu closed when the same kebab button is clicked again and cover the behavior with tests

## Test Plan
- `npx vitest run src/features/file-browser/fileTreeMenuActions.test.ts src/features/file-browser/FileTreeNode.test.tsx src/features/file-browser/FileTreePanel.test.tsx`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compact layout for the file browser now shows an inline "Open actions" button on rows to access item-specific menus without selecting or toggling the row; filename truncation and spacing adjusted to accommodate the button.

* **Tests**
  * Expanded test coverage for compact-mode behaviors: actions button click/keyboard/touch handling, menu open/close semantics, and prevention of unintended selection or directory toggles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->