### PR TITLE
fix(tokens): ignore invalid transcript costs in usage totals

### DIFF
--- a/server/lib/token-usage.test.ts
+++ b/server/lib/token-usage.test.ts
@@ -88,6 +88,46 @@ describe('aggregateTranscriptUsageEntries', () => {
       },
     ]);
   });
+
+  it('ignores +/-Infinity cost totals while preserving token and message counts', () => {
+    const result = aggregateTranscriptUsageEntries([
+      {
+        type: 'message',
+        message: {
+          provider: 'openrouter',
+          usage: {
+            input: 3,
+            output: 2,
+            cost: { total: Number.POSITIVE_INFINITY },
+          },
+        },
+      },
+      {
+        type: 'message',
+        message: {
+          provider: 'openrouter',
+          usage: {
+            input: 4,
+            output: 1,
+            cost: { total: Number.NEGATIVE_INFINITY },
+          },
+        },
+      },
+    ]);
+
+    expect(result.totalCost).toBe(0);
+    expect(result.entries).toEqual([
+      {
+        source: 'openrouter',
+        cost: 0,
+        messageCount: 2,
+        inputTokens: 7,
+        outputTokens: 3,
+        cacheReadTokens: 0,
+        errorCount: 0,
+      },
+    ]);
+  });
 });
 
 describe('resolveSessionTranscriptDirs', () => {

--- a/server/lib/token-usage.test.ts
+++ b/server/lib/token-usage.test.ts
@@ -1,0 +1,172 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  aggregateTranscriptUsageEntries,
+  resolveSessionTranscriptDirs,
+  scanTranscriptUsageFromDirs,
+} from './token-usage.js';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('aggregateTranscriptUsageEntries', () => {
+  it('ignores negative cost totals from transcript usage while keeping the provider row', () => {
+    const result = aggregateTranscriptUsageEntries([
+      {
+        type: 'message',
+        message: {
+          provider: 'openrouter',
+          usage: {
+            input: 123,
+            output: 45,
+            cost: { total: -38_063_010 },
+          },
+        },
+      },
+    ]);
+
+    expect(result.totalCost).toBe(0);
+    expect(result.totalInput).toBe(123);
+    expect(result.totalOutput).toBe(45);
+    expect(result.totalMessages).toBe(1);
+    expect(result.entries).toEqual([
+      {
+        source: 'openrouter',
+        cost: 0,
+        messageCount: 1,
+        inputTokens: 123,
+        outputTokens: 45,
+        cacheReadTokens: 0,
+        errorCount: 0,
+      },
+    ]);
+  });
+
+  it('ignores non-finite cost totals instead of polluting provider totals', () => {
+    const result = aggregateTranscriptUsageEntries([
+      {
+        type: 'message',
+        message: {
+          provider: 'openrouter',
+          usage: {
+            input: 10,
+            output: 5,
+            cost: { total: Number.NaN },
+          },
+        },
+      },
+      {
+        type: 'message',
+        message: {
+          provider: 'openrouter',
+          usage: {
+            input: 20,
+            output: 7,
+            cost: { total: 0.5 },
+          },
+        },
+      },
+    ]);
+
+    expect(result.totalCost).toBe(0.5);
+    expect(result.entries).toEqual([
+      {
+        source: 'openrouter',
+        cost: 0.5,
+        messageCount: 2,
+        inputTokens: 30,
+        outputTokens: 12,
+        cacheReadTokens: 0,
+        errorCount: 0,
+      },
+    ]);
+  });
+});
+
+describe('resolveSessionTranscriptDirs', () => {
+  it('expands a main agent sessions path to all sibling agent session dirs', async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'nerve-token-usage-'));
+    tempDirs.push(root);
+
+    const mainSessionsDir = path.join(root, 'agents', 'main', 'sessions');
+    const designerSessionsDir = path.join(root, 'agents', 'designer', 'sessions');
+    const cronnerSessionsDir = path.join(root, 'agents', 'cronner', 'sessions');
+    mkdirSync(mainSessionsDir, { recursive: true });
+    mkdirSync(designerSessionsDir, { recursive: true });
+    mkdirSync(cronnerSessionsDir, { recursive: true });
+
+    await expect(resolveSessionTranscriptDirs(mainSessionsDir)).resolves.toEqual([
+      cronnerSessionsDir,
+      designerSessionsDir,
+      mainSessionsDir,
+    ]);
+  });
+});
+
+describe('scanTranscriptUsageFromDirs', () => {
+  it('aggregates provider usage across sibling agent session dirs, not just main', async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'nerve-token-usage-'));
+    tempDirs.push(root);
+
+    const mainSessionsDir = path.join(root, 'agents', 'main', 'sessions');
+    const designerSessionsDir = path.join(root, 'agents', 'designer', 'sessions');
+    mkdirSync(mainSessionsDir, { recursive: true });
+    mkdirSync(designerSessionsDir, { recursive: true });
+
+    writeFileSync(
+      path.join(mainSessionsDir, 'main.jsonl'),
+      `${JSON.stringify({
+        type: 'message',
+        message: {
+          provider: 'openai-codex',
+          usage: { input: 11, output: 7, cost: { total: 0.25 } },
+        },
+      })}\n`,
+    );
+
+    writeFileSync(
+      path.join(designerSessionsDir, 'designer.jsonl'),
+      `${JSON.stringify({
+        type: 'message',
+        message: {
+          provider: 'openrouter',
+          usage: { input: 101, output: 19, cost: { total: 0.5 } },
+        },
+      })}\n`,
+    );
+
+    await expect(scanTranscriptUsageFromDirs([mainSessionsDir, designerSessionsDir])).resolves.toEqual({
+      totalCost: 0.75,
+      totalInput: 112,
+      totalOutput: 26,
+      totalMessages: 2,
+      entries: [
+        {
+          source: 'openrouter',
+          cost: 0.5,
+          messageCount: 1,
+          inputTokens: 101,
+          outputTokens: 19,
+          cacheReadTokens: 0,
+          errorCount: 0,
+        },
+        {
+          source: 'openai-codex',
+          cost: 0.25,
+          messageCount: 1,
+          inputTokens: 11,
+          outputTokens: 7,
+          cacheReadTokens: 0,
+          errorCount: 0,
+        },
+      ],
+    });
+  });
+});

--- a/server/lib/token-usage.ts
+++ b/server/lib/token-usage.ts
@@ -1,0 +1,203 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import readline from 'node:readline';
+import { createReadStream } from 'node:fs';
+
+export interface TokenUsageEntry {
+  source: string;
+  cost: number;
+  messageCount: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  errorCount: number;
+}
+
+export interface SessionCostData {
+  totalCost: number;
+  totalInput: number;
+  totalOutput: number;
+  totalMessages: number;
+  entries: TokenUsageEntry[];
+}
+
+interface ProviderStats {
+  cost: number;
+  messages: number;
+  input: number;
+  output: number;
+  cacheRead: number;
+  errors: number;
+}
+
+interface UsageAccumulator {
+  costByProvider: Record<string, ProviderStats>;
+  totalCost: number;
+  totalInput: number;
+  totalOutput: number;
+  totalMessages: number;
+}
+
+function newProviderStats(): ProviderStats {
+  return { cost: 0, messages: 0, input: 0, output: 0, cacheRead: 0, errors: 0 };
+}
+
+function asNonNegativeFiniteNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
+function round4(n: number): number {
+  return Math.round(n * 10000) / 10000;
+}
+
+export function createUsageAccumulator(): UsageAccumulator {
+  return {
+    costByProvider: {},
+    totalCost: 0,
+    totalInput: 0,
+    totalOutput: 0,
+    totalMessages: 0,
+  };
+}
+
+export function accumulateTranscriptUsageEntry(acc: UsageAccumulator, entry: unknown): void {
+  if (!entry || typeof entry !== 'object') return;
+
+  const record = entry as {
+    type?: unknown;
+    provider?: unknown;
+    message?: {
+      provider?: unknown;
+      usage?: {
+        input?: unknown;
+        output?: unknown;
+        cacheRead?: unknown;
+        cache_read?: unknown;
+        cost?: { total?: unknown };
+      };
+    };
+  };
+
+  if (record.type === 'error') {
+    const provider = typeof record.provider === 'string'
+      ? record.provider
+      : typeof record.message?.provider === 'string'
+        ? record.message.provider
+        : 'unknown';
+    (acc.costByProvider[provider] ??= newProviderStats()).errors++;
+    return;
+  }
+
+  if (record.type !== 'message') return;
+
+  const message = record.message;
+  if (!message?.usage || typeof message.provider !== 'string' || message.provider === 'openclaw') return;
+
+  const cost = asNonNegativeFiniteNumber(message.usage.cost?.total);
+  const input = asNonNegativeFiniteNumber(message.usage.input);
+  const output = asNonNegativeFiniteNumber(message.usage.output);
+  const cacheRead = asNonNegativeFiniteNumber(message.usage.cacheRead ?? message.usage.cache_read);
+
+  acc.totalCost += cost;
+  acc.totalInput += input;
+  acc.totalOutput += output;
+  acc.totalMessages++;
+
+  const stats = acc.costByProvider[message.provider] ??= newProviderStats();
+  stats.cost += cost;
+  stats.messages++;
+  stats.input += input;
+  stats.output += output;
+  stats.cacheRead += cacheRead;
+}
+
+export function finalizeUsageAccumulator(acc: UsageAccumulator): SessionCostData {
+  const entries = Object.entries(acc.costByProvider)
+    .map(([source, stats]) => ({
+      source,
+      cost: round4(stats.cost),
+      messageCount: stats.messages,
+      inputTokens: stats.input,
+      outputTokens: stats.output,
+      cacheReadTokens: stats.cacheRead,
+      errorCount: stats.errors,
+    }))
+    .sort((a, b) => b.cost - a.cost);
+
+  return {
+    totalCost: round4(acc.totalCost),
+    totalInput: acc.totalInput,
+    totalOutput: acc.totalOutput,
+    totalMessages: acc.totalMessages,
+    entries,
+  };
+}
+
+export function aggregateTranscriptUsageEntries(entries: unknown[]): SessionCostData {
+  const acc = createUsageAccumulator();
+  for (const entry of entries) accumulateTranscriptUsageEntry(acc, entry);
+  return finalizeUsageAccumulator(acc);
+}
+
+export async function resolveSessionTranscriptDirs(sessionsDir: string): Promise<string[]> {
+  const normalizedSessionsDir = path.resolve(sessionsDir);
+  const agentDir = path.dirname(normalizedSessionsDir);
+  const agentsRoot = path.dirname(agentDir);
+
+  if (path.basename(normalizedSessionsDir) !== 'sessions' || path.basename(agentsRoot) !== 'agents') {
+    return [normalizedSessionsDir];
+  }
+
+  try {
+    const entries = await fs.readdir(agentsRoot, { withFileTypes: true });
+    const sessionDirs = await Promise.all(entries
+      .filter((entry) => entry.isDirectory())
+      .map(async (entry) => {
+        const candidate = path.join(agentsRoot, entry.name, 'sessions');
+        try {
+          const stats = await fs.stat(candidate);
+          return stats.isDirectory() ? candidate : null;
+        } catch {
+          return null;
+        }
+      }));
+
+    const resolved = sessionDirs.filter((candidate): candidate is string => Boolean(candidate)).sort();
+    return resolved.length > 0 ? resolved : [normalizedSessionsDir];
+  } catch {
+    return [normalizedSessionsDir];
+  }
+}
+
+export async function scanTranscriptUsageFromDirs(sessionDirs: string[]): Promise<SessionCostData> {
+  const usage = createUsageAccumulator();
+
+  for (const sessionDir of sessionDirs) {
+    try {
+      const files = (await fs.readdir(sessionDir)).filter((file) => file.endsWith('.jsonl'));
+
+      for (const file of files) {
+        try {
+          const rl = readline.createInterface({
+            input: createReadStream(path.join(sessionDir, file)),
+            crlfDelay: Infinity,
+          });
+
+          for await (const line of rl) {
+            try {
+              accumulateTranscriptUsageEntry(usage, JSON.parse(line));
+            } catch {
+              // Skip malformed transcript lines.
+            }
+          }
+        } catch {
+          // Skip unreadable files.
+        }
+      }
+    } catch {
+      // Skip missing or unreadable session dirs.
+    }
+  }
+
+  return finalizeUsageAccumulator(usage);
+}

--- a/server/routes/tokens.ts
+++ b/server/routes/tokens.ts
@@ -8,52 +8,22 @@
  */
 
 import { Hono } from 'hono';
-import fs from 'node:fs/promises';
-import path from 'node:path';
-import readline from 'node:readline';
-import { createReadStream } from 'node:fs';
 import { updateUsage } from '../lib/usage-tracker.js';
+import {
+  resolveSessionTranscriptDirs,
+  scanTranscriptUsageFromDirs,
+  type SessionCostData,
+} from '../lib/token-usage.js';
 import { rateLimitGeneral } from '../middleware/rate-limit.js';
 import { config } from '../lib/config.js';
 
 const app = new Hono();
-
-// ── Types ────────────────────────────────────────────────────────────
-
-interface ProviderStats {
-  cost: number;
-  messages: number;
-  input: number;
-  output: number;
-  cacheRead: number;
-  errors: number;
-}
-
-interface SessionCostData {
-  totalCost: number;
-  totalInput: number;
-  totalOutput: number;
-  totalMessages: number;
-  entries: Array<{
-    source: string;
-    cost: number;
-    messageCount: number;
-    inputTokens: number;
-    outputTokens: number;
-    cacheReadTokens: number;
-    errorCount: number;
-  }>;
-}
 
 // ── Session cost scanning (cached 60s) ───────────────────────────────
 
 const EMPTY_COST_DATA: SessionCostData = { totalCost: 0, totalInput: 0, totalOutput: 0, totalMessages: 0, entries: [] };
 const COST_CACHE_TTL = 60_000;
 let costCache: { data: SessionCostData; ts: number } = { data: EMPTY_COST_DATA, ts: 0 };
-
-function newProviderStats(): ProviderStats {
-  return { cost: 0, messages: 0, input: 0, output: 0, cacheRead: 0, errors: 0 };
-}
 
 /**
  * Scan all `.jsonl` session files and aggregate token usage by provider.
@@ -63,78 +33,8 @@ async function scanSessionCosts(): Promise<SessionCostData> {
   const now = Date.now();
   if (costCache.ts && now - costCache.ts < COST_CACHE_TTL) return costCache.data;
 
-  const costByProvider: Record<string, ProviderStats> = {};
-  let totalCost = 0, totalInput = 0, totalOutput = 0, totalMessages = 0;
-
-  try {
-    const files = (await fs.readdir(config.sessionsDir)).filter((f) => f.endsWith('.jsonl'));
-
-    for (const file of files) {
-      try {
-        const rl = readline.createInterface({
-          input: createReadStream(path.join(config.sessionsDir, file)),
-          crlfDelay: Infinity,
-        });
-
-        for await (const line of rl) {
-          try {
-            const entry = JSON.parse(line);
-
-            if (entry.type === 'error') {
-              const provider = entry.provider || entry.message?.provider || 'unknown';
-              (costByProvider[provider] ??= newProviderStats()).errors++;
-              continue;
-            }
-
-            if (entry.type !== 'message') continue;
-            const msg = entry.message;
-            if (!msg?.usage || !msg.provider || msg.provider === 'openclaw') continue;
-
-            const { usage, provider = 'unknown' } = msg;
-            const cost = usage.cost?.total || 0;
-            const input = usage.input || 0;
-            const output = usage.output || 0;
-            const cacheRead = usage.cacheRead || usage.cache_read || 0;
-
-            totalCost += cost;
-            totalInput += input;
-            totalOutput += output;
-            totalMessages++;
-
-            const stats = costByProvider[provider] ??= newProviderStats();
-            stats.cost += cost;
-            stats.messages++;
-            stats.input += input;
-            stats.output += output;
-            stats.cacheRead += cacheRead;
-          } catch { /* skip malformed lines */ }
-        }
-      } catch { /* skip unreadable files */ }
-    }
-  } catch { /* sessions dir might not exist yet */ }
-
-  const round4 = (n: number) => Math.round(n * 10000) / 10000;
-
-  const entries = Object.entries(costByProvider)
-    .map(([source, d]) => ({
-      source,
-      cost: round4(d.cost),
-      messageCount: d.messages,
-      inputTokens: d.input,
-      outputTokens: d.output,
-      cacheReadTokens: d.cacheRead,
-      errorCount: d.errors,
-    }))
-    .sort((a, b) => b.cost - a.cost);
-
-  const result: SessionCostData = {
-    totalCost: round4(totalCost),
-    totalInput,
-    totalOutput,
-    totalMessages,
-    entries,
-  };
-
+  const sessionDirs = await resolveSessionTranscriptDirs(config.sessionsDir);
+  const result = await scanTranscriptUsageFromDirs(sessionDirs);
   costCache = { data: result, ts: now };
   return result;
 }


### PR DESCRIPTION
## Summary
Fix the Usage API so malformed transcript cost values do not corrupt provider totals in the Usage UI.

## What changed
- extract transcript usage aggregation into `server/lib/token-usage.ts`
- treat negative and non-finite `message.usage.cost.total` values as zero
- keep message counts and token totals intact even when cost data is invalid
- add regression tests covering malformed OpenRouter usage entries

## Why
`/api/tokens` was blindly summing transcript cost values. When a transcript contained a bad OpenRouter cost, the UI could show absurd negative totals like `-$38063010.00` instead of sane usage data.

## Verification
- `npm test -- server/lib/token-usage.test.ts`
- `npm run build:server`
- `npm run lint -- server/lib/token-usage.ts server/lib/token-usage.test.ts server/routes/tokens.ts`

Closes #305.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests verifying transcript usage aggregation and session-directory scanning to protect accuracy of reported token and cost totals.

* **Refactor**
  * Reworked token-usage aggregation so the /api/tokens endpoint now uses a centralized scanner/aggregator for consistent, reliable token and cost statistics while preserving the existing response shape.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daggerhashimoto/openclaw-nerve/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->