### PR TITLE
fix(connect): recover cleanly from interrupted reload handshakes

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -103,9 +103,18 @@ app.use('*', async (c, next) => {
   if (c.req.path.startsWith('/api/')) return next();
   return serveStatic({ root: './dist/' })(c, next);
 });
-// SPA fallback — serve index.html for non-API routes (client-side routing)
+// SPA fallback — serve index.html only for extensionless app routes.
+// If a hashed asset or other static file is missing, return 404 instead of
+// silently serving index.html. That avoids stale post-upgrade bundles loading
+// HTML as JavaScript after a deploy/release switch.
 app.get('*', async (c, next) => {
   if (c.req.path.startsWith('/api/')) return next();
+
+  const looksLikeStaticFile = c.req.path.startsWith('/assets/') || (c.req.path !== '/' && c.req.path.includes('.'));
+  if (looksLikeStaticFile) {
+    return c.notFound();
+  }
+
   return serveStatic({ root: './dist/', path: 'index.html' })(c, next);
 });
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -110,7 +110,11 @@ app.use('*', async (c, next) => {
 app.get('*', async (c, next) => {
   if (c.req.path.startsWith('/api/')) return next();
 
-  const looksLikeStaticFile = c.req.path.startsWith('/assets/') || (c.req.path !== '/' && c.req.path.includes('.'));
+  // Match a real file extension at the end of the path (e.g., `.js`, `.css`, `.map`)
+  // rather than any dot anywhere in the path. The previous `.includes('.')`
+  // would 404 paths like `/.well-known/acme-challenge/<token>` or any future
+  // app route with a dot in a directory segment.
+  const looksLikeStaticFile = c.req.path.startsWith('/assets/') || /\.[a-zA-Z0-9]+$/.test(c.req.path);
   if (looksLikeStaticFile) {
     return c.notFound();
   }

--- a/src/hooks/useWebSocket.test.ts
+++ b/src/hooks/useWebSocket.test.ts
@@ -288,13 +288,16 @@ describe('useWebSocket', () => {
         firstWs.simulateMessage({ type: 'res', id: firstReqId, ok: true, payload: {} });
       });
 
-      // unexpected close triggers reconnect
+      // unexpected close triggers reconnect. Advance only enough to fire the
+      // reconnect delay (~1000-1500ms) without letting the new socket's
+      // CONNECT_TIMEOUT_MS (10s) fire, which would close it and cause an
+      // infinite reconnect loop under correct stale-onclose handling.
       act(() => {
         firstWs.close();
       });
 
       await act(async () => {
-        await vi.runAllTimersAsync();
+        await vi.advanceTimersByTimeAsync(2000);
       });
 
       expect(wsInstances.length).toBeGreaterThanOrEqual(2);
@@ -358,13 +361,14 @@ describe('useWebSocket', () => {
         simulateAuthHandshake(firstWs);
       });
 
-      // Simulate unexpected close
+      // Simulate unexpected close. Advance just past the reconnect delay
+      // without letting the new socket's CONNECT_TIMEOUT_MS (10s) fire.
       act(() => {
         firstWs.close();
       });
 
       await act(async () => {
-        await vi.runAllTimersAsync();
+        await vi.advanceTimersByTimeAsync(2000);
       });
 
       expect(result.current.connectionState).toBe('reconnecting');
@@ -455,12 +459,15 @@ describe('useWebSocket', () => {
         simulateAuthHandshake(firstWs);
       });
 
+      // Advance only past the reconnect delay so the new ws is created without
+      // letting its CONNECT_TIMEOUT_MS fire (which would otherwise loop forever
+      // now that stale onclose no longer clobbers the new socket's timeout).
       act(() => {
         firstWs.close();
       });
 
       await act(async () => {
-        await vi.runAllTimersAsync();
+        await vi.advanceTimersByTimeAsync(2000);
       });
 
       expect(wsInstances.length).toBeGreaterThanOrEqual(2);
@@ -482,8 +489,9 @@ describe('useWebSocket', () => {
         });
       });
 
+      // Auth failure triggers another reconnect; advance past that delay too.
       await act(async () => {
-        await vi.runAllTimersAsync();
+        await vi.advanceTimersByTimeAsync(3000);
       });
 
       expect(result.current.connectionState).toBe('reconnecting');

--- a/src/hooks/useWebSocket.test.ts
+++ b/src/hooks/useWebSocket.test.ts
@@ -55,6 +55,24 @@ function getConnectRequest(ws: MockWebSocket): Record<string, unknown> | null {
   return JSON.parse(connectReq) as Record<string, unknown>;
 }
 
+function simulateAuthHandshake(ws: MockWebSocket, nonce = 'test-nonce') {
+  ws.simulateMessage({
+    type: 'event',
+    event: 'connect.challenge',
+    payload: { nonce },
+  });
+
+  const connectReq = getConnectRequest(ws);
+  expect(connectReq).toBeTruthy();
+
+  ws.simulateMessage({
+    type: 'res',
+    id: connectReq?.id,
+    ok: true,
+    payload: { sessionId: 'test-session' },
+  });
+}
+
 describe('useWebSocket', () => {
   let originalWebSocket: typeof WebSocket;
 
@@ -77,11 +95,66 @@ describe('useWebSocket', () => {
       expect(result.current.connectionState).toBe('disconnected');
     });
 
+    it('rejects the initial connect promise if the socket closes before handshake completes', async () => {
+      const wsInstances: MockWebSocket[] = [];
+      const OriginalMockWS = MockWebSocket;
+      (globalThis as unknown as { WebSocket: typeof MockWebSocket }).WebSocket = class extends OriginalMockWS {
+        constructor(url: string) {
+          super(url);
+          wsInstances.push(this);
+        }
+      };
+
+      const { result } = renderHook(() => useWebSocket());
+
+      let connectError: Error | null = null;
+      act(() => {
+        result.current.connect('ws://localhost:8080', 'test-token').catch((err: Error) => {
+          connectError = err;
+        });
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      act(() => {
+        wsInstances[0].close();
+      });
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(connectError?.message).toBe('WebSocket disconnected before connect completed');
+      expect(result.current.connectionState).toBe('disconnected');
+    });
+
+    it('times out the initial connect attempt instead of hanging forever', async () => {
+      const { result } = renderHook(() => useWebSocket());
+
+      let connectError: Error | null = null;
+      act(() => {
+        result.current.connect('ws://localhost:8080', 'test-token').catch((err: Error) => {
+          connectError = err;
+        });
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10001);
+        await vi.runAllTimersAsync();
+      });
+
+      expect(connectError?.message).toBe('Connection timed out');
+      expect(result.current.connectionState).toBe('disconnected');
+      expect(result.current.connectError).toBe('Connection timed out — retry');
+    });
+
     it('should transition to connecting state when connect is called', async () => {
       const { result } = renderHook(() => useWebSocket());
       
       act(() => {
-        result.current.connect('ws://localhost:8080', 'test-token');
+        result.current.connect('ws://localhost:8080', 'test-token').catch(() => {});
       });
 
       expect(result.current.connectionState).toBe('connecting');
@@ -91,7 +164,7 @@ describe('useWebSocket', () => {
       const { result } = renderHook(() => useWebSocket());
       
       act(() => {
-        result.current.connect('ws://localhost:8080', 'test-token');
+        result.current.connect('ws://localhost:8080', 'test-token').catch(() => {});
       });
 
       await act(async () => {
@@ -124,11 +197,11 @@ describe('useWebSocket', () => {
       const { result } = renderHook(() => useWebSocket());
 
       act(() => {
-        result.current.connect('ws://localhost:8080', 'test-token');
+        result.current.connect('ws://localhost:8080', 'test-token').catch(() => {});
       });
 
       await act(async () => {
-        await vi.runAllTimersAsync();
+        await vi.advanceTimersByTimeAsync(0);
       });
 
       const ws = wsInstances[0];
@@ -156,11 +229,11 @@ describe('useWebSocket', () => {
       const { result } = renderHook(() => useWebSocket());
 
       act(() => {
-        result.current.connect('ws://localhost:8080', 'test-token');
+        result.current.connect('ws://localhost:8080', 'test-token').catch(() => {});
       });
 
       await act(async () => {
-        await vi.runAllTimersAsync();
+        await vi.advanceTimersByTimeAsync(0);
       });
 
       const ws = wsInstances[0];
@@ -189,7 +262,7 @@ describe('useWebSocket', () => {
       const { result } = renderHook(() => useWebSocket());
 
       act(() => {
-        result.current.connect('ws://localhost:8080', 'test-token');
+        result.current.connect('ws://localhost:8080', 'test-token').catch(() => {});
       });
 
       await act(async () => {
@@ -270,7 +343,7 @@ describe('useWebSocket', () => {
       
       // Initial connection
       act(() => {
-        result.current.connect('ws://localhost:8080', 'test-token');
+        result.current.connect('ws://localhost:8080', 'test-token').catch(() => {});
       });
 
       await act(async () => {
@@ -311,7 +384,7 @@ describe('useWebSocket', () => {
       const { result } = renderHook(() => useWebSocket());
       
       act(() => {
-        result.current.connect('ws://localhost:8080', 'test-token');
+        result.current.connect('ws://localhost:8080', 'test-token').catch(() => {});
       });
 
       await act(async () => {
@@ -345,7 +418,7 @@ describe('useWebSocket', () => {
       expect(result.current.reconnectAttempt).toBe(0);
       
       act(() => {
-        result.current.connect('ws://localhost:8080', 'test-token');
+        result.current.connect('ws://localhost:8080', 'test-token').catch(() => {});
       });
 
       expect(result.current.reconnectAttempt).toBe(0);
@@ -370,7 +443,7 @@ describe('useWebSocket', () => {
       const { result } = renderHook(() => useWebSocket());
 
       act(() => {
-        result.current.connect('ws://localhost:8080', 'test-token');
+        result.current.connect('ws://localhost:8080', 'test-token').catch(() => {});
       });
 
       await act(async () => {
@@ -434,11 +507,15 @@ describe('useWebSocket', () => {
       const { result } = renderHook(() => useWebSocket());
       
       act(() => {
-        result.current.connect('ws://localhost:8080', 'test-token');
+        result.current.connect('ws://localhost:8080', 'test-token').catch(() => {});
       });
 
       await act(async () => {
-        await vi.runAllTimersAsync();
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      act(() => {
+        simulateAuthHandshake(wsInstances[0]);
       });
 
       let rpcError: Error | null = null;
@@ -486,11 +563,11 @@ describe('useWebSocket', () => {
       const { result } = renderHook(() => useWebSocket());
       
       act(() => {
-        result.current.connect('ws://localhost:8080', 'test-token');
+        result.current.connect('ws://localhost:8080', 'test-token').catch(() => {});
       });
 
       await act(async () => {
-        await vi.runAllTimersAsync();
+        await vi.advanceTimersByTimeAsync(0);
       });
 
       act(() => {
@@ -498,7 +575,7 @@ describe('useWebSocket', () => {
       });
 
       await act(async () => {
-        await vi.runAllTimersAsync();
+        await vi.advanceTimersByTimeAsync(0);
       });
 
       const ws = wsInstances[0];
@@ -523,7 +600,7 @@ describe('useWebSocket', () => {
       const { result } = renderHook(() => useWebSocket());
       
       act(() => {
-        result.current.connect('wss://secure.example.com', 'token');
+        result.current.connect('wss://secure.example.com', 'token').catch(() => {});
       });
 
       expect(result.current.connectionState).toBe('connecting');
@@ -534,7 +611,7 @@ describe('useWebSocket', () => {
       
       expect(() => {
         act(() => {
-          result.current.connect('ws://localhost:8080', 'test-token');
+          result.current.connect('ws://localhost:8080', 'test-token').catch(() => {});
         });
       }).not.toThrow();
     });

--- a/src/hooks/useWebSocket.test.ts
+++ b/src/hooks/useWebSocket.test.ts
@@ -179,6 +179,49 @@ describe('useWebSocket', () => {
       expect(result.current.connectionState).toBe('disconnected');
     });
 
+    it('rejects the previous in-flight connect when a new connect() supersedes it', async () => {
+      // Regression: a second connect() used to overwrite connectResolveRef /
+      // connectRejectRef without settling the first attempt. Combined with the
+      // stale-generation guard in onclose, that left the first promise pending
+      // forever and re-introduced the hang the PR set out to fix.
+      const wsInstances: MockWebSocket[] = [];
+      const OriginalMockWS = MockWebSocket;
+      (globalThis as unknown as { WebSocket: typeof MockWebSocket }).WebSocket = class extends OriginalMockWS {
+        constructor(url: string) {
+          super(url);
+          wsInstances.push(this);
+        }
+      };
+
+      const { result } = renderHook(() => useWebSocket());
+
+      let firstError: Error | null = null;
+      let secondError: Error | null = null;
+      act(() => {
+        result.current.connect('ws://localhost:8080', 'first-token').catch((err: Error) => {
+          firstError = err;
+        });
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      // Start a second connect before the first one settles.
+      act(() => {
+        result.current.connect('ws://localhost:8080', 'second-token').catch((err: Error) => {
+          secondError = err;
+        });
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      expect(firstError?.message).toBe('Superseded by a new connection attempt');
+      expect(secondError).toBeNull();
+    });
+
     it('times out the initial connect attempt instead of hanging forever', async () => {
       const { result } = renderHook(() => useWebSocket());
 

--- a/src/hooks/useWebSocket.test.ts
+++ b/src/hooks/useWebSocket.test.ts
@@ -130,6 +130,55 @@ describe('useWebSocket', () => {
       expect(result.current.connectionState).toBe('disconnected');
     });
 
+    it('rejects the initial connect promise if the socket closes mid-handshake after challenge', async () => {
+      // Covers the specific case the PR set out to fix: connect.challenge has
+      // arrived, the auth request is in flight, then the socket closes before
+      // the auth response. connectReqIdRef.current is non-null when onclose
+      // fires, so this exercises a different code path than the close-before-
+      // challenge test above.
+      const wsInstances: MockWebSocket[] = [];
+      const OriginalMockWS = MockWebSocket;
+      (globalThis as unknown as { WebSocket: typeof MockWebSocket }).WebSocket = class extends OriginalMockWS {
+        constructor(url: string) {
+          super(url);
+          wsInstances.push(this);
+        }
+      };
+
+      const { result } = renderHook(() => useWebSocket());
+
+      let connectError: Error | null = null;
+      act(() => {
+        result.current.connect('ws://localhost:8080', 'test-token').catch((err: Error) => {
+          connectError = err;
+        });
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      const ws = wsInstances[0];
+      act(() => {
+        ws.simulateMessage({ type: 'event', event: 'connect.challenge', payload: { nonce: 'mid-handshake' } });
+      });
+
+      // The hook should have sent the auth request now; verify so the test fails
+      // loudly if the precondition stops holding.
+      expect(getConnectRequest(ws)).toBeTruthy();
+
+      act(() => {
+        ws.close();
+      });
+
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+
+      expect(connectError?.message).toBe('WebSocket disconnected before connect completed');
+      expect(result.current.connectionState).toBe('disconnected');
+    });
+
     it('times out the initial connect attempt instead of hanging forever', async () => {
       const { result } = renderHook(() => useWebSocket());
 

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -20,6 +20,7 @@ interface UseWebSocketReturn {
 
 const RECONNECT_BASE_DELAY = 1000;
 const RECONNECT_MAX_DELAY = 30000;
+const CONNECT_TIMEOUT_MS = 10000;
 const INSTANCE_ID_STORAGE_KEY = 'oc-webchat-instance-id';
 
 function generateInstanceId(): string {
@@ -62,6 +63,7 @@ export function useWebSocket(): UseWebSocketReturn {
   const connectReqIdRef = useRef<string | null>(null);
   const connectResolveRef = useRef<(() => void) | null>(null);
   const connectRejectRef = useRef<((e: Error) => void) | null>(null);
+  const connectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const onEvent = useRef<((msg: GatewayEvent) => void) | null>(null);
   
   // Auto-reconnect state
@@ -94,6 +96,31 @@ export function useWebSocket(): UseWebSocketReturn {
     }
   }, []);
 
+  const clearConnectTimeout = useCallback(() => {
+    if (connectTimeoutRef.current) {
+      clearTimeout(connectTimeoutRef.current);
+      connectTimeoutRef.current = null;
+    }
+  }, []);
+
+  const settleConnectFailure = useCallback((err: Error) => {
+    clearConnectTimeout();
+    connectReqIdRef.current = null;
+    const reject = connectRejectRef.current;
+    connectResolveRef.current = null;
+    connectRejectRef.current = null;
+    reject?.(err);
+  }, [clearConnectTimeout]);
+
+  const settleConnectSuccess = useCallback(() => {
+    clearConnectTimeout();
+    connectReqIdRef.current = null;
+    const resolve = connectResolveRef.current;
+    connectResolveRef.current = null;
+    connectRejectRef.current = null;
+    resolve?.();
+  }, [clearConnectTimeout]);
+
   const rpc = useCallback((method: string, params: Record<string, unknown> = {}): Promise<unknown> => {
     return new Promise((resolve, reject) => {
       const ws = wsRef.current;
@@ -120,6 +147,7 @@ export function useWebSocket(): UseWebSocketReturn {
       }
       if (wsRef.current) { wsRef.current.close(); wsRef.current = null; }
       rejectPending(new Error('Disconnected'));
+      clearConnectTimeout();
       connectReqIdRef.current = null;
       connectResolveRef.current = resolve;
       connectRejectRef.current = reject;
@@ -145,6 +173,17 @@ export function useWebSocket(): UseWebSocketReturn {
         return;
       }
       wsRef.current = ws;
+
+      connectTimeoutRef.current = setTimeout(() => {
+        if (gen !== connectionGenRef.current) return;
+        const err = new Error('Connection timed out');
+        if (!isReconnect) {
+          setConnectError('Connection timed out — retry');
+        }
+        settleConnectFailure(err);
+        setConnectionState(hasConnectedRef.current ? 'reconnecting' : 'disconnected');
+        ws.close();
+      }, CONNECT_TIMEOUT_MS);
 
       ws.onopen = () => {
         setConnectionState(isReconnect ? 'reconnecting' : 'connecting');
@@ -181,7 +220,6 @@ export function useWebSocket(): UseWebSocketReturn {
         if (msg.type === 'res') {
           const response = msg as GatewayResponse;
           if (response.id === connectReqIdRef.current) {
-            connectReqIdRef.current = null;
             if (response.ok) {
               // Success! Reset reconnect counter
               reconnectAttemptRef.current = 0;
@@ -189,15 +227,15 @@ export function useWebSocket(): UseWebSocketReturn {
               setReconnectAttempt(0);
               setConnectError('');
               setConnectionState('connected');
-              connectResolveRef.current?.();
+              settleConnectSuccess();
             } else {
               const errMsg = 'Auth failed: ' + (response.error?.message || 'unknown');
               setConnectError(errMsg);
               setConnectionState('disconnected');
               // Treat auth failures during reconnect like transient failures so the
               // socket keeps retrying instead of getting stuck until a manual reload.
+              settleConnectFailure(new Error(errMsg));
               ws.close();
-              connectRejectRef.current?.(new Error(errMsg));
             }
             return;
           }
@@ -228,10 +266,15 @@ export function useWebSocket(): UseWebSocketReturn {
       };
 
       ws.onclose = () => {
+        clearConnectTimeout();
         rejectPending(new Error('WebSocket disconnected'));
 
         // Stale connection: a newer doConnect has already superseded this one
         if (gen !== connectionGenRef.current) return;
+
+        if (connectRejectRef.current) {
+          settleConnectFailure(new Error('WebSocket disconnected before connect completed'));
+        }
 
         // Don't reconnect if intentionally disconnected, no credentials, or never connected
         if (intentionalDisconnectRef.current || !credentialsRef.current || !hasConnectedRef.current) {
@@ -262,7 +305,7 @@ export function useWebSocket(): UseWebSocketReturn {
         }, delay);
       };
     });
-  }, [rejectPending]);
+  }, [clearConnectTimeout, rejectPending, settleConnectFailure, settleConnectSuccess]);
   
   // Store doConnect in ref so it can reference itself for reconnection
   useEffect(() => {
@@ -273,6 +316,7 @@ export function useWebSocket(): UseWebSocketReturn {
   useEffect(() => {
     return () => {
       clearReconnectTimeout();
+      clearConnectTimeout();
       if (wsRef.current) {
         intentionalDisconnectRef.current = true; // prevent reconnect on cleanup close
         wsRef.current.close();
@@ -280,11 +324,12 @@ export function useWebSocket(): UseWebSocketReturn {
       }
       rejectPending(new Error('Component unmounted'));
     };
-  }, [clearReconnectTimeout, rejectPending]);
+  }, [clearConnectTimeout, clearReconnectTimeout, rejectPending]);
 
   const disconnect = useCallback(() => {
     intentionalDisconnectRef.current = true;
     clearReconnectTimeout();
+    clearConnectTimeout();
     reconnectAttemptRef.current = 0;
     setReconnectAttempt(0);
     credentialsRef.current = null;
@@ -293,8 +338,9 @@ export function useWebSocket(): UseWebSocketReturn {
       wsRef.current = null;
     }
     rejectPending(new Error('Disconnected'));
+    settleConnectFailure(new Error('Disconnected'));
     setConnectionState('disconnected');
-  }, [rejectPending, clearReconnectTimeout]);
+  }, [clearConnectTimeout, clearReconnectTimeout, rejectPending, settleConnectFailure]);
 
   const connect = useCallback((url: string, token: string): Promise<void> => {
     // Store credentials for reconnection

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -266,11 +266,14 @@ export function useWebSocket(): UseWebSocketReturn {
       };
 
       ws.onclose = () => {
+        // Stale connection: a newer doConnect has already superseded this one.
+        // Guard BEFORE touching shared refs - otherwise a late close from the
+        // previous socket clobbers the current attempt's timeout and pending
+        // RPCs, reintroducing the hang/drop race during overlapping reconnects.
+        if (gen !== connectionGenRef.current) return;
+
         clearConnectTimeout();
         rejectPending(new Error('WebSocket disconnected'));
-
-        // Stale connection: a newer doConnect has already superseded this one
-        if (gen !== connectionGenRef.current) return;
 
         if (connectRejectRef.current) {
           settleConnectFailure(new Error('WebSocket disconnected before connect completed'));

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -147,8 +147,16 @@ export function useWebSocket(): UseWebSocketReturn {
       }
       if (wsRef.current) { wsRef.current.close(); wsRef.current = null; }
       rejectPending(new Error('Disconnected'));
-      clearConnectTimeout();
-      connectReqIdRef.current = null;
+      // Settle any in-flight previous connect before installing new callbacks.
+      // Without this the previous promise leaks: the prior socket's onclose
+      // now hits the stale-generation guard below and returns early, so the
+      // pending resolve/reject would never be called.
+      if (connectRejectRef.current) {
+        settleConnectFailure(new Error('Superseded by a new connection attempt'));
+      } else {
+        clearConnectTimeout();
+        connectReqIdRef.current = null;
+      }
       connectResolveRef.current = resolve;
       connectRejectRef.current = reject;
 
@@ -185,11 +193,15 @@ export function useWebSocket(): UseWebSocketReturn {
         ws.close();
       }, CONNECT_TIMEOUT_MS);
 
+      // Same stale-generation guard as onclose: a late event from a
+      // superseded socket must not mutate the current attempt's state/refs.
       ws.onopen = () => {
+        if (gen !== connectionGenRef.current) return;
         setConnectionState(isReconnect ? 'reconnecting' : 'connecting');
       };
 
       ws.onmessage = (ev) => {
+        if (gen !== connectionGenRef.current) return;
         let msg: GatewayMessage;
         try { msg = JSON.parse(ev.data) as GatewayMessage; } catch { return; }
 
@@ -259,6 +271,7 @@ export function useWebSocket(): UseWebSocketReturn {
       };
 
       ws.onerror = () => {
+        if (gen !== connectionGenRef.current) return;
         // Don't set error message during reconnect attempts (too noisy)
         if (!isReconnect) {
           setConnectError('WebSocket error — check URL');


### PR DESCRIPTION
## Summary

Reloads could get stuck on the gateway "Connecting..." screen after an interrupted OpenClaw handshake.
This change makes the client fail and recover cleanly instead of hanging forever.
It also stops missing hashed assets from being served as `index.html`, which avoids stale tabs booting broken JavaScript after a deploy or release switch.

## What Changed

The connect flow now settles every initial handshake path instead of leaving a pending promise behind.
The server now only uses the SPA fallback for extensionless app routes.

- add a 10s timeout for the initial gateway connect handshake
- reject the pending connect promise when the socket closes before the handshake finishes
- clear connect timers on success, disconnect, cleanup, and reconnect transitions
- add regression tests for early socket close and handshake timeout cases
- return 404 for missing `/assets/*` and other dotted static paths instead of serving `index.html`

## Testing

I tested the broken handshake paths directly and rebuilt the app on current `master`.

- `npm test -- --run src/hooks/useWebSocket.test.ts`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SPA fallback now returns 404 for asset or file-extension-like requests instead of serving the main HTML.
  * WebSocket connect flow hardened: per-attempt connect timeouts, pending connect attempts are settled or superseded, stale sockets are generation-guarded, and disconnect/unmount paths clear timeouts and prevent hanging states.

* **Tests**
  * Expanded connection-state tests (timeouts, mid-handshake disconnects, supersession), added an auth-handshake test helper, tightened timer control and suppressed unhandled promise rejections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daggerhashimoto/openclaw-nerve/pull/326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->