### PR TITLE
fix(chat): render edit tool diffs from nested edits arrays

### DIFF
--- a/src/features/chat/edit-blocks.test.ts
+++ b/src/features/chat/edit-blocks.test.ts
@@ -30,6 +30,23 @@ describe('extractEditBlocks', () => {
     expect(extractEditBlocks(text2)[0].oldText).toBe('a');
   });
 
+  it('extracts nested edits arrays from real edit tool payloads', () => {
+    const text = '**tool:** `edit`\n```json\n{"path":"2026-04-20.md","edits":[{"oldText":"foo","newText":"bar"},{"oldText":"baz","newText":"qux"}]}\n```';
+
+    const blocks = extractEditBlocks(text);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]).toEqual({ filePath: '2026-04-20.md', oldText: 'foo', newText: 'bar' });
+    expect(blocks[1]).toEqual({ filePath: '2026-04-20.md', oldText: 'baz', newText: 'qux' });
+  });
+
+  it('uses per-edit path when present inside nested edits', () => {
+    const text = '**tool:** `edit`\n```json\n{"path":"fallback.md","edits":[{"path":"nested.md","oldText":"a","newText":"b"}]}\n```';
+
+    const blocks = extractEditBlocks(text);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]).toEqual({ filePath: 'nested.md', oldText: 'a', newText: 'b' });
+  });
+
   it('skips malformed JSON', () => {
     const text = '**tool:** `Edit`\n```json\n{not valid json}\n```';
     expect(extractEditBlocks(text)).toHaveLength(0);

--- a/src/features/chat/edit-blocks.ts
+++ b/src/features/chat/edit-blocks.ts
@@ -11,15 +11,31 @@ export function extractEditBlocks(rawText: string): EditBlock[] {
   
   const toolPattern = /\*\*tool:\*\*\s*`(Edit|edit)`\s*\n```json\n([\s\S]*?)```/g;
   let match;
+
+  const collectBlock = (input: Record<string, unknown>, fallbackPath = '') => {
+    const filePath = String(input.file_path || input.path || fallbackPath || '');
+    const oldStr = String(input.old_string || input.oldText || '');
+    const newStr = String(input.new_string || input.newText || '');
+    if (oldStr || newStr) {
+      blocks.push({ filePath, oldText: oldStr, newText: newStr });
+    }
+  };
   
   while ((match = toolPattern.exec(rawText)) !== null) {
     try {
-      const input = JSON.parse(match[2]);
-      const filePath = input.file_path || input.path || '';
-      const oldStr = input.old_string || input.oldText || '';
-      const newStr = input.new_string || input.newText || '';
-      if (oldStr || newStr) {
-        blocks.push({ filePath, oldText: oldStr, newText: newStr });
+      const input = JSON.parse(match[2]) as Record<string, unknown>;
+      const filePath = String(input.file_path || input.path || '');
+
+      if (Array.isArray(input.edits)) {
+        for (const edit of input.edits) {
+          if (edit && typeof edit === 'object') {
+            collectBlock(edit as Record<string, unknown>, filePath);
+          }
+        }
+      }
+
+      if (!Array.isArray(input.edits) || input.edits.length === 0) {
+        collectBlock(input, filePath);
       }
     } catch { /* skip malformed JSON */ }
   }


### PR DESCRIPTION
Edit tool calls were showing summary text like `editing 2026-04-20.md` instead of expandable before/after diffs.

This fixes the edit diff extractor so it handles the real payload shape, where changes come through inside an `edits` array. That makes both single tool bubbles and grouped tool entries render diffs correctly again.

## Testing
- `npx vitest run src/features/chat/edit-blocks.test.ts`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat editing now supports processing multiple file edits in a single JSON payload for efficient batch operations. Each edit can specify its own file path, allowing flexible path customization per change.

* **Tests**
  * Added test coverage for batch edit processing and per-edit file path override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->