### PR TITLE
fix(file-browser): add mobile PDF fallback

### DIFF
--- a/src/features/file-browser/PdfViewer.test.tsx
+++ b/src/features/file-browser/PdfViewer.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { PdfViewer } from './PdfViewer';
+import type { OpenFile } from './types';
+
+const baseFile: OpenFile = {
+  path: 'docs/spec.pdf',
+  name: 'spec.pdf',
+  content: '',
+  savedContent: '',
+  dirty: false,
+  locked: false,
+  mtime: 0,
+  loading: false,
+};
+
+const originalNavigator = {
+  userAgent: window.navigator.userAgent,
+  platform: window.navigator.platform,
+  maxTouchPoints: window.navigator.maxTouchPoints,
+};
+
+function setNavigatorEnv({
+  userAgent = originalNavigator.userAgent,
+  platform = originalNavigator.platform,
+  maxTouchPoints = originalNavigator.maxTouchPoints,
+}: Partial<typeof originalNavigator>) {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    configurable: true,
+    value: userAgent,
+  });
+
+  Object.defineProperty(window.navigator, 'platform', {
+    configurable: true,
+    value: platform,
+  });
+
+  Object.defineProperty(window.navigator, 'maxTouchPoints', {
+    configurable: true,
+    value: maxTouchPoints,
+  });
+}
+
+afterEach(() => {
+  setNavigatorEnv(originalNavigator);
+});
+
+describe('PdfViewer', () => {
+  it('renders the inline iframe viewer on desktop browsers', () => {
+    render(<PdfViewer file={baseFile} agentId="agent-1" />);
+
+    const iframe = screen.getByTitle('spec.pdf');
+    expect(iframe).toHaveAttribute(
+      'src',
+      '/api/files/raw?path=docs%2Fspec.pdf&agentId=agent-1',
+    );
+  });
+
+  it('shows an external-open fallback on mobile web where inline PDF preview is unsupported', () => {
+    setNavigatorEnv({
+      userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Chrome/123.0.0.0 Mobile Safari/537.36',
+      platform: 'Linux armv81',
+      maxTouchPoints: 5,
+    });
+
+    render(<PdfViewer file={baseFile} agentId="agent-1" />);
+
+    expect(screen.getByText(/pdf preview isn't supported on mobile web/i)).toBeInTheDocument();
+    expect(screen.queryByTitle('spec.pdf')).not.toBeInTheDocument();
+
+    const openLink = screen.getByRole('link', { name: /open pdf/i });
+    expect(openLink).toHaveAttribute(
+      'href',
+      '/api/files/raw?path=docs%2Fspec.pdf&agentId=agent-1',
+    );
+    expect(openLink).toHaveAttribute('target', '_blank');
+  });
+});

--- a/src/features/file-browser/PdfViewer.test.tsx
+++ b/src/features/file-browser/PdfViewer.test.tsx
@@ -74,5 +74,27 @@ describe('PdfViewer', () => {
       '/api/files/raw?path=docs%2Fspec.pdf&agentId=agent-1',
     );
     expect(openLink).toHaveAttribute('target', '_blank');
+    expect(openLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('shows the mobile fallback for iPadOS Safari reporting a desktop-like UA', () => {
+    setNavigatorEnv({
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605.1.15 Version/17.3 Safari/605.1.15',
+      platform: 'MacIntel',
+      maxTouchPoints: 5,
+    });
+
+    render(<PdfViewer file={baseFile} agentId="agent-1" />);
+
+    expect(screen.getByText(/pdf preview isn't supported on mobile web/i)).toBeInTheDocument();
+    expect(screen.queryByTitle('spec.pdf')).not.toBeInTheDocument();
+
+    const openLink = screen.getByRole('link', { name: /open pdf/i });
+    expect(openLink).toHaveAttribute(
+      'href',
+      '/api/files/raw?path=docs%2Fspec.pdf&agentId=agent-1',
+    );
+    expect(openLink).toHaveAttribute('target', '_blank');
+    expect(openLink).toHaveAttribute('rel', 'noopener noreferrer');
   });
 });

--- a/src/features/file-browser/PdfViewer.tsx
+++ b/src/features/file-browser/PdfViewer.tsx
@@ -34,11 +34,13 @@ export function PdfViewer({ file, agentId }: PdfViewerProps) {
   }
 
   const src = `/api/files/raw?path=${encodeURIComponent(file.path)}&agentId=${encodeURIComponent(agentId)}`;
-  const userAgent = typeof navigator === 'undefined' ? '' : (navigator.userAgent || '').toLowerCase();
-  const platform = typeof navigator === 'undefined' ? '' : (navigator.platform || '').toLowerCase();
-  const maxTouchPoints = typeof navigator === 'undefined' ? 0 : navigator.maxTouchPoints || 0;
-  const isMobileWeb = /android|iphone|ipod/.test(userAgent)
-    || /ipad|mobile|tablet/.test(userAgent)
+  const nav = typeof navigator === 'undefined' ? undefined : navigator;
+  const userAgent = (nav?.userAgent || '').toLowerCase();
+  // navigator.platform is deprecated, but the MacIntel + touchpoints check is still
+  // the most reliable way to catch iPadOS Safari reporting a desktop-like UA.
+  const platform = (nav?.platform || '').toLowerCase();
+  const maxTouchPoints = nav?.maxTouchPoints ?? 0;
+  const isMobileWeb = /android|iphone|ipad|mobile|tablet/.test(userAgent)
     || (platform === 'macintel' && maxTouchPoints > 1);
 
   if (isMobileWeb) {
@@ -50,7 +52,7 @@ export function PdfViewer({ file, agentId }: PdfViewerProps) {
           Open the file directly for your browser's native PDF handling.
         </div>
         <Button asChild size="sm">
-          <a href={src} target="_blank" rel="noreferrer">
+          <a href={src} target="_blank" rel="noopener noreferrer">
             <ExternalLink size={14} />
             Open PDF
           </a>

--- a/src/features/file-browser/PdfViewer.tsx
+++ b/src/features/file-browser/PdfViewer.tsx
@@ -1,8 +1,11 @@
 /**
  * PdfViewer — Renders PDF files using the browser's built-in PDF viewer via iframe.
+ * Falls back to opening the raw file directly on mobile web, where inline PDF embeds
+ * are unreliable in Chrome-based browsers.
  */
 
-import { Loader2, AlertTriangle } from 'lucide-react';
+import { Loader2, AlertTriangle, ExternalLink } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import type { OpenFile } from './types';
 
 interface PdfViewerProps {
@@ -31,6 +34,30 @@ export function PdfViewer({ file, agentId }: PdfViewerProps) {
   }
 
   const src = `/api/files/raw?path=${encodeURIComponent(file.path)}&agentId=${encodeURIComponent(agentId)}`;
+  const userAgent = typeof navigator === 'undefined' ? '' : (navigator.userAgent || '').toLowerCase();
+  const platform = typeof navigator === 'undefined' ? '' : (navigator.platform || '').toLowerCase();
+  const maxTouchPoints = typeof navigator === 'undefined' ? 0 : navigator.maxTouchPoints || 0;
+  const isMobileWeb = /android|iphone|ipod/.test(userAgent)
+    || /ipad|mobile|tablet/.test(userAgent)
+    || (platform === 'macintel' && maxTouchPoints > 1);
+
+  if (isMobileWeb) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 bg-[#0a0a0a] px-6 text-center text-muted-foreground">
+        <AlertTriangle size={24} className="text-amber-400" />
+        <div className="text-sm text-foreground">PDF preview isn't supported on mobile web.</div>
+        <div className="max-w-sm text-xs">
+          Open the file directly for your browser's native PDF handling.
+        </div>
+        <Button asChild size="sm">
+          <a href={src} target="_blank" rel="noreferrer">
+            <ExternalLink size={14} />
+            Open PDF
+          </a>
+        </Button>
+      </div>
+    );
+  }
 
   return (
     <div className="h-full w-full bg-[#0a0a0a]">


### PR DESCRIPTION
## Summary

Fixes #313.

Mobile Chrome does not reliably render our iframe-based PDF viewer. This keeps the existing inline viewer on desktop and shows a simple `Open PDF` fallback on mobile web.

## Changes

- detect mobile web in `PdfViewer`
- keep inline PDF rendering on desktop
- replace the broken mobile inline preview with an `Open PDF` action
- add regression coverage for desktop and mobile behavior

## Verification

- `npm run lint`
- `npm test -- --run src/features/file-browser/PdfViewer.test.tsx src/features/file-browser/TabbedContentArea.test.tsx`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile web experience: PDF viewer detects mobile browsers and shows a centered message with an “Open PDF” link to open files externally instead of attempting unsupported inline rendering.

* **Tests**
  * Added automated tests covering PDF viewer behavior across desktop, mobile-web, and tablet-like environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->