### PR TITLE
[codex] fix mobile dropdown click-through

### DIFF
--- a/src/components/ui/InlineSelect.test.tsx
+++ b/src/components/ui/InlineSelect.test.tsx
@@ -1,0 +1,38 @@
+import '@testing-library/jest-dom';
+import { createEvent, fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { InlineSelect } from './InlineSelect';
+
+describe('InlineSelect', () => {
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+  it('prevents default on option pointerdown to avoid mobile click-through', () => {
+    const onChange = vi.fn();
+
+    render(
+      <div>
+        <InlineSelect
+          value="default"
+          onChange={onChange}
+          options={[
+            { value: 'default', label: 'Default' },
+            { value: 'medium', label: 'medium' },
+            { value: 'high', label: 'high' },
+          ]}
+          ariaLabel="Thinking"
+          inline
+        />
+        <button type="button">Launch subagent</button>
+      </div>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Thinking' }));
+
+    const option = screen.getByRole('option', { name: 'medium' });
+    const event = createEvent.pointerDown(option);
+    fireEvent(option, event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onChange).toHaveBeenCalledWith('medium');
+  });
+});

--- a/src/components/ui/InlineSelect.tsx
+++ b/src/components/ui/InlineSelect.tsx
@@ -235,6 +235,9 @@ export function InlineSelect({
               'hover:bg-secondary/80 hover:text-foreground'
             )}
             onPointerDown={(e) => {
+              // Prevent touch browsers from retargeting a follow-up click onto
+              // whatever sits underneath the menu after we close it.
+              e.preventDefault();
               e.stopPropagation();
               onChange(option.value);
               close();


### PR DESCRIPTION
## What

Prevent `InlineSelect` option picks on mobile browsers from clicking controls underneath the menu after the menu closes.

## Why

On mobile Safari, selecting an option from the shared inline dropdown could synthesize a follow-up click after the menu dismissed. In the subagent creation dialog this could hit the button underneath the menu and close or submit the dialog unexpectedly.

## How

- call `preventDefault()` in `InlineSelect` option `onPointerDown` before closing the menu
- add a regression test for the shared component that verifies the option pointerdown prevents default while still updating the selection

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [ ] New features include tests
- [ ] UI changes include a screenshot or screen recording

## Screenshots

Not attached in this CLI-created PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pointer event handling in dropdown menus to prevent accidental clicks from reaching elements beneath the menu on touch-enabled devices, improving user experience on mobile and tablet platforms.

* **Tests**
  * Added test coverage for dropdown pointer event interactions to verify proper event behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->