### PR TITLE
fix(whisper): enable Vulkan GPU backend on Linux

### DIFF
--- a/server/services/whisper-local.ts
+++ b/server/services/whisper-local.ts
@@ -70,12 +70,16 @@ async function getContext(): Promise<WhisperContext> {
   // Prevent concurrent initialization (multiple requests hitting at same time)
   if (contextInitializing) return contextInitializing;
 
-  // Pick the GPU backend: Vulkan on Linux (AMD/Intel/NVIDIA), default (Metal) on macOS.
-  const backend = process.platform === 'linux' ? 'vulkan' : undefined;
+  // Pick the GPU backend: Vulkan on Linux when a GPU is actually detected (covers
+  // AMD/Intel/NVIDIA); fall back to undefined so the underlying library can pick
+  // the default backend (Metal on macOS, CPU when no GPU is present). Forcing
+  // `'vulkan'` on a Linux host without a Vulkan ICD makes initWhisper throw and
+  // takes local STT offline entirely.
+  const backend = process.platform === 'linux' && detectGpu() ? 'vulkan' : undefined;
 
   contextInitializing = initWhisper({
     filePath: modelPath(),
-    useGpu: true, // auto-detects Metal on macOS; Vulkan on Linux; CPU fallback elsewhere
+    useGpu: true, // auto-detects Metal on macOS; Vulkan on Linux when present; CPU fallback elsewhere
   }, backend).then((ctx) => {
     whisperContext = ctx;
     contextInitializing = null;

--- a/server/services/whisper-local.ts
+++ b/server/services/whisper-local.ts
@@ -70,12 +70,13 @@ async function getContext(): Promise<WhisperContext> {
   // Prevent concurrent initialization (multiple requests hitting at same time)
   if (contextInitializing) return contextInitializing;
 
-  // Pick the GPU backend: Vulkan on Linux when a GPU is actually detected (covers
-  // AMD/Intel/NVIDIA); fall back to undefined so the underlying library can pick
-  // the default backend (Metal on macOS, CPU when no GPU is present). Forcing
-  // `'vulkan'` on a Linux host without a Vulkan ICD makes initWhisper throw and
-  // takes local STT offline entirely.
-  const backend = process.platform === 'linux' && detectGpu() ? 'vulkan' : undefined;
+  // Pick the GPU backend: Vulkan on Linux only when a Vulkan ICD/runtime is
+  // actually installed; fall back to undefined so initWhisper can pick its
+  // default (Metal on macOS, CPU on Linux without Vulkan). `detectGpu()` is too
+  // permissive here — it returns true on CUDA-only NVIDIA containers where
+  // `nvidia-smi` works but no Vulkan ICD is present, and forcing `'vulkan'` in
+  // that case makes initWhisper throw at context init.
+  const backend = process.platform === 'linux' && hasVulkanBackend() ? 'vulkan' : undefined;
 
   contextInitializing = initWhisper({
     filePath: modelPath(),
@@ -274,6 +275,19 @@ export async function setWhisperModel(model: string): Promise<{ ok: boolean; mes
 // ── System info ──────────────────────────────────────────────────────────────
 
 let gpuDetected: boolean | null = null;
+let vulkanBackendAvailable: boolean | null = null;
+
+/** Probe for a Vulkan ICD/runtime specifically — the stricter check needed before passing 'vulkan' to initWhisper. */
+function hasVulkanBackend(): boolean {
+  if (vulkanBackendAvailable !== null) return vulkanBackendAvailable;
+  try {
+    execSync('vulkaninfo --summary', { stdio: 'pipe', timeout: 3000 });
+    vulkanBackendAvailable = true;
+  } catch {
+    vulkanBackendAvailable = false;
+  }
+  return vulkanBackendAvailable;
+}
 
 /** Check if a GPU is available by looking at Vulkan/Metal/CUDA device presence. */
 function detectGpu(): boolean {

--- a/server/services/whisper-local.ts
+++ b/server/services/whisper-local.ts
@@ -70,10 +70,13 @@ async function getContext(): Promise<WhisperContext> {
   // Prevent concurrent initialization (multiple requests hitting at same time)
   if (contextInitializing) return contextInitializing;
 
+  // Pick the GPU backend: Vulkan on Linux (AMD/Intel/NVIDIA), default (Metal) on macOS.
+  const backend = process.platform === 'linux' ? 'vulkan' : undefined;
+
   contextInitializing = initWhisper({
     filePath: modelPath(),
-    useGpu: true, // auto-detects Metal on macOS; CPU fallback elsewhere
-  }).then((ctx) => {
+    useGpu: true, // auto-detects Metal on macOS; Vulkan on Linux; CPU fallback elsewhere
+  }, backend).then((ctx) => {
     whisperContext = ctx;
     contextInitializing = null;
     console.log(`[whisper-local] Model loaded: ${activeModel}`);
@@ -393,6 +396,7 @@ export async function transcribeLocal(
     const transcribeOpts: TranscribeOptions = {
       temperature: 0.0,
       language: whisperLang,
+      maxThreads: cpus().length,
     };
     const { promise } = ctx.transcribeFile(wavTmp, transcribeOpts);
 

--- a/server/services/whisper-local.ts
+++ b/server/services/whisper-local.ts
@@ -70,17 +70,19 @@ async function getContext(): Promise<WhisperContext> {
   // Prevent concurrent initialization (multiple requests hitting at same time)
   if (contextInitializing) return contextInitializing;
 
-  // Pick the GPU backend: Vulkan on Linux only when a Vulkan ICD/runtime is
-  // actually installed; fall back to undefined so initWhisper can pick its
-  // default (Metal on macOS, CPU on Linux without Vulkan). `detectGpu()` is too
-  // permissive here — it returns true on CUDA-only NVIDIA containers where
-  // `nvidia-smi` works but no Vulkan ICD is present, and forcing `'vulkan'` in
-  // that case makes initWhisper throw at context init.
-  const backend = process.platform === 'linux' && hasVulkanBackend() ? 'vulkan' : undefined;
+  // useGpu is meaningful on macOS (triggers Metal) and on Linux when a Vulkan
+  // ICD is present; on Linux without Vulkan we must keep useGpu false too so
+  // initWhisper doesn't fall into "useGpu=true + backend=undefined" territory
+  // and probe on its own. `detectGpu()` is too permissive for the backend
+  // gate — it returns true on CUDA-only NVIDIA containers where nvidia-smi
+  // works but no Vulkan ICD is installed, and forcing 'vulkan' in that case
+  // makes initWhisper throw at context init.
+  const useGpu = process.platform !== 'linux' || hasVulkanBackend();
+  const backend = process.platform === 'linux' && useGpu ? 'vulkan' : undefined;
 
   contextInitializing = initWhisper({
     filePath: modelPath(),
-    useGpu: true, // auto-detects Metal on macOS; Vulkan on Linux when present; CPU fallback elsewhere
+    useGpu, // Metal on macOS; Vulkan on Linux when present; CPU fallback elsewhere
   }, backend).then((ctx) => {
     whisperContext = ctx;
     contextInitializing = null;
@@ -295,8 +297,8 @@ function detectGpu(): boolean {
   try {
     // Try nvidia-smi (CUDA)
     try { execSync('nvidia-smi', { stdio: 'pipe', timeout: 3000 }); gpuDetected = true; return true; } catch { /* no nvidia */ }
-    // Try vulkaninfo
-    try { execSync('vulkaninfo --summary', { stdio: 'pipe', timeout: 3000 }); gpuDetected = true; return true; } catch { /* no vulkan */ }
+    // Reuse the Vulkan probe so vulkaninfo is spawned at most once per process.
+    if (hasVulkanBackend()) { gpuDetected = true; return true; }
     // macOS Metal is always available on Apple Silicon
     if (process.platform === 'darwin' && process.arch === 'arm64') { gpuDetected = true; return true; }
     gpuDetected = false;


### PR DESCRIPTION

UPDATED SUMMARY:
Summary
Enables the Vulkan GPU backend for local Whisper transcription on Linux, and utilizes all available CPU threads for transcription.

Problem
On Linux systems with AMD or Intel GPUs, the @fugood/whisper.node binding silently falls back to CPU-only inference even when useGpu: true is passed to initWhisper. This results in transcription times of 14–34 seconds for short audio clips on an AMD RX 6600 XT.

The root cause is that the binding requires an explicit backend variant string ('vulkan') on Linux to load the GPU backend, unlike macOS where Metal is auto-detected via the 'default' variant.

Additionally, the transcription options did not set maxThreads, leaving performance on the table on multi-core systems.

Changes
Platform-conditional backend selection in server/services/whisper-local.ts:

Linux → 'vulkan' (enables GPU acceleration for AMD/Intel/NVIDIA via RADV/mesa)
macOS → undefined (uses 'default' variant, enabling Metal on Apple Silicon with CPU fallback on x86_64)
Windows/others → undefined (uses 'default' variant)
Set maxThreads: cpus().length in the TranscribeOptions passed to transcribeFile. This ensures transcription uses all available logical CPU cores.
[Dev option as to whether this is wise or not, see coderabbit review]

Performance Impact
Tested on AMD Radeon RX 6600 XT (RADV NAVI23, Mesa Vulkan drivers):

Model	Before (CPU)	After (Vulkan)	Improvement
tiny	~14 s	~0.9 s	15.6×
base	~34 s	~0.58 s	58.6×
small	—	~1.77 s	—
Verification
 vkcube runs successfully, confirming Vulkan driver availability.
 Whisper logs show using Vulkan0 backend after the change.
 Rebuild (npm run build:server) and server restart confirmed working.
Compatibility Notes
macOS: Preserved. Metal is still auto-detected via the 'default' variant on Apple Silicon.
Linux + NVIDIA: The 'vulkan' backend should also work for NVIDIA GPUs with proprietary or Nouveau Vulkan drivers, but has not been explicitly tested.
Linux without GPU: The binding will fall back to CPU if Vulkan is unavailable, maintaining existing behavior.
Non-Vulkan Linux: Will throw if Vulkan drivers are absent; users should install Mesa/Vulkan ICDs or fall back to CPU-only systems.
Related
This fix was initially documented in the agent's session memory on 2026-04-24 after debugging slow transcription on an Arch Linux workstation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Transcription now prefers GPU-based (Vulkan) compute on Linux only when a quick compatibility probe confirms availability, with a cached result to avoid repeated checks.
  * Added a per-request thread cap for transcription set to the host CPU count to limit concurrency and reduce resource contention.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daggerhashimoto/openclaw-nerve/pull/319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->