### PR TITLE
fix(setup): respect OPENCLAW_CONFIG_PATH

### DIFF
--- a/scripts/lib/gateway-detect.test.ts
+++ b/scripts/lib/gateway-detect.test.ts
@@ -232,6 +232,13 @@ describe('gateway detection and repair', () => {
         },
       },
     }, null, 2));
+    writeFileSync(path.join(customHome, 'identity', 'device-auth.json'), JSON.stringify({
+      version: 1,
+      deviceId: 'custom-gateway-device',
+      tokens: {
+        operator: { token: 'custom-token', scopes: ['operator.read'] },
+      },
+    }, null, 2));
 
     process.env.OPENCLAW_CONFIG_PATH = customConfigPath;
 
@@ -242,9 +249,35 @@ describe('gateway detection and repair', () => {
     const repairedCustom = JSON.parse(readFileSync(path.join(customHome, 'devices', 'paired.json'), 'utf8'));
     expect(repairedCustom['custom-gateway-device'].scopes).toEqual(expect.arrayContaining(FULL_OPERATOR_SCOPES));
 
+    const repairedIdentity = JSON.parse(readFileSync(path.join(customHome, 'identity', 'device-auth.json'), 'utf8'));
+    expect(repairedIdentity.tokens.operator.scopes).toEqual(expect.arrayContaining(FULL_OPERATOR_SCOPES));
+
     const untouchedDefault = JSON.parse(readFileSync(path.join(tempHome, '.openclaw', 'devices', 'paired.json'), 'utf8'));
     expect(untouchedDefault['gateway-device'].scopes).toEqual(FULL_OPERATOR_SCOPES);
     expect(untouchedDefault['custom-gateway-device']).toBeUndefined();
+  });
+
+  it('uses OPENCLAW_CONFIG_PATH when patching gateway allowed origins', async () => {
+    const customConfigPath = path.join(tempHome, 'custom', 'openclaw-alt.json');
+    mkdirSync(path.dirname(customConfigPath), { recursive: true });
+    writeFileSync(customConfigPath, JSON.stringify({
+      gateway: { controlUi: { allowedOrigins: [] } },
+    }, null, 2));
+    process.env.OPENCLAW_CONFIG_PATH = customConfigPath;
+
+    const { mod } = await importGatewayDetect();
+    const result = mod.patchGatewayAllowedOrigins('http://custom.local:3080');
+
+    expect(result.ok).toBe(true);
+    expect(result.configPath).toBe(customConfigPath);
+
+    const updatedCustom = JSON.parse(readFileSync(customConfigPath, 'utf8'));
+    expect(updatedCustom.gateway.controlUi.allowedOrigins).toContain('http://custom.local:3080');
+
+    const unchangedDefault = JSON.parse(
+      readFileSync(path.join(tempHome, '.openclaw', 'openclaw.json'), 'utf8'),
+    );
+    expect(unchangedDefault.gateway.controlUi.allowedOrigins).not.toContain('http://custom.local:3080');
   });
 
   it('prefers a detected config token over a stale shell env token during setup', async () => {

--- a/scripts/lib/gateway-detect.test.ts
+++ b/scripts/lib/gateway-detect.test.ts
@@ -210,6 +210,43 @@ describe('gateway detection and repair', () => {
     expect(unchangedDefault.gateway.tools.allow).toEqual(['cron', 'gateway']);
   });
 
+  it('writes device repair under the OPENCLAW_HOME derived from OPENCLAW_CONFIG_PATH', async () => {
+    const customHome = path.join(tempHome, 'custom');
+    const customConfigPath = path.join(customHome, 'openclaw.json');
+    mkdirSync(path.join(customHome, 'devices'), { recursive: true });
+    mkdirSync(path.join(customHome, 'identity'), { recursive: true });
+
+    writeFileSync(customConfigPath, JSON.stringify({
+      gateway: { port: 19999, auth: { token: 'custom-token' } },
+    }, null, 2));
+    writeFileSync(path.join(customHome, 'identity', 'device.json'), JSON.stringify({
+      deviceId: 'custom-gateway-device',
+      publicKeyPem: '-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEA2sI3DpP2u80EIk1BddY5hAzvY4xXHzkwmo7aX6ixkm0=\n-----END PUBLIC KEY-----\n',
+    }, null, 2));
+    writeFileSync(path.join(customHome, 'devices', 'paired.json'), JSON.stringify({
+      'custom-gateway-device': {
+        deviceId: 'custom-gateway-device',
+        scopes: ['operator.read'],
+        tokens: {
+          operator: { token: 'custom-token', scopes: ['operator.read'] },
+        },
+      },
+    }, null, 2));
+
+    process.env.OPENCLAW_CONFIG_PATH = customConfigPath;
+
+    const { mod } = await importGatewayDetect();
+    const result = mod.fixGatewayDeviceScopes();
+    expect(result.ok).toBe(true);
+
+    const repairedCustom = JSON.parse(readFileSync(path.join(customHome, 'devices', 'paired.json'), 'utf8'));
+    expect(repairedCustom['custom-gateway-device'].scopes).toEqual(expect.arrayContaining(FULL_OPERATOR_SCOPES));
+
+    const untouchedDefault = JSON.parse(readFileSync(path.join(tempHome, '.openclaw', 'devices', 'paired.json'), 'utf8'));
+    expect(untouchedDefault['gateway-device'].scopes).toEqual(FULL_OPERATOR_SCOPES);
+    expect(untouchedDefault['custom-gateway-device']).toBeUndefined();
+  });
+
   it('prefers a detected config token over a stale shell env token during setup', async () => {
     process.env.OPENCLAW_GATEWAY_TOKEN = 'stale-shell-token';
 

--- a/scripts/lib/gateway-detect.test.ts
+++ b/scripts/lib/gateway-detect.test.ts
@@ -165,6 +165,51 @@ describe('gateway detection and repair', () => {
     ]));
   });
 
+  it('uses OPENCLAW_CONFIG_PATH when detecting gateway config', async () => {
+    const customConfigPath = path.join(tempHome, 'custom', 'openclaw-alt.json');
+    mkdirSync(path.dirname(customConfigPath), { recursive: true });
+    writeFileSync(customConfigPath, JSON.stringify({
+      gateway: {
+        port: 19999,
+        auth: { token: 'custom-token' },
+        tools: { allow: [] },
+      },
+    }, null, 2));
+    process.env.OPENCLAW_CONFIG_PATH = customConfigPath;
+
+    const { mod } = await importGatewayDetect();
+    const detected = mod.detectGatewayConfig();
+
+    expect(detected).toEqual({
+      token: 'custom-token',
+      url: 'http://127.0.0.1:19999',
+    });
+  });
+
+  it('uses OPENCLAW_CONFIG_PATH when patching gateway tool allowlist', async () => {
+    const customConfigPath = path.join(tempHome, 'custom', 'openclaw-alt.json');
+    mkdirSync(path.dirname(customConfigPath), { recursive: true });
+    writeFileSync(customConfigPath, JSON.stringify({
+      gateway: {
+        auth: { token: 'custom-token' },
+        tools: { allow: [] },
+      },
+    }, null, 2));
+    process.env.OPENCLAW_CONFIG_PATH = customConfigPath;
+
+    const { mod } = await importGatewayDetect();
+    const result = mod.patchGatewayToolsAllow();
+
+    expect(result.ok).toBe(true);
+    expect(result.configPath).toBe(customConfigPath);
+
+    const updatedCustom = JSON.parse(readFileSync(customConfigPath, 'utf8'));
+    expect(updatedCustom.gateway.tools.allow).toEqual(['cron', 'gateway', 'sessions_spawn']);
+
+    const unchangedDefault = JSON.parse(readFileSync(path.join(tempHome, '.openclaw', 'openclaw.json'), 'utf8'));
+    expect(unchangedDefault.gateway.tools.allow).toEqual(['cron', 'gateway']);
+  });
+
   it('prefers a detected config token over a stale shell env token during setup', async () => {
     process.env.OPENCLAW_GATEWAY_TOKEN = 'stale-shell-token';
 

--- a/scripts/lib/gateway-detect.ts
+++ b/scripts/lib/gateway-detect.ts
@@ -13,7 +13,11 @@ import crypto from 'node:crypto';
 import os from 'node:os';
 
 const HOME = process.env.HOME || os.homedir();
-const OPENCLAW_CONFIG = join(HOME, '.openclaw', 'openclaw.json');
+const DEFAULT_OPENCLAW_CONFIG = join(HOME, '.openclaw', 'openclaw.json');
+
+function resolveOpenClawConfigPath(): string {
+  return process.env.OPENCLAW_CONFIG_PATH?.trim() || DEFAULT_OPENCLAW_CONFIG;
+}
 
 interface OpenClawConfig {
   gateway?: {
@@ -51,6 +55,7 @@ export interface GatewayTokenChoice {
  */
 export function detectGatewayConfig(): DetectedGateway {
   const result: DetectedGateway = { token: null, url: null };
+  const openclawConfigPath = resolveOpenClawConfigPath();
 
   // The gateway process prefers the systemd env var over the config file token,
   // so detect it first even when openclaw.json is absent or broken.
@@ -59,12 +64,12 @@ export function detectGatewayConfig(): DetectedGateway {
     result.token = systemdToken;
   }
 
-  if (!existsSync(OPENCLAW_CONFIG)) {
+  if (!existsSync(openclawConfigPath)) {
     return result;
   }
 
   try {
-    const raw = readFileSync(OPENCLAW_CONFIG, 'utf-8');
+    const raw = readFileSync(openclawConfigPath, 'utf-8');
     const config = JSON.parse(raw) as OpenClawConfig;
 
     if (!result.token && config.gateway?.auth?.token) {
@@ -138,15 +143,16 @@ export interface GatewayPatchResult {
  * Returns a result indicating success/failure.
  */
 export function patchGatewayAllowedOrigins(origin: string): GatewayPatchResult {
-  const result: GatewayPatchResult = { ok: false, message: '', configPath: OPENCLAW_CONFIG };
+  const openclawConfigPath = resolveOpenClawConfigPath();
+  const result: GatewayPatchResult = { ok: false, message: '', configPath: openclawConfigPath };
 
-  if (!existsSync(OPENCLAW_CONFIG)) {
-    result.message = `Config not found: ${OPENCLAW_CONFIG}`;
+  if (!existsSync(openclawConfigPath)) {
+    result.message = `Config not found: ${openclawConfigPath}`;
     return result;
   }
 
   try {
-    const raw = readFileSync(OPENCLAW_CONFIG, 'utf-8');
+    const raw = readFileSync(openclawConfigPath, 'utf-8');
     const config = JSON.parse(raw) as OpenClawConfig;
 
     config.gateway = config.gateway || {};
@@ -162,7 +168,7 @@ export function patchGatewayAllowedOrigins(origin: string): GatewayPatchResult {
     origins.push(origin);
     config.gateway.controlUi.allowedOrigins = origins;
 
-    writeFileSync(OPENCLAW_CONFIG, JSON.stringify(config, null, 2) + '\n');
+    writeFileSync(openclawConfigPath, JSON.stringify(config, null, 2) + '\n');
     result.ok = true;
     result.message = `Added ${origin} to gateway.controlUi.allowedOrigins`;
     return result;
@@ -187,15 +193,16 @@ const NERVE_PAIRED_DISPLAY_NAME = 'Nerve UI';
  * Returns a result indicating success/failure.
  */
 export function patchGatewayToolsAllow(): GatewayPatchResult {
-  const result: GatewayPatchResult = { ok: false, message: '', configPath: OPENCLAW_CONFIG };
+  const openclawConfigPath = resolveOpenClawConfigPath();
+  const result: GatewayPatchResult = { ok: false, message: '', configPath: openclawConfigPath };
 
-  if (!existsSync(OPENCLAW_CONFIG)) {
-    result.message = `Config not found: ${OPENCLAW_CONFIG}`;
+  if (!existsSync(openclawConfigPath)) {
+    result.message = `Config not found: ${openclawConfigPath}`;
     return result;
   }
 
   try {
-    const raw = readFileSync(OPENCLAW_CONFIG, 'utf-8');
+    const raw = readFileSync(openclawConfigPath, 'utf-8');
     const config = JSON.parse(raw) as OpenClawConfig;
 
     config.gateway = config.gateway || {};
@@ -211,7 +218,7 @@ export function patchGatewayToolsAllow(): GatewayPatchResult {
 
     config.gateway.tools.allow = [...allow, ...missing];
 
-    writeFileSync(OPENCLAW_CONFIG, JSON.stringify(config, null, 2) + '\n');
+    writeFileSync(openclawConfigPath, JSON.stringify(config, null, 2) + '\n');
     result.ok = true;
     result.message = `Added ${missing.join(', ')} to gateway.tools.allow`;
     return result;
@@ -850,10 +857,11 @@ function needsPrePair(gatewayToken?: string): boolean {
  * Detect whether gateway.tools.allow is missing required HTTP tools.
  */
 function needsToolsAllow(): boolean {
-  if (!existsSync(OPENCLAW_CONFIG)) return false;
+  const openclawConfigPath = resolveOpenClawConfigPath();
+  if (!existsSync(openclawConfigPath)) return false;
 
   try {
-    const raw = readFileSync(OPENCLAW_CONFIG, 'utf-8');
+    const raw = readFileSync(openclawConfigPath, 'utf-8');
     const config = JSON.parse(raw) as OpenClawConfig;
     const allow = Array.isArray(config.gateway?.tools?.allow) ? config.gateway.tools.allow : [];
     return REQUIRED_HTTP_TOOLS.some(tool => !allow.includes(tool));
@@ -866,10 +874,11 @@ function needsToolsAllow(): boolean {
  * Detect whether a specific origin is missing from gateway.controlUi.allowedOrigins.
  */
 function needsOriginPatch(origin: string): boolean {
-  if (!existsSync(OPENCLAW_CONFIG)) return false;
+  const openclawConfigPath = resolveOpenClawConfigPath();
+  if (!existsSync(openclawConfigPath)) return false;
 
   try {
-    const raw = readFileSync(OPENCLAW_CONFIG, 'utf-8');
+    const raw = readFileSync(openclawConfigPath, 'utf-8');
     const config = JSON.parse(raw) as OpenClawConfig;
     const origins = config.gateway?.controlUi?.allowedOrigins || [];
     return !origins.includes(origin);

--- a/scripts/lib/gateway-detect.ts
+++ b/scripts/lib/gateway-detect.ts
@@ -23,9 +23,16 @@ function resolveOpenClawConfigPath(): string {
   return process.env.OPENCLAW_CONFIG_PATH?.trim() || DEFAULT_OPENCLAW_CONFIG;
 }
 
+/**
+ * Returns the directory that contains the OpenClaw config file.
+ * Device and identity sub-directories (`devices/`, `identity/`) are expected
+ * to be siblings of the config file, matching the default `~/.openclaw` layout.
+ * Composed off of `resolveOpenClawConfigPath` so the two helpers can't drift
+ * if the override/trim logic changes later.
+ */
 function resolveOpenClawHome(): string {
-  const overridePath = process.env.OPENCLAW_CONFIG_PATH?.trim();
-  return overridePath ? dirname(overridePath) : DEFAULT_OPENCLAW_HOME;
+  const configPath = resolveOpenClawConfigPath();
+  return configPath !== DEFAULT_OPENCLAW_CONFIG ? dirname(configPath) : DEFAULT_OPENCLAW_HOME;
 }
 
 interface OpenClawConfig {

--- a/scripts/lib/gateway-detect.ts
+++ b/scripts/lib/gateway-detect.ts
@@ -1,22 +1,31 @@
 /**
  * Auto-detect gateway token from the local OpenClaw configuration.
  *
- * Reads ~/.openclaw/openclaw.json and extracts the gateway auth token.
- * This avoids requiring users to manually copy-paste the token during setup.
+ * Reads the OpenClaw config (default ~/.openclaw/openclaw.json, override via
+ * OPENCLAW_CONFIG_PATH) and extracts the gateway auth token. Device/identity
+ * files (paired.json, device.json, device-auth.json) live alongside that
+ * config, so when the config path is overridden every other path under the
+ * OpenClaw home shifts with it.
  */
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import type { ExecSyncOptions } from 'node:child_process';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import crypto from 'node:crypto';
 import os from 'node:os';
 
 const HOME = process.env.HOME || os.homedir();
-const DEFAULT_OPENCLAW_CONFIG = join(HOME, '.openclaw', 'openclaw.json');
+const DEFAULT_OPENCLAW_HOME = join(HOME, '.openclaw');
+const DEFAULT_OPENCLAW_CONFIG = join(DEFAULT_OPENCLAW_HOME, 'openclaw.json');
 
 function resolveOpenClawConfigPath(): string {
   return process.env.OPENCLAW_CONFIG_PATH?.trim() || DEFAULT_OPENCLAW_CONFIG;
+}
+
+function resolveOpenClawHome(): string {
+  const overridePath = process.env.OPENCLAW_CONFIG_PATH?.trim();
+  return overridePath ? dirname(overridePath) : DEFAULT_OPENCLAW_HOME;
 }
 
 interface OpenClawConfig {
@@ -259,7 +268,7 @@ function hasFullOperatorScopes(scopes?: string[]): boolean {
 }
 
 function readGatewayDeviceId(): string | null {
-  const deviceJsonPath = join(HOME, '.openclaw', 'identity', 'device.json');
+  const deviceJsonPath = join(resolveOpenClawHome(), 'identity', 'device.json');
   if (!existsSync(deviceJsonPath)) return null;
 
   try {
@@ -309,7 +318,7 @@ function matchesPendingDeviceRequest(item: PendingDeviceRequest, identity: Devic
 }
 
 function localIdentityNeedsScopeFix(targetDeviceId: string): boolean {
-  const identityPath = join(HOME, '.openclaw', 'identity', 'device-auth.json');
+  const identityPath = join(resolveOpenClawHome(), 'identity', 'device-auth.json');
   if (!existsSync(identityPath)) return false;
 
   try {
@@ -352,9 +361,9 @@ function repairPairedDeviceScopes(device: {
  * with full operator scopes + a device-auth.json for the CLI.
  */
 function bootstrapPairedJson(): { ok: boolean; message: string; needsRestart: boolean } {
-  const deviceJsonPath = join(HOME, '.openclaw', 'identity', 'device.json');
-  const pairedPath = join(HOME, '.openclaw', 'devices', 'paired.json');
-  const deviceAuthPath = join(HOME, '.openclaw', 'identity', 'device-auth.json');
+  const deviceJsonPath = join(resolveOpenClawHome(), 'identity', 'device.json');
+  const pairedPath = join(resolveOpenClawHome(), 'devices', 'paired.json');
+  const deviceAuthPath = join(resolveOpenClawHome(), 'identity', 'device-auth.json');
 
   if (!existsSync(deviceJsonPath)) {
     return { ok: false, message: 'No gateway device identity found', needsRestart: false };
@@ -399,7 +408,7 @@ function bootstrapPairedJson(): { ok: boolean; message: string; needsRestart: bo
       },
     };
 
-    const devicesDir = join(HOME, '.openclaw', 'devices');
+    const devicesDir = join(resolveOpenClawHome(), 'devices');
     if (!existsSync(devicesDir)) {
       mkdirSync(devicesDir, { recursive: true, mode: 0o700 });
     }
@@ -444,7 +453,7 @@ function bootstrapPairedJson(): { ok: boolean; message: string; needsRestart: bo
 export function fixGatewayDeviceScopes(opts: {
   targetDeviceId?: string;
 } = {}): { ok: boolean; message: string; needsRestart: boolean } {
-  const pairedPath = join(HOME, '.openclaw', 'devices', 'paired.json');
+  const pairedPath = join(resolveOpenClawHome(), 'devices', 'paired.json');
 
   if (!existsSync(pairedPath)) {
     // Fresh install — no paired.json yet. Bootstrap by creating it with the
@@ -479,7 +488,7 @@ export function fixGatewayDeviceScopes(opts: {
     // and triggers a scope-upgrade request that requires approval scopes to
     // approve, creating another deadlock.
     let identityChanged = false;
-    const identityPath = join(HOME, '.openclaw', 'identity', 'device-auth.json');
+    const identityPath = join(resolveOpenClawHome(), 'identity', 'device-auth.json');
     if (existsSync(identityPath)) {
       try {
         const idRaw = readFileSync(identityPath, 'utf-8');
@@ -604,7 +613,7 @@ export function prePairNerveDevice(gatewayToken?: string): { ok: boolean; messag
   const nerveDir = process.env.NERVE_DATA_DIR
     || join(process.env.HOME || HOME, '.nerve');
   const identityPath = join(nerveDir, 'device-identity.json');
-  const pairedPath = join(HOME, '.openclaw', 'devices', 'paired.json');
+  const pairedPath = join(resolveOpenClawHome(), 'devices', 'paired.json');
 
   if (!existsSync(pairedPath)) {
     // fixGatewayDeviceScopes should have created this — but handle gracefully
@@ -775,11 +784,11 @@ export interface ConfigChange {
  * Detect whether gateway-side operator scopes need repair/bootstrap.
  */
 function needsDeviceScopeFix(): boolean {
-  const pairedPath = join(HOME, '.openclaw', 'devices', 'paired.json');
+  const pairedPath = join(resolveOpenClawHome(), 'devices', 'paired.json');
 
   if (!existsSync(pairedPath)) {
     // Fresh install — needs bootstrap if the gateway identity exists
-    const deviceJsonPath = join(HOME, '.openclaw', 'identity', 'device.json');
+    const deviceJsonPath = join(resolveOpenClawHome(), 'identity', 'device.json');
     return existsSync(deviceJsonPath);
   }
 
@@ -811,7 +820,7 @@ function needsDeviceScopeFix(): boolean {
 function needsPrePair(gatewayToken?: string): boolean {
   const nerveDir = process.env.NERVE_DATA_DIR || join(process.env.HOME || HOME, '.nerve');
   const identityPath = join(nerveDir, 'device-identity.json');
-  const pairedPath = join(HOME, '.openclaw', 'devices', 'paired.json');
+  const pairedPath = join(resolveOpenClawHome(), 'devices', 'paired.json');
 
   if (!existsSync(pairedPath)) return false;
 
@@ -898,7 +907,7 @@ export function detectNeededConfigChanges(opts: {
   gatewayToken?: string;
 }): ConfigChange[] {
   const changes: ConfigChange[] = [];
-  const pairedPath = join(HOME, '.openclaw', 'devices', 'paired.json');
+  const pairedPath = join(resolveOpenClawHome(), 'devices', 'paired.json');
 
   const deviceScopeFixNeeded = needsDeviceScopeFix();
 


### PR DESCRIPTION
## Summary

Fixes #306.

Setup was hardcoded to `~/.openclaw/openclaw.json` for gateway config detection and repair. When the active gateway used `OPENCLAW_CONFIG_PATH`, Nerve could patch the wrong file and still leave cron unavailable.

## Changes

- resolve the active OpenClaw config path dynamically
- use it for gateway config detection and repair
- add regression coverage for custom `OPENCLAW_CONFIG_PATH`

## Verification

- `npm test -- --run scripts/lib/gateway-detect.test.ts`
- `npm run lint -- scripts/lib/gateway-detect.ts scripts/lib/gateway-detect.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an environment-variable override to allow using a custom gateway configuration file.

* **Improvements**
  * Configuration reads, writes and error reporting now use and surface the resolved config path.
  * Related identity/device file locations are derived from the resolved home when a custom config is used.

* **Tests**
  * Added tests ensuring custom-config behaviors and that default config/device files remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daggerhashimoto/openclaw-nerve/pull/316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->