### PR TITLE
chore(release): prepare v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.5.3] - 2026-04-21
+
+### Highlights
+
+**Workspace context is much more usable inside chat.** Nerve can now add files and directories to chat, open rendered markdown documents in-app, and follow configurable workspace path links and aliases directly from messages or docs (PR #239, PR #248, PR #271, PR #273, PR #288).
+
+**File browsing works better on real devices.** The file browser now supports in-app PDF viewing, moves compact actions into kebab menus, and handles touch long-press context menus more reliably on mobile (PR #254, PR #299, PR #303, PR #307).
+
+**Session visibility got less confusing.** Spawned child sessions survive refreshes, channel sessions show up in the agent sidebar, root agent labels derive more reliably from identity, and orphaned agent sessions no longer disappear from the tree (PR #226, PR #236, PR #259, PR #297).
+
+**Uploads and shell controls got cleaner.** The paperclip is now the primary upload flow, attachments use a canonical upload reference contract, and the command palette has clearer launchers and visibility toggles across desktop and mobile layouts (PR #229, PR #231, PR #291, PR #292, PR #293).
+
+### Added
+- In-app PDF viewing with file type checks in the file browser (PR #254)
+- An in-app bead viewer with context-safe bead links (PR #275)
+- Configurable workspace path links plus `CHAT_PATH_LINKS` alias mapping for chat references (PR #239, PR #288)
+- File-tree actions to add individual files or whole directories to chat (PR #271, PR #273)
+- A hidden-workspace-entries toggle for the workspace panel (PR #274)
+- Support for adaptive thinking selection in the UI (PR #302)
+
+### Changed
+- The paperclip is now the primary upload entry point in chat (PR #231)
+- Workspace markdown documents now render in a dedicated navigable document view instead of forcing raw file reads (PR #248)
+- Compact file-browser actions now live behind kebab menus to reduce accidental taps and visual noise (PR #307)
+- The command palette now has clearer launchers, mobile entry points, and visibility controls (PR #291, PR #292, PR #293)
+- Built-in Kanban can now be disabled from settings while remaining enabled by default for existing installs (PR #242)
+- The updater now surfaces a copy-paste command during update flows for easier manual recovery (PR #295)
+
+### Fixed
+- Spawned child sessions now remain visible after refresh instead of disappearing from the sidebar (PR #226)
+- Uploaded user images now survive history reconciliation correctly (PR #220)
+- The workspace watcher again refreshes config changes and restores workspace labels correctly (PR #261, PR #284)
+- Local chat path link configuration now self-heals safer defaults, and inline workspace references replay correctly after follow-up renders (PR #267, PR #285)
+- Session roots now derive stable labels from identity, keep inherited effort labels after reload, and continue showing channel and orphaned sessions in the sidebar (PR #236, PR #257, PR #259, PR #297)
+- Kanban assigned execution now falls back to the full session list when needed instead of dropping valid targets (PR #287)
+- Panel dividers stay interactive when the sidebar is collapsed, and resizable panel lint regressions are cleaned up (PR #281, PR #289)
+- ArrowUp history recall, untrusted system event parsing, and nested edit diff rendering all behave correctly in chat again (PR #278, PR #280, PR #308)
+- The server-side upload config endpoint is available again, and subagent lifecycle handling now lives on the server for more reliable spawn cleanup (PR #247, PR #265)
+- Tailscale serve docs and examples now use valid command syntax again (PR #276, PR #277)
+
+### Documentation
+- Refreshed local setup wording in the README to better match current install expectations
+
 ## [1.5.2] - 2026-03-30
 
 ### Highlights

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-nerve",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-nerve",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-nerve",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Web interface for OpenClaw — chat, voice input, TTS, and agent monitoring in the browser",
   "license": "MIT",
   "engines": {

--- a/src/features/kanban/lib/assigneeOptions.test.ts
+++ b/src/features/kanban/lib/assigneeOptions.test.ts
@@ -21,7 +21,7 @@ describe('assigneeOptions', () => {
       { value: '', label: 'Unassigned' },
       { value: 'operator', label: 'Operator' },
       { value: 'agent:designer', label: 'designer' },
-      { value: 'agent:reviewer', label: 'reviewer' },
+      { value: 'agent:reviewer', label: 'Reviewer' },
     ]);
   });
 
@@ -63,7 +63,7 @@ describe('assigneeOptions', () => {
     expect(buildAssigneeOptions(sessions, 'Nerve')).toEqual([
       { value: '', label: 'Unassigned' },
       { value: 'operator', label: 'Operator' },
-      { value: 'agent:builder', label: 'builder' },
+      { value: 'agent:builder', label: 'Builder' },
     ]);
   });
 
@@ -76,7 +76,7 @@ describe('assigneeOptions', () => {
     expect(buildAssigneeOptionsForEdit(sessions, 'agent:design-reviewer-2', 'Nerve')).toEqual([
       { value: '', label: 'Unassigned' },
       { value: 'operator', label: 'Operator' },
-      { value: 'agent:reviewer', label: 'reviewer' },
+      { value: 'agent:reviewer', label: 'Reviewer' },
       { value: 'agent:design-reviewer-2', label: 'Agent design reviewer 2 (inactive)', disabled: true },
     ]);
   });
@@ -90,7 +90,7 @@ describe('assigneeOptions', () => {
     const expected = [
       { value: '', label: 'Unassigned' },
       { value: 'operator', label: 'Operator' },
-      { value: 'agent:reviewer', label: 'reviewer' },
+      { value: 'agent:reviewer', label: 'Reviewer' },
     ];
 
     expect(buildAssigneeOptionsForEdit(sessions, '')).toEqual(expected);
@@ -108,7 +108,7 @@ describe('assigneeOptions', () => {
     expect(buildAssigneeOptionsForEdit(sessions, ' agent:reviewer ')).toEqual([
       { value: '', label: 'Unassigned' },
       { value: 'operator', label: 'Operator' },
-      { value: 'agent:reviewer', label: 'reviewer' },
+      { value: 'agent:reviewer', label: 'Reviewer' },
     ]);
   });
 

--- a/src/features/sessions/sessionKeys.test.ts
+++ b/src/features/sessions/sessionKeys.test.ts
@@ -93,10 +93,10 @@ describe('sessionKeys', () => {
     expect(pickDefaultSessionKey(sessions)).toBe('agent:main:main');
   });
 
-  it('builds display labels from identity name, then root id for root sessions', () => {
-    expect(getSessionDisplayLabel(session('agent:reviewer:main', { label: 'Reviewer', displayName: 'webchat:reviewer' }), 'Nerve')).toBe('reviewer');
+  it('prefers explicit labels for root sessions, then falls back to identity name and root id', () => {
+    expect(getSessionDisplayLabel(session('agent:reviewer:main', { label: 'Reviewer', displayName: 'webchat:reviewer' }), 'Nerve')).toBe('Reviewer');
+    expect(getSessionDisplayLabel(session('agent:reviewer:main', { label: 'Release QA', identityName: 'Reviewer Prime' }), 'Nerve')).toBe('Release QA');
     expect(getSessionDisplayLabel(session('agent:reviewer:main', { displayName: 'Reviewer Prime' }), 'Nerve')).toBe('reviewer');
-    expect(getSessionDisplayLabel(session('agent:reviewer:main', { label: 'Reviewer' }), 'Nerve')).toBe('reviewer');
     expect(getSessionDisplayLabel(session('agent:reviewer:main', { identityName: 'Reviewer Prime' }), 'Nerve')).toBe('Reviewer Prime (reviewer)');
     expect(getSessionDisplayLabel(session('agent:reviewer:main'), 'Nerve')).toBe('reviewer');
     expect(getSessionDisplayLabel(session('agent:main:main'), 'Nerve')).toBe('Nerve (main)');
@@ -111,7 +111,8 @@ describe('sessionKeys', () => {
     ).toBe('coding');
   });
 
-  it('keeps the main root label canonical even if gateway metadata says heartbeat', () => {
+  it('uses an explicit custom label for the main root, but ignores heartbeat metadata', () => {
+    expect(getSessionDisplayLabel(session('agent:main:main', { label: 'Ops Desk' }), 'Nerve')).toBe('Ops Desk');
     expect(getSessionDisplayLabel(session('agent:main:main', { label: 'heartbeat' }), 'Nerve')).toBe('Nerve (main)');
     expect(getSessionDisplayLabel(session('agent:main:main', { displayName: 'heartbeat' }), 'Nerve')).toBe('Nerve (main)');
   });

--- a/src/features/sessions/sessionKeys.ts
+++ b/src/features/sessions/sessionKeys.ts
@@ -156,17 +156,21 @@ export function getSessionDisplayLabel(session: Session, agentName = 'Agent'): s
   const sessionKey = getSessionKey(session);
   const rootId = getRootAgentId(sessionKey);
   const identityName = session.identityName?.trim();
+  const explicitLabel = session.label?.trim();
 
   if (sessionKey === 'agent:main:main') {
+    const normalized = explicitLabel?.toLowerCase();
+    if (explicitLabel && normalized !== 'main' && normalized !== 'heartbeat') return explicitLabel;
     return `${agentName} (main)`;
   }
 
   if (isTopLevelAgentSessionKey(sessionKey)) {
+    if (explicitLabel) return explicitLabel;
     if (identityName && rootId) return `${identityName} (${rootId})`;
     if (rootId) return rootId;
   }
 
-  if (session.label?.trim()) return session.label.trim();
+  if (explicitLabel) return explicitLabel;
   if (session.displayName?.trim()) return session.displayName.trim();
 
   if (isCronSessionKey(sessionKey)) {


### PR DESCRIPTION
## Summary
- bump the app version from `1.5.2` to `1.5.3`
- add the `1.5.3` changelog entry
- honor saved custom labels when renaming top-level agent sessions in the sidebar
- align Kanban assignee-option expectations with explicit root-session labels

## Files
- `package.json`
- `package-lock.json`
- `CHANGELOG.md`
- `src/features/sessions/sessionKeys.ts`
- `src/features/sessions/sessionKeys.test.ts`
- `src/features/kanban/lib/assigneeOptions.test.ts`

## Validation
- [x] `npm run lint`
- [x] `npm test -- --run`
- [x] `npm run build`
- [x] `npm run build:server`

## Notes
- Shaun smoke tested session renaming on the deployed `release/v1.5.3` build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * In-chat workspace context improvements
  * Enhanced file-browser with in-app PDF viewing
  * Improved upload and command-palette workflows

* **Improvements**
  * Better session-tree visibility across refreshes
  * More reliable mobile touch and long-press interactions
  * Enhanced session labeling and retention

* **Bug Fixes**
  * Fixed chat history recall, workspace configuration restoration, and panel divider interactivity
  * Corrected Kanban execution fallback behavior and server-side upload configuration

* **Documentation**
  * Updated local setup instructions in README

<!-- end of auto-generated comment: release notes by coderabbit.ai -->