### PR TITLE
Fix active chat rejoin after refresh

### DIFF
--- a/src/contexts/ChatContext.subscription.test.tsx
+++ b/src/contexts/ChatContext.subscription.test.tsx
@@ -1,8 +1,9 @@
-/** Regression test: ChatContext should not resubscribe on local state updates. */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, act, waitFor } from '@testing-library/react';
+/** Regression tests for ChatContext realtime subscriptions. */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act, waitFor, screen } from '@testing-library/react';
 import { useEffect } from 'react';
 import type { ImageAttachment } from '@/features/chat/types';
+import type { GatewayEvent, Session } from '@/types';
 
 describe('ChatContext subscription stability', () => {
   beforeEach(() => {
@@ -10,16 +11,29 @@ describe('ChatContext subscription stability', () => {
     vi.clearAllMocks();
   });
 
-  async function setup() {
-    const subscribeMock = vi.fn(() => () => {});
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function setup(options: {
+    connectionState?: 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
+    currentSession?: string;
+    sessions?: Session[];
+  } = {}) {
+    const subscribedHandlers: Array<(msg: GatewayEvent) => void> = [];
+    const subscribeMock = vi.fn((handler: (msg: GatewayEvent) => void) => {
+      subscribedHandlers.push(handler);
+      return () => {};
+    });
     const rpcMock = vi.fn(async (method: string) => {
       if (method === 'chat.send') return { runId: 'run-1', status: 'started' };
+      if (method === 'chat.history') return { messages: [] };
       return {};
     });
 
     vi.doMock('./GatewayContext', () => ({
       useGateway: () => ({
-        connectionState: 'disconnected',
+        connectionState: options.connectionState || 'disconnected',
         rpc: rpcMock,
         subscribe: subscribeMock,
       }),
@@ -27,8 +41,8 @@ describe('ChatContext subscription stability', () => {
 
     vi.doMock('./SessionContext', () => ({
       useSessionContext: () => ({
-        currentSession: 'main',
-        sessions: [],
+        currentSession: options.currentSession || 'main',
+        sessions: options.sessions || [],
       }),
     }));
 
@@ -40,7 +54,7 @@ describe('ChatContext subscription stability', () => {
     }));
 
     const mod = await import('./ChatContext');
-    return { ...mod, subscribeMock };
+    return { ...mod, rpcMock, subscribeMock, subscribedHandlers };
   }
 
   it('keeps a single subscribe registration after handleSend-triggered rerender', async () => {
@@ -71,5 +85,92 @@ describe('ChatContext subscription stability', () => {
 
     // Regression assertion: local state updates should not cause resubscription churn.
     expect(subscribeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribes to current session message broadcasts while connected and cleans up', async () => {
+    const { ChatProvider, rpcMock } = await setup({ connectionState: 'connected' });
+
+    const { unmount } = render(
+      <ChatProvider>
+        <div />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('sessions.messages.subscribe', { key: 'main' });
+    });
+
+    unmount();
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('sessions.messages.unsubscribe', { key: 'main' });
+    });
+  });
+
+  it('hydrates active generation state from a refreshed session snapshot', async () => {
+    const { ChatProvider, useChat, rpcMock } = await setup({
+      connectionState: 'connected',
+      sessions: [{ sessionKey: 'main', hasActiveRun: true, status: 'running' }],
+    });
+
+    function Consumer() {
+      const chat = useChat();
+      return (
+        <div>
+          <div data-testid="is-generating">{String(chat.isGenerating)}</div>
+          <div data-testid="processing-stage">{chat.processingStage || 'NONE'}</div>
+        </div>
+      );
+    }
+
+    render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('true');
+    });
+    expect(screen.getByTestId('processing-stage').textContent).toBe('thinking');
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('chat.history', { sessionKey: 'main', limit: 120 });
+    });
+  });
+
+  it('hydrates active generation state from a subscribed lifecycle event after refresh', async () => {
+    const { ChatProvider, useChat, subscribedHandlers } = await setup({ connectionState: 'connected' });
+
+    function Consumer() {
+      const chat = useChat();
+      return (
+        <div>
+          <div data-testid="is-generating">{String(chat.isGenerating)}</div>
+          <div data-testid="processing-stage">{chat.processingStage || 'NONE'}</div>
+        </div>
+      );
+    }
+
+    render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(subscribedHandlers.length).toBe(1));
+
+    act(() => {
+      subscribedHandlers[0]({
+        type: 'event',
+        event: 'sessions.changed',
+        payload: { sessionKey: 'main', phase: 'start' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('true');
+    });
+    expect(screen.getByTestId('processing-stage').textContent).toBe('thinking');
   });
 });

--- a/src/contexts/ChatContext.subscription.test.tsx
+++ b/src/contexts/ChatContext.subscription.test.tsx
@@ -165,6 +165,54 @@ describe('ChatContext subscription stability', () => {
     });
   });
 
+  it('does not hydrate the selected chat from child-only active run snapshots', async () => {
+    const { ChatProvider, useChat, rpcMock } = await setup({
+      connectionState: 'connected',
+      sessions: [{ sessionKey: 'main', hasActiveRun: false, hasActiveSubagentRun: true, status: 'running' }],
+    });
+
+    function Consumer() {
+      const chat = useChat();
+      return <div data-testid="is-generating">{String(chat.isGenerating)}</div>;
+    }
+
+    render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('sessions.messages.subscribe', { key: 'main' });
+    });
+    expect(screen.getByTestId('is-generating').textContent).toBe('false');
+    expect(rpcMock).not.toHaveBeenCalledWith('chat.history', { sessionKey: 'main', limit: 120 });
+  });
+
+  it('does not hydrate from stale running text when explicit own run flag is inactive', async () => {
+    const { ChatProvider, useChat, rpcMock } = await setup({
+      connectionState: 'connected',
+      sessions: [{ sessionKey: 'main', hasActiveRun: false, status: 'running' }],
+    });
+
+    function Consumer() {
+      const chat = useChat();
+      return <div data-testid="is-generating">{String(chat.isGenerating)}</div>;
+    }
+
+    render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('sessions.messages.subscribe', { key: 'main' });
+    });
+    expect(screen.getByTestId('is-generating').textContent).toBe('false');
+    expect(rpcMock).not.toHaveBeenCalledWith('chat.history', { sessionKey: 'main', limit: 120 });
+  });
+
   it('clears hydrated generation state from a terminal refreshed session snapshot', async () => {
     const { ChatProvider, useChat, setSessions, rpcMock } = await setup({
       connectionState: 'connected',

--- a/src/contexts/ChatContext.subscription.test.tsx
+++ b/src/contexts/ChatContext.subscription.test.tsx
@@ -189,6 +189,56 @@ describe('ChatContext subscription stability', () => {
     expect(rpcMock).not.toHaveBeenCalledWith('chat.history', { sessionKey: 'main', limit: 120 });
   });
 
+  it('hydrates selected chat when child activity is accompanied by own-run legacy signals', async () => {
+    const { ChatProvider, useChat, rpcMock } = await setup({
+      connectionState: 'connected',
+      sessions: [{ sessionKey: 'main', hasActiveSubagentRun: true, busy: true }],
+    });
+
+    function Consumer() {
+      const chat = useChat();
+      return <div data-testid="is-generating">{String(chat.isGenerating)}</div>;
+    }
+
+    render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('true');
+    });
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('chat.history', { sessionKey: 'main', limit: 120 });
+    });
+  });
+
+  it('hydrates selected chat when child activity is accompanied by own active status', async () => {
+    const { ChatProvider, useChat, rpcMock } = await setup({
+      connectionState: 'connected',
+      sessions: [{ sessionKey: 'main', hasActiveSubagentRun: true, status: 'running' }],
+    });
+
+    function Consumer() {
+      const chat = useChat();
+      return <div data-testid="is-generating">{String(chat.isGenerating)}</div>;
+    }
+
+    render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('true');
+    });
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('chat.history', { sessionKey: 'main', limit: 120 });
+    });
+  });
+
   it('does not hydrate from stale running text when explicit own run flag is inactive', async () => {
     const { ChatProvider, useChat, rpcMock } = await setup({
       connectionState: 'connected',
@@ -431,6 +481,71 @@ describe('ChatContext subscription stability', () => {
     });
 
     expect(screen.getByTestId('is-generating').textContent).toBe('false');
+  });
+
+  it('keeps slow terminal recovery results valid after a missed chat final frame', async () => {
+    const { ChatProvider, useChat, subscribedHandlers, rpcMock } = await setup({ connectionState: 'connected' });
+
+    let send: ((text: string, images?: ImageAttachment[]) => Promise<void>) | null = null;
+
+    function Consumer() {
+      const chat = useChat();
+      useEffect(() => {
+        send = chat.handleSend;
+      }, [chat]);
+      return (
+        <div>
+          <div data-testid="is-generating">{String(chat.isGenerating)}</div>
+          <div data-testid="messages">{chat.messages.map((m) => m.rawText || m.html).join('\n')}</div>
+        </div>
+      );
+    }
+
+    render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(subscribedHandlers.length).toBe(1));
+    await act(async () => {
+      await send!('hello');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('true');
+    });
+
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'chat.send') return { runId: 'run-1', status: 'started' };
+      if (method === 'chat.history') {
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+        return { messages: [{ role: 'assistant', content: 'recovered final' }] };
+      }
+      return {};
+    });
+
+    vi.useFakeTimers();
+
+    act(() => {
+      subscribedHandlers[0]({
+        type: 'event',
+        event: 'sessions.changed',
+        payload: { sessionKey: 'main', hasActiveRun: false, status: 'done' },
+      });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    expect(screen.getByTestId('is-generating').textContent).toBe('false');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(screen.getByTestId('messages').textContent).toContain('recovered final');
   });
 
   it('clears hydrated generation state from a terminal agentState refreshed session snapshot', async () => {

--- a/src/contexts/ChatContext.subscription.test.tsx
+++ b/src/contexts/ChatContext.subscription.test.tsx
@@ -143,6 +143,28 @@ describe('ChatContext subscription stability', () => {
     });
   });
 
+  it('hydrates active generation state from a busy refreshed session snapshot', async () => {
+    const { ChatProvider, useChat } = await setup({
+      connectionState: 'connected',
+      sessions: [{ sessionKey: 'main', status: 'busy' }],
+    });
+
+    function Consumer() {
+      const chat = useChat();
+      return <div data-testid="is-generating">{String(chat.isGenerating)}</div>;
+    }
+
+    render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('true');
+    });
+  });
+
   it('clears hydrated generation state from a terminal refreshed session snapshot', async () => {
     const { ChatProvider, useChat, setSessions, rpcMock } = await setup({
       connectionState: 'connected',
@@ -183,6 +205,45 @@ describe('ChatContext subscription stability', () => {
     await waitFor(() => {
       expect(rpcMock).toHaveBeenCalledWith('chat.history', { sessionKey: 'main', limit: 120 });
     });
+  });
+
+  it('clears hydrated generation state from a terminal agentState refreshed session snapshot', async () => {
+    const { ChatProvider, useChat, setSessions } = await setup({
+      connectionState: 'connected',
+      sessions: [{ sessionKey: 'main', agentState: 'running' }],
+    });
+
+    function Consumer() {
+      const chat = useChat();
+      return (
+        <div>
+          <div data-testid="is-generating">{String(chat.isGenerating)}</div>
+          <div data-testid="processing-stage">{chat.processingStage || 'NONE'}</div>
+        </div>
+      );
+    }
+
+    const { rerender } = render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('true');
+    });
+
+    setSessions([{ sessionKey: 'main', agentState: 'done' }]);
+    rerender(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('false');
+    });
+    expect(screen.getByTestId('processing-stage').textContent).toBe('NONE');
   });
 
   it('hydrates active generation state from a subscribed lifecycle event after refresh', async () => {

--- a/src/contexts/ChatContext.subscription.test.tsx
+++ b/src/contexts/ChatContext.subscription.test.tsx
@@ -21,7 +21,11 @@ describe('ChatContext subscription stability', () => {
     sessions?: Session[];
   } = {}) {
     const subscribedHandlers: Array<(msg: GatewayEvent) => void> = [];
+    let currentSession = options.currentSession || 'main';
     let sessions = options.sessions || [];
+    const setCurrentSession = (nextSession: string) => {
+      currentSession = nextSession;
+    };
     const setSessions = (nextSessions: Session[]) => {
       sessions = nextSessions;
     };
@@ -45,7 +49,7 @@ describe('ChatContext subscription stability', () => {
 
     vi.doMock('./SessionContext', () => ({
       useSessionContext: () => ({
-        currentSession: options.currentSession || 'main',
+        currentSession,
         sessions,
       }),
     }));
@@ -58,7 +62,7 @@ describe('ChatContext subscription stability', () => {
     }));
 
     const mod = await import('./ChatContext');
-    return { ...mod, rpcMock, subscribeMock, subscribedHandlers, setSessions };
+    return { ...mod, rpcMock, subscribeMock, subscribedHandlers, setCurrentSession, setSessions };
   }
 
   it('keeps a single subscribe registration after handleSend-triggered rerender', async () => {
@@ -383,6 +387,106 @@ describe('ChatContext subscription stability', () => {
       expect(screen.getByTestId('is-generating').textContent).toBe('false');
     });
     expect(screen.getByTestId('processing-stage').textContent).toBe('NONE');
+  });
+
+  it('keeps active chat generating when child terminal state is mixed with own active status', async () => {
+    const { ChatProvider, useChat, subscribedHandlers } = await setup({
+      connectionState: 'connected',
+      sessions: [{ sessionKey: 'main', hasActiveRun: true, status: 'running' }],
+    });
+
+    function Consumer() {
+      const chat = useChat();
+      return <div data-testid="is-generating">{String(chat.isGenerating)}</div>;
+    }
+
+    render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('true');
+    });
+    await waitFor(() => expect(subscribedHandlers.length).toBe(1));
+
+    act(() => {
+      subscribedHandlers[0]({
+        type: 'event',
+        event: 'sessions.changed',
+        payload: { sessionKey: 'main', status: 'running', subagentRunState: 'done' },
+      });
+    });
+
+    expect(screen.getByTestId('is-generating').textContent).toBe('true');
+  });
+
+  it('hydrates phase-start snapshots even when stale inactive flags are present', async () => {
+    const { ChatProvider, useChat, subscribedHandlers } = await setup({ connectionState: 'connected' });
+
+    function Consumer() {
+      const chat = useChat();
+      return <div data-testid="is-generating">{String(chat.isGenerating)}</div>;
+    }
+
+    render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(subscribedHandlers.length).toBe(1));
+
+    act(() => {
+      subscribedHandlers[0]({
+        type: 'event',
+        event: 'sessions.changed',
+        payload: { sessionKey: 'main', phase: 'start', hasActiveRun: false, busy: false, status: 'done' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('true');
+    });
+  });
+
+  it('hydrates a newly selected active session after resetting the previous generating session', async () => {
+    const { ChatProvider, useChat, setCurrentSession, rpcMock } = await setup({
+      connectionState: 'connected',
+      currentSession: 'main',
+      sessions: [
+        { sessionKey: 'main', hasActiveRun: true, status: 'running' },
+        { sessionKey: 'agent:reviewer:main', hasActiveRun: true, status: 'running' },
+      ],
+    });
+
+    function Consumer() {
+      const chat = useChat();
+      return <div data-testid="is-generating">{String(chat.isGenerating)}</div>;
+    }
+
+    const { rerender } = render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('true');
+    });
+
+    setCurrentSession('agent:reviewer:main');
+    rerender(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('true');
+      expect(rpcMock).toHaveBeenCalledWith('chat.history', { sessionKey: 'agent:reviewer:main', limit: 120 });
+    });
   });
 
   it('keeps live active runs generating when terminal session snapshots race before chat final', async () => {

--- a/src/contexts/ChatContext.subscription.test.tsx
+++ b/src/contexts/ChatContext.subscription.test.tsx
@@ -95,6 +95,91 @@ describe('ChatContext subscription stability', () => {
     expect(subscribeMock).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps the previous final assistant bubble when a new send receives an immediate session.message echo', async () => {
+    const { ChatProvider, useChat, rpcMock, subscribedHandlers } = await setup({ connectionState: 'connected' });
+
+    let send: ((text: string, images?: ImageAttachment[]) => Promise<void>) | null = null;
+    let sendCount = 0;
+    let historyIsStale = false;
+    let resolveSecondSend: ((value: { runId: string; status: 'started' }) => void) | null = null;
+
+    rpcMock.mockImplementation((method: string) => {
+      if (method === 'chat.send') {
+        sendCount += 1;
+        if (sendCount === 1) return Promise.resolve({ runId: 'run-1', status: 'started' });
+        return new Promise((resolve) => {
+          resolveSecondSend = resolve as (value: { runId: string; status: 'started' }) => void;
+        });
+      }
+      if (method === 'chat.history') {
+        return Promise.resolve({
+          messages: historyIsStale
+            ? [{ role: 'user', content: 'old question', timestamp: Date.now() - 10_000 }]
+            : [],
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    function Consumer() {
+      const chat = useChat();
+      useEffect(() => {
+        send = chat.handleSend;
+      }, [chat]);
+      return <div data-testid="messages">{chat.messages.map((m) => m.rawText || m.html).join('\n')}</div>;
+    }
+
+    render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(subscribedHandlers.length).toBe(1));
+    await waitFor(() => expect(send).not.toBeNull());
+
+    await act(async () => {
+      await send!('old question');
+    });
+
+    act(() => {
+      subscribedHandlers[0]({
+        type: 'event',
+        event: 'chat',
+        payload: { sessionKey: 'main', runId: 'run-1', state: 'final', message: 'previous answer' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('messages').textContent).toContain('previous answer');
+    });
+
+    historyIsStale = true;
+    vi.useFakeTimers();
+
+    let secondSend: Promise<void> | null = null;
+    act(() => {
+      secondSend = send!('next question');
+      subscribedHandlers[0]({
+        type: 'event',
+        event: 'session.message',
+        payload: { sessionKey: 'main', message: { role: 'user', content: 'next question' } },
+      });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+
+    expect(screen.getByTestId('messages').textContent).toContain('previous answer');
+    expect(screen.getByTestId('messages').textContent).toContain('next question');
+
+    await act(async () => {
+      resolveSecondSend?.({ runId: 'run-2', status: 'started' });
+      await secondSend;
+    });
+  });
+
   it('subscribes to current session message broadcasts while connected and cleans up', async () => {
     const { ChatProvider, rpcMock } = await setup({ connectionState: 'connected' });
 

--- a/src/contexts/ChatContext.subscription.test.tsx
+++ b/src/contexts/ChatContext.subscription.test.tsx
@@ -255,6 +255,86 @@ describe('ChatContext subscription stability', () => {
     });
   });
 
+  it('clears hydrated generation state from explicit inactive flags with stale running status', async () => {
+    const { ChatProvider, useChat, setSessions } = await setup({
+      connectionState: 'connected',
+      sessions: [{ sessionKey: 'main', hasActiveRun: true, status: 'running' }],
+    });
+
+    function Consumer() {
+      const chat = useChat();
+      return (
+        <div>
+          <div data-testid="is-generating">{String(chat.isGenerating)}</div>
+          <div data-testid="processing-stage">{chat.processingStage || 'NONE'}</div>
+        </div>
+      );
+    }
+
+    const { rerender } = render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('true');
+    });
+
+    setSessions([{ sessionKey: 'main', busy: false, processing: false, status: 'running' }]);
+    rerender(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('false');
+    });
+    expect(screen.getByTestId('processing-stage').textContent).toBe('NONE');
+  });
+
+  it('clears hydrated generation state from a subscribed explicit inactive snapshot', async () => {
+    const { ChatProvider, useChat, subscribedHandlers } = await setup({
+      connectionState: 'connected',
+      sessions: [{ sessionKey: 'main', hasActiveRun: true, status: 'running' }],
+    });
+
+    function Consumer() {
+      const chat = useChat();
+      return (
+        <div>
+          <div data-testid="is-generating">{String(chat.isGenerating)}</div>
+          <div data-testid="processing-stage">{chat.processingStage || 'NONE'}</div>
+        </div>
+      );
+    }
+
+    render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('true');
+    });
+    await waitFor(() => expect(subscribedHandlers.length).toBe(1));
+
+    act(() => {
+      subscribedHandlers[0]({
+        type: 'event',
+        event: 'sessions.changed',
+        payload: { sessionKey: 'main', busy: false, status: 'running' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('false');
+    });
+    expect(screen.getByTestId('processing-stage').textContent).toBe('NONE');
+  });
+
   it('clears hydrated generation state from a terminal agentState refreshed session snapshot', async () => {
     const { ChatProvider, useChat, setSessions } = await setup({
       connectionState: 'connected',

--- a/src/contexts/ChatContext.subscription.test.tsx
+++ b/src/contexts/ChatContext.subscription.test.tsx
@@ -386,6 +386,53 @@ describe('ChatContext subscription stability', () => {
     });
   });
 
+  it('clears active run state from terminal snapshots when the chat final frame is missed', async () => {
+    const { ChatProvider, useChat, subscribedHandlers } = await setup({ connectionState: 'connected' });
+
+    let send: ((text: string, images?: ImageAttachment[]) => Promise<void>) | null = null;
+
+    function Consumer() {
+      const chat = useChat();
+      useEffect(() => {
+        send = chat.handleSend;
+      }, [chat]);
+      return <div data-testid="is-generating">{String(chat.isGenerating)}</div>;
+    }
+
+    render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(subscribedHandlers.length).toBe(1));
+    await act(async () => {
+      await send!('hello');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('true');
+    });
+
+    vi.useFakeTimers();
+
+    act(() => {
+      subscribedHandlers[0]({
+        type: 'event',
+        event: 'sessions.changed',
+        payload: { sessionKey: 'main', hasActiveRun: false, status: 'done' },
+      });
+    });
+
+    expect(screen.getByTestId('is-generating').textContent).toBe('true');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    expect(screen.getByTestId('is-generating').textContent).toBe('false');
+  });
+
   it('clears hydrated generation state from a terminal agentState refreshed session snapshot', async () => {
     const { ChatProvider, useChat, setSessions } = await setup({
       connectionState: 'connected',

--- a/src/contexts/ChatContext.subscription.test.tsx
+++ b/src/contexts/ChatContext.subscription.test.tsx
@@ -21,6 +21,10 @@ describe('ChatContext subscription stability', () => {
     sessions?: Session[];
   } = {}) {
     const subscribedHandlers: Array<(msg: GatewayEvent) => void> = [];
+    let sessions = options.sessions || [];
+    const setSessions = (nextSessions: Session[]) => {
+      sessions = nextSessions;
+    };
     const subscribeMock = vi.fn((handler: (msg: GatewayEvent) => void) => {
       subscribedHandlers.push(handler);
       return () => {};
@@ -42,7 +46,7 @@ describe('ChatContext subscription stability', () => {
     vi.doMock('./SessionContext', () => ({
       useSessionContext: () => ({
         currentSession: options.currentSession || 'main',
-        sessions: options.sessions || [],
+        sessions,
       }),
     }));
 
@@ -54,7 +58,7 @@ describe('ChatContext subscription stability', () => {
     }));
 
     const mod = await import('./ChatContext');
-    return { ...mod, rpcMock, subscribeMock, subscribedHandlers };
+    return { ...mod, rpcMock, subscribeMock, subscribedHandlers, setSessions };
   }
 
   it('keeps a single subscribe registration after handleSend-triggered rerender', async () => {
@@ -134,6 +138,48 @@ describe('ChatContext subscription stability', () => {
     });
     expect(screen.getByTestId('processing-stage').textContent).toBe('thinking');
 
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('chat.history', { sessionKey: 'main', limit: 120 });
+    });
+  });
+
+  it('clears hydrated generation state from a terminal refreshed session snapshot', async () => {
+    const { ChatProvider, useChat, setSessions, rpcMock } = await setup({
+      connectionState: 'connected',
+      sessions: [{ sessionKey: 'main', hasActiveRun: true, status: 'running' }],
+    });
+
+    function Consumer() {
+      const chat = useChat();
+      return (
+        <div>
+          <div data-testid="is-generating">{String(chat.isGenerating)}</div>
+          <div data-testid="processing-stage">{chat.processingStage || 'NONE'}</div>
+        </div>
+      );
+    }
+
+    const { rerender } = render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('true');
+    });
+
+    setSessions([{ sessionKey: 'main', hasActiveRun: false, status: 'done' }]);
+    rerender(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('false');
+    });
+    expect(screen.getByTestId('processing-stage').textContent).toBe('NONE');
     await waitFor(() => {
       expect(rpcMock).toHaveBeenCalledWith('chat.history', { sessionKey: 'main', limit: 120 });
     });

--- a/src/contexts/ChatContext.subscription.test.tsx
+++ b/src/contexts/ChatContext.subscription.test.tsx
@@ -335,6 +335,57 @@ describe('ChatContext subscription stability', () => {
     expect(screen.getByTestId('processing-stage').textContent).toBe('NONE');
   });
 
+  it('keeps live active runs generating when terminal session snapshots race before chat final', async () => {
+    const { ChatProvider, useChat, subscribedHandlers } = await setup({ connectionState: 'connected' });
+
+    let send: ((text: string, images?: ImageAttachment[]) => Promise<void>) | null = null;
+
+    function Consumer() {
+      const chat = useChat();
+      useEffect(() => {
+        send = chat.handleSend;
+      }, [chat]);
+      return <div data-testid="is-generating">{String(chat.isGenerating)}</div>;
+    }
+
+    render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(subscribedHandlers.length).toBe(1));
+    await act(async () => {
+      await send!('hello');
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('true');
+    });
+
+    act(() => {
+      subscribedHandlers[0]({
+        type: 'event',
+        event: 'sessions.changed',
+        payload: { sessionKey: 'main', hasActiveRun: false, status: 'done' },
+      });
+    });
+
+    expect(screen.getByTestId('is-generating').textContent).toBe('true');
+
+    act(() => {
+      subscribedHandlers[0]({
+        type: 'event',
+        event: 'chat',
+        payload: { sessionKey: 'main', runId: 'run-1', state: 'final', message: 'done' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('false');
+    });
+  });
+
   it('clears hydrated generation state from a terminal agentState refreshed session snapshot', async () => {
     const { ChatProvider, useChat, setSessions } = await setup({
       connectionState: 'connected',

--- a/src/contexts/ChatContext.subscription.test.tsx
+++ b/src/contexts/ChatContext.subscription.test.tsx
@@ -173,4 +173,45 @@ describe('ChatContext subscription stability', () => {
     });
     expect(screen.getByTestId('processing-stage').textContent).toBe('thinking');
   });
+
+  it('clears hydrated generation state from a subscribed terminal lifecycle event', async () => {
+    const { ChatProvider, useChat, subscribedHandlers } = await setup({
+      connectionState: 'connected',
+      sessions: [{ sessionKey: 'main', hasActiveRun: true, status: 'running' }],
+    });
+
+    function Consumer() {
+      const chat = useChat();
+      return (
+        <div>
+          <div data-testid="is-generating">{String(chat.isGenerating)}</div>
+          <div data-testid="processing-stage">{chat.processingStage || 'NONE'}</div>
+        </div>
+      );
+    }
+
+    render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('true');
+    });
+    await waitFor(() => expect(subscribedHandlers.length).toBe(1));
+
+    act(() => {
+      subscribedHandlers[0]({
+        type: 'event',
+        event: 'sessions.changed',
+        payload: { sessionKey: 'main', phase: 'end', status: 'done' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('is-generating').textContent).toBe('false');
+    });
+    expect(screen.getByTestId('processing-stage').textContent).toBe('NONE');
+  });
 });

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -18,7 +18,7 @@ import { createContext, useContext, useCallback, useRef, useEffect, useState, us
 import { useGateway } from './GatewayContext';
 import { useSessionContext } from './SessionContext';
 import { useSettings } from './SettingsContext';
-import { getSessionKey, type GatewayEvent } from '@/types';
+import { getSessionKey, type EventPayload, type GatewayEvent, type Session } from '@/types';
 import {
   getRootAgentSessionKey,
   isRootChildSession,
@@ -98,6 +98,27 @@ interface ChatContextValue {
 }
 
 const ChatContext = createContext<ChatContextValue | null>(null);
+
+const ACTIVE_SESSION_STATES = new Set(['running', 'thinking', 'processing', 'streaming', 'tool_use', 'executing', 'tool', 'delta', 'started', 'active']);
+const TERMINAL_SESSION_STATES = new Set(['idle', 'done', 'error', 'final', 'aborted', 'completed', 'finished', 'ended', 'cancelled', 'timeout', 'stopped']);
+
+function lowerString(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function sessionLooksActive(session?: Partial<Session & EventPayload> | null): boolean {
+  if (!session) return false;
+  if (session.hasActiveRun || session.hasActiveSubagentRun || session.busy || session.processing) return true;
+  if (lowerString(session.phase) === 'start') return true;
+  return [session.state, session.status, session.agentState, session.subagentRunState]
+    .map(lowerString)
+    .some((state) => ACTIVE_SESSION_STATES.has(state));
+}
+
+function sessionLooksTerminal(session?: Partial<EventPayload> | Partial<Session> | null): boolean {
+  if (!session) return false;
+  return [session.state, session.status].map(lowerString).some((state) => TERMINAL_SESSION_STATES.has(state));
+}
 
 export function ChatProvider({ children }: { children: ReactNode }) {
   const { connectionState, rpc, subscribe } = useGateway();
@@ -179,6 +200,28 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     handleFinalTTS,
   } = ttsHook;
 
+  const currentSessionMeta = useMemo(
+    () => sessions.find((session) => getSessionKey(session) === currentSession) || null,
+    [currentSession, sessions],
+  );
+
+  const hydrateActiveSessionRun = useCallback((stateHint?: string) => {
+    if (!currentSessionRef.current) return;
+    if (isGeneratingRef.current || activeRunIdRef.current) return;
+
+    const state = lowerString(stateHint);
+    isGeneratingRef.current = true;
+    setIsGenerating(true);
+    resetPlayedSounds();
+    setProcessingStage(
+      state === 'delta' || state === 'streaming'
+        ? 'streaming'
+        : (state === 'tool' || state === 'tool_use' || state === 'executing' ? 'tool_use' : 'thinking'),
+    );
+    setLastEventTimestamp(Date.now());
+    triggerRecovery('reconnect');
+  }, [resetPlayedSounds, setLastEventTimestamp, setProcessingStage, triggerRecovery]);
+
   // ─── Reset transient state on session switch ──────────────────────────────
   useEffect(() => {
     setIsGenerating(false);
@@ -225,6 +268,29 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     if (connectionState !== 'connected' || !currentSession) return;
     loadHistory(currentSession);
   }, [connectionState, currentSession, loadHistory]);
+
+  // Request transcript/message broadcasts for the currently viewed session.
+  useEffect(() => {
+    if (connectionState !== 'connected' || !currentSession) return;
+    const key = currentSession;
+    void rpc('sessions.messages.subscribe', { key }).catch((err) => {
+      console.debug('[ChatContext] sessions.messages.subscribe unavailable:', err);
+    });
+    return () => {
+      void rpc('sessions.messages.unsubscribe', { key }).catch(() => {});
+    };
+  }, [connectionState, currentSession, rpc]);
+
+  // A page refresh loses the in-memory chat_started event. Hydrate from the
+  // gateway's session snapshot so the UI rejoins the active run instead of
+  // looking idle until the final transcript lands.
+  useEffect(() => {
+    if (connectionState !== 'connected' || !currentSession) return;
+    if (!sessionLooksActive(currentSessionMeta)) return;
+    hydrateActiveSessionRun(
+      currentSessionMeta?.state || currentSessionMeta?.status || currentSessionMeta?.agentState || currentSessionMeta?.subagentRunState,
+    );
+  }, [connectionState, currentSession, currentSessionMeta, hydrateActiveSessionRun]);
 
   // ─── Periodic history poll for sub-agent sessions ─────────────────────────
   const isSubagentSession = currentSession ? isSubagentSessionKey(currentSession) : false;
@@ -294,10 +360,21 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         triggerRecovery(reason);
       };
 
+      const currentSk = currentSessionRef.current;
+      const payload = (msg.payload || {}) as EventPayload;
+
+      if ((msg.event === 'sessions.changed' || msg.event === 'session.message') && payload.sessionKey === currentSk) {
+        const stateHint = payload.state || payload.status || payload.phase;
+        if (sessionLooksActive(payload)) {
+          hydrateActiveSessionRun(stateHint);
+        }
+        if (msg.event === 'session.message' || sessionLooksTerminal(payload)) {
+          triggerRecoveryOnce('reconnect');
+        }
+      }
+
       const classified = classifyStreamEvent(msg);
       if (!classified) return;
-
-      const currentSk = currentSessionRef.current;
       if (classified.sessionKey !== currentSk) {
         if (
           isTopLevelAgentSessionKey(currentSk) &&
@@ -585,6 +662,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     playCompletionPing,
     resetPlayedSounds,
     handleFinalTTS,
+    hydrateActiveSessionRun,
     subscribe,
     rpc,
   ]);

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -108,8 +108,14 @@ function lowerString(value: unknown): string {
 
 function sessionLooksActive(session?: Partial<Session & EventPayload> | null): boolean {
   if (!session) return false;
-  if (session.hasActiveRun || session.hasActiveSubagentRun || session.busy || session.processing) return true;
-  if (lowerString(session.phase) === 'start') return true;
+  const phase = lowerString(session.phase);
+  if (phase === 'end' || phase === 'error') return false;
+  // The chat pane should only hydrate the selected session's own run. A parent
+  // with only an active child/subagent belongs in the sidebar, not Stop/send UI.
+  if (session.hasActiveSubagentRun === true && session.hasActiveRun !== true) return false;
+  if (session.hasActiveRun === true || session.busy === true || session.processing === true) return true;
+  if (session.hasActiveRun === false || session.busy === false || session.processing === false) return false;
+  if (phase === 'start') return true;
   return [session.state, session.status, session.agentState, session.subagentRunState]
     .map(lowerString)
     .some((state) => ACTIVE_SESSION_STATES.has(state));
@@ -119,6 +125,8 @@ function sessionLooksTerminal(session?: Partial<Session & EventPayload> | null):
   if (!session) return false;
   const phase = lowerString(session.phase);
   if (phase === 'end' || phase === 'error') return true;
+  if (session.hasActiveRun === true || session.busy === true || session.processing === true) return false;
+  if (session.hasActiveRun === false) return true;
   return [session.state, session.status, session.agentState, session.subagentRunState]
     .map(lowerString)
     .some((state) => TERMINAL_SESSION_STATES.has(state));
@@ -393,15 +401,20 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       const payload = (msg.payload || {}) as EventPayload;
 
       if ((msg.event === 'sessions.changed' || msg.event === 'session.message') && payload.sessionKey === currentSk) {
-        const stateHint = payload.state || payload.status || payload.phase;
+        const stateHint = payload.state || payload.status || payload.agentState || payload.subagentRunState || payload.phase;
         const terminalUpdate = sessionLooksTerminal(payload);
-        if (sessionLooksActive(payload)) {
+        const activeUpdate = sessionLooksActive(payload);
+        if (activeUpdate) {
           hydrateActiveSessionRun(stateHint);
         }
         if (terminalUpdate) {
           finishHydratedSessionRun(stateHint);
         }
-        if (msg.event === 'session.message' || terminalUpdate) {
+        const shouldRecoverFromMessage = msg.event === 'session.message'
+          && !activeUpdate
+          && !isGeneratingRef.current
+          && !activeRunIdRef.current;
+        if (terminalUpdate || shouldRecoverFromMessage) {
           triggerRecoveryOnce('reconnect');
         }
       }

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -99,7 +99,7 @@ interface ChatContextValue {
 
 const ChatContext = createContext<ChatContextValue | null>(null);
 
-const ACTIVE_SESSION_STATES = new Set(['running', 'thinking', 'processing', 'streaming', 'tool_use', 'executing', 'tool', 'delta', 'started', 'active']);
+const ACTIVE_SESSION_STATES = new Set(['running', 'busy', 'thinking', 'processing', 'streaming', 'tool_use', 'executing', 'tool', 'delta', 'started', 'active']);
 const TERMINAL_SESSION_STATES = new Set(['idle', 'done', 'error', 'failed', 'killed', 'final', 'aborted', 'completed', 'finished', 'ended', 'cancelled', 'timeout', 'stopped']);
 
 function lowerString(value: unknown): string {
@@ -119,7 +119,9 @@ function sessionLooksTerminal(session?: Partial<Session & EventPayload> | null):
   if (!session) return false;
   const phase = lowerString(session.phase);
   if (phase === 'end' || phase === 'error') return true;
-  return [session.state, session.status].map(lowerString).some((state) => TERMINAL_SESSION_STATES.has(state));
+  return [session.state, session.status, session.agentState, session.subagentRunState]
+    .map(lowerString)
+    .some((state) => TERMINAL_SESSION_STATES.has(state));
 }
 
 export function ChatProvider({ children }: { children: ReactNode }) {

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -101,6 +101,7 @@ const ChatContext = createContext<ChatContextValue | null>(null);
 
 const ACTIVE_SESSION_STATES = new Set(['running', 'busy', 'thinking', 'processing', 'streaming', 'tool_use', 'executing', 'tool', 'delta', 'started', 'active']);
 const TERMINAL_SESSION_STATES = new Set(['idle', 'done', 'error', 'failed', 'killed', 'final', 'aborted', 'completed', 'finished', 'ended', 'cancelled', 'timeout', 'stopped']);
+const TERMINAL_SNAPSHOT_FINISH_DELAY_MS = 1_500;
 
 function lowerString(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
@@ -160,6 +161,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const lastGatewaySeqRef = useRef<number | null>(null);
   const lastChatSeqRef = useRef<number | null>(null);
   const toolResultRefreshRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const terminalSnapshotFinishRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // ─── Compose hooks ────────────────────────────────────────────────────────
   const msgHook = useChatMessages({ rpc, currentSessionRef });
@@ -217,8 +219,15 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     [currentSession, sessions],
   );
 
+  const clearTerminalSnapshotFinish = useCallback(() => {
+    if (!terminalSnapshotFinishRef.current) return;
+    clearTimeout(terminalSnapshotFinishRef.current);
+    terminalSnapshotFinishRef.current = null;
+  }, []);
+
   const hydrateActiveSessionRun = useCallback((stateHint?: string) => {
     if (!currentSessionRef.current) return;
+    clearTerminalSnapshotFinish();
     if (isGeneratingRef.current || activeRunIdRef.current) return;
 
     const state = lowerString(stateHint);
@@ -232,9 +241,10 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     );
     setLastEventTimestamp(Date.now());
     triggerRecovery('reconnect');
-  }, [resetPlayedSounds, setLastEventTimestamp, setProcessingStage, triggerRecovery]);
+  }, [clearTerminalSnapshotFinish, resetPlayedSounds, setLastEventTimestamp, setProcessingStage, triggerRecovery]);
 
   const finishHydratedSessionRun = useCallback((stateHint?: string) => {
+    clearTerminalSnapshotFinish();
     if (!isGeneratingRef.current && !activeRunIdRef.current) return;
     const state = lowerString(stateHint);
 
@@ -252,7 +262,22 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     if (state !== 'error' && state !== 'failed') {
       playCompletionPing();
     }
-  }, [clearStreamBuffer, incrementGeneration, playCompletionPing, resetThinking, setActivityLog, setLastEventTimestamp, setProcessingStage]);
+  }, [clearStreamBuffer, clearTerminalSnapshotFinish, incrementGeneration, playCompletionPing, resetThinking, setActivityLog, setLastEventTimestamp, setProcessingStage]);
+
+  const scheduleTerminalSnapshotFinish = useCallback((stateHint?: string) => {
+    const activeRunId = activeRunIdRef.current;
+    if (!activeRunId) {
+      finishHydratedSessionRun(stateHint);
+      return;
+    }
+    clearTerminalSnapshotFinish();
+    terminalSnapshotFinishRef.current = setTimeout(() => {
+      terminalSnapshotFinishRef.current = null;
+      if (activeRunIdRef.current === activeRunId) {
+        finishHydratedSessionRun(stateHint);
+      }
+    }, TERMINAL_SNAPSHOT_FINISH_DELAY_MS);
+  }, [clearTerminalSnapshotFinish, finishHydratedSessionRun]);
 
   // ─── Reset transient state on session switch ──────────────────────────────
   useEffect(() => {
@@ -268,8 +293,11 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       clearTimeout(toolResultRefreshRef.current);
       toolResultRefreshRef.current = null;
     }
+    clearTerminalSnapshotFinish();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentSession]);
+  }, [currentSession, clearTerminalSnapshotFinish]);
+
+  useEffect(() => () => clearTerminalSnapshotFinish(), [clearTerminalSnapshotFinish]);
 
   // ─── Load history on connect / recover on reconnect ───────────────────────
   const previousConnectionStateRef = useRef(connectionState);
@@ -322,13 +350,13 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     if (sessionLooksTerminal(currentSessionMeta)) {
       const hasLiveRun = Boolean(activeRunIdRef.current);
       const wasActive = isGeneratingRef.current || hasLiveRun;
-      if (!hasLiveRun) finishHydratedSessionRun(stateHint);
+      scheduleTerminalSnapshotFinish(stateHint);
       if (wasActive) triggerRecovery('reconnect');
       return;
     }
     if (!sessionLooksActive(currentSessionMeta)) return;
     hydrateActiveSessionRun(stateHint);
-  }, [connectionState, currentSession, currentSessionMeta, finishHydratedSessionRun, hydrateActiveSessionRun, triggerRecovery]);
+  }, [connectionState, currentSession, currentSessionMeta, hydrateActiveSessionRun, scheduleTerminalSnapshotFinish, triggerRecovery]);
 
   // ─── Periodic history poll for sub-agent sessions ─────────────────────────
   const isSubagentSession = currentSession ? isSubagentSessionKey(currentSession) : false;
@@ -408,8 +436,8 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         if (activeUpdate) {
           hydrateActiveSessionRun(stateHint);
         }
-        if (terminalUpdate && !activeRunIdRef.current) {
-          finishHydratedSessionRun(stateHint);
+        if (terminalUpdate) {
+          scheduleTerminalSnapshotFinish(stateHint);
         }
         const shouldRecoverFromMessage = msg.event === 'session.message'
           && !activeUpdate
@@ -450,6 +478,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         const ap = classified.agentPayload!;
 
         if (type === 'lifecycle_start') {
+          clearTerminalSnapshotFinish();
           setIsGenerating(true);
           setProcessingStage('thinking');
           setLastEventTimestamp(Date.now());
@@ -475,6 +504,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         }
 
         if (type === 'assistant_stream') {
+          clearTerminalSnapshotFinish();
           setProcessingStage('streaming');
           setLastEventTimestamp(Date.now());
           return;
@@ -488,12 +518,14 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         setLastEventTimestamp(Date.now());
 
         if (type === 'agent_tool_start') {
+          clearTerminalSnapshotFinish();
           setProcessingStage('tool_use');
           addActivityEntry(ap);
           return;
         }
 
         if (type === 'agent_tool_result') {
+          clearTerminalSnapshotFinish();
           const completedId = ap.data?.toolCallId;
           if (completedId) completeActivityEntry(completedId);
 
@@ -545,6 +577,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       setLastEventTimestamp(Date.now());
 
       if (type === 'chat_started') {
+        clearTerminalSnapshotFinish();
         activeRunIdRef.current = runId;
         run.startedAt = Date.now();
         run.finalized = false;
@@ -562,6 +595,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       }
 
       if (type === 'chat_delta') {
+        clearTerminalSnapshotFinish();
         if (run.finalized) return;
         if (typeof classified.chatSeq === 'number' && prevRunSeq !== null && classified.chatSeq <= prevRunSeq) return;
 
@@ -581,6 +615,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       }
 
       if (type === 'chat_final') {
+        clearTerminalSnapshotFinish();
         const isActiveRun = activeRunBefore !== null
           ? activeRunBefore === runId
           : isGeneratingRef.current;
@@ -623,6 +658,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       }
 
       if (type === 'chat_aborted') {
+        clearTerminalSnapshotFinish();
         const isActiveRun = activeRunBefore !== null
           ? activeRunBefore === runId
           : isGeneratingRef.current;
@@ -660,6 +696,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       }
 
       if (type === 'chat_error') {
+        clearTerminalSnapshotFinish();
         const isActiveRun = activeRunBefore !== null
           ? activeRunBefore === runId
           : isGeneratingRef.current;
@@ -709,8 +746,9 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     playCompletionPing,
     resetPlayedSounds,
     handleFinalTTS,
+    clearTerminalSnapshotFinish,
     hydrateActiveSessionRun,
-    finishHydratedSessionRun,
+    scheduleTerminalSnapshotFinish,
     subscribe,
     rpc,
   ]);

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -126,7 +126,7 @@ function sessionLooksTerminal(session?: Partial<Session & EventPayload> | null):
   const phase = lowerString(session.phase);
   if (phase === 'end' || phase === 'error') return true;
   if (session.hasActiveRun === true || session.busy === true || session.processing === true) return false;
-  if (session.hasActiveRun === false) return true;
+  if (session.hasActiveRun === false || session.busy === false || session.processing === false) return true;
   return [session.state, session.status, session.agentState, session.subagentRunState]
     .map(lowerString)
     .some((state) => TERMINAL_SESSION_STATES.has(state));

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -492,6 +492,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
 
         if (type === 'lifecycle_start') {
           clearTerminalSnapshotFinish();
+          isGeneratingRef.current = true;
           setIsGenerating(true);
           setProcessingStage('thinking');
           setLastEventTimestamp(Date.now());
@@ -499,6 +500,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         }
 
         if (type === 'lifecycle_end') {
+          isGeneratingRef.current = false;
           setIsGenerating(false);
           setProcessingStage(null);
           setActivityLog([]);
@@ -525,6 +527,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
 
         const agentState = ap.state || ap.agentState;
         if (!isGeneratingRef.current && agentState && isActiveAgentState(agentState)) {
+          isGeneratingRef.current = true;
           setIsGenerating(true);
         }
 
@@ -599,6 +602,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         run.bufferRaw = '';
         run.bufferText = '';
 
+        isGeneratingRef.current = true;
         setIsGenerating(true);
         resetPlayedSounds();
         setProcessingStage('thinking');
@@ -612,7 +616,10 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         if (run.finalized) return;
         if (typeof classified.chatSeq === 'number' && prevRunSeq !== null && classified.chatSeq <= prevRunSeq) return;
 
-        if (!isGeneratingRef.current) setIsGenerating(true);
+        if (!isGeneratingRef.current) {
+          isGeneratingRef.current = true;
+          setIsGenerating(true);
+        }
         if (!activeRunIdRef.current) activeRunIdRef.current = runId;
 
         captureThinkingDuration();
@@ -643,6 +650,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         incrementGeneration();
 
         if (isActiveRun) {
+          isGeneratingRef.current = false;
           setIsGenerating(false);
           setProcessingStage(null);
           setActivityLog([]);
@@ -695,6 +703,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         }
 
         if (isActiveRun) {
+          isGeneratingRef.current = false;
           setIsGenerating(false);
           setProcessingStage(null);
           setActivityLog([]);
@@ -724,6 +733,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         incrementGeneration();
 
         if (isActiveRun) {
+          isGeneratingRef.current = false;
           setIsGenerating(false);
           setProcessingStage(null);
           setActivityLog([]);
@@ -777,6 +787,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     // Optimistic insert (functional updater to avoid read-then-write race)
     msgHook.setAllMessages(prev => [...prev, userMsg]);
     msgHook.setMessages((prev: ChatMsg[]) => [...prev, userMsg]);
+    isGeneratingRef.current = true;
     setIsGenerating(true);
     streamHook.setStream((prev: ChatStreamState) => ({ ...prev, html: '', runId: undefined }));
     setProcessingStage('thinking');
@@ -820,6 +831,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       };
       msgHook.setAllMessages(prev => [...prev, errMsgBubble]);
       msgHook.setMessages((prev: ChatMsg[]) => [...prev, errMsgBubble]);
+      isGeneratingRef.current = false;
       setIsGenerating(false);
     }
   }, [rpc, msgHook, streamHook, ttsHook, incrementGeneration, setProcessingStage, startThinking]);

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -308,11 +308,16 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   // looking idle until the final transcript lands.
   useEffect(() => {
     if (connectionState !== 'connected' || !currentSession) return;
+    const stateHint = currentSessionMeta?.state || currentSessionMeta?.status || currentSessionMeta?.agentState || currentSessionMeta?.subagentRunState || currentSessionMeta?.phase;
+    if (sessionLooksTerminal(currentSessionMeta)) {
+      const wasActive = isGeneratingRef.current || Boolean(activeRunIdRef.current);
+      finishHydratedSessionRun(stateHint);
+      if (wasActive) triggerRecovery('reconnect');
+      return;
+    }
     if (!sessionLooksActive(currentSessionMeta)) return;
-    hydrateActiveSessionRun(
-      currentSessionMeta?.state || currentSessionMeta?.status || currentSessionMeta?.agentState || currentSessionMeta?.subagentRunState,
-    );
-  }, [connectionState, currentSession, currentSessionMeta, hydrateActiveSessionRun]);
+    hydrateActiveSessionRun(stateHint);
+  }, [connectionState, currentSession, currentSessionMeta, finishHydratedSessionRun, hydrateActiveSessionRun, triggerRecovery]);
 
   // ─── Periodic history poll for sub-agent sessions ─────────────────────────
   const isSubagentSession = currentSession ? isSubagentSessionKey(currentSession) : false;

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -107,37 +107,43 @@ function lowerString(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
 
+function sessionHasOwnActiveSignal(session: Partial<Session & EventPayload>): boolean {
+  return session.hasActiveRun === true || session.busy === true || session.processing === true;
+}
+
+function sessionHasOwnInactiveSignal(session: Partial<Session & EventPayload>): boolean {
+  return session.hasActiveRun === false || session.busy === false || session.processing === false;
+}
+
+function ownSessionStates(session: Partial<Session & EventPayload>): string[] {
+  return [session.state, session.status, session.agentState].map(lowerString);
+}
+
 function sessionLooksActive(session?: Partial<Session & EventPayload> | null): boolean {
   if (!session) return false;
   const phase = lowerString(session.phase);
   if (phase === 'end' || phase === 'error') return false;
-  if (session.hasActiveRun === true || session.busy === true || session.processing === true) return true;
-  if (session.hasActiveRun === false || session.busy === false || session.processing === false) return false;
+  if (sessionHasOwnActiveSignal(session)) return true;
   if (phase === 'start') return true;
+  if (sessionHasOwnInactiveSignal(session)) return false;
 
-  const ownStateActive = [session.state, session.status, session.agentState]
-    .map(lowerString)
-    .some((state) => ACTIVE_SESSION_STATES.has(state));
+  const ownStateActive = ownSessionStates(session).some((state) => ACTIVE_SESSION_STATES.has(state));
   if (ownStateActive) return true;
 
   // The chat pane should only hydrate the selected session's own run. A parent
   // with only an active child/subagent belongs in the sidebar, not Stop/send UI.
   if (session.hasActiveSubagentRun === true) return false;
-
-  return [session.subagentRunState]
-    .map(lowerString)
-    .some((state) => ACTIVE_SESSION_STATES.has(state));
+  return false;
 }
 
 function sessionLooksTerminal(session?: Partial<Session & EventPayload> | null): boolean {
   if (!session) return false;
   const phase = lowerString(session.phase);
   if (phase === 'end' || phase === 'error') return true;
-  if (session.hasActiveRun === true || session.busy === true || session.processing === true) return false;
-  if (session.hasActiveRun === false || session.busy === false || session.processing === false) return true;
-  return [session.state, session.status, session.agentState, session.subagentRunState]
-    .map(lowerString)
-    .some((state) => TERMINAL_SESSION_STATES.has(state));
+  if (phase === 'start') return false;
+  if (sessionHasOwnActiveSignal(session)) return false;
+  if (sessionHasOwnInactiveSignal(session)) return true;
+  return ownSessionStates(session).some((state) => TERMINAL_SESSION_STATES.has(state));
 }
 
 export function ChatProvider({ children }: { children: ReactNode }) {
@@ -287,6 +293,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
 
   // ─── Reset transient state on session switch ──────────────────────────────
   useEffect(() => {
+    isGeneratingRef.current = false;
     setIsGenerating(false);
     msgHook.resetMessageState();
     streamHook.resetStreamState();
@@ -352,7 +359,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   // looking idle until the final transcript lands.
   useEffect(() => {
     if (connectionState !== 'connected' || !currentSession) return;
-    const stateHint = currentSessionMeta?.state || currentSessionMeta?.status || currentSessionMeta?.agentState || currentSessionMeta?.subagentRunState || currentSessionMeta?.phase;
+    const stateHint = currentSessionMeta?.state || currentSessionMeta?.status || currentSessionMeta?.agentState || currentSessionMeta?.phase;
     if (sessionLooksTerminal(currentSessionMeta)) {
       const hasLiveRun = Boolean(activeRunIdRef.current);
       const wasActive = isGeneratingRef.current || hasLiveRun;
@@ -436,7 +443,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       const payload = (msg.payload || {}) as EventPayload;
 
       if ((msg.event === 'sessions.changed' || msg.event === 'session.message') && payload.sessionKey === currentSk) {
-        const stateHint = payload.state || payload.status || payload.agentState || payload.subagentRunState || payload.phase;
+        const stateHint = payload.state || payload.status || payload.agentState || payload.phase;
         const terminalUpdate = sessionLooksTerminal(payload);
         const activeUpdate = sessionLooksActive(payload);
         if (activeUpdate) {

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -111,13 +111,20 @@ function sessionLooksActive(session?: Partial<Session & EventPayload> | null): b
   if (!session) return false;
   const phase = lowerString(session.phase);
   if (phase === 'end' || phase === 'error') return false;
-  // The chat pane should only hydrate the selected session's own run. A parent
-  // with only an active child/subagent belongs in the sidebar, not Stop/send UI.
-  if (session.hasActiveSubagentRun === true && session.hasActiveRun !== true) return false;
   if (session.hasActiveRun === true || session.busy === true || session.processing === true) return true;
   if (session.hasActiveRun === false || session.busy === false || session.processing === false) return false;
   if (phase === 'start') return true;
-  return [session.state, session.status, session.agentState, session.subagentRunState]
+
+  const ownStateActive = [session.state, session.status, session.agentState]
+    .map(lowerString)
+    .some((state) => ACTIVE_SESSION_STATES.has(state));
+  if (ownStateActive) return true;
+
+  // The chat pane should only hydrate the selected session's own run. A parent
+  // with only an active child/subagent belongs in the sidebar, not Stop/send UI.
+  if (session.hasActiveSubagentRun === true) return false;
+
+  return [session.subagentRunState]
     .map(lowerString)
     .some((state) => ACTIVE_SESSION_STATES.has(state));
 }
@@ -251,7 +258,6 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     isGeneratingRef.current = false;
     setIsGenerating(false);
     activeRunIdRef.current = null;
-    incrementGeneration();
     setProcessingStage(null);
     setActivityLog([]);
     setLastEventTimestamp(0);
@@ -262,7 +268,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     if (state !== 'error' && state !== 'failed') {
       playCompletionPing();
     }
-  }, [clearStreamBuffer, clearTerminalSnapshotFinish, incrementGeneration, playCompletionPing, resetThinking, setActivityLog, setLastEventTimestamp, setProcessingStage]);
+  }, [clearStreamBuffer, clearTerminalSnapshotFinish, playCompletionPing, resetThinking, setActivityLog, setLastEventTimestamp, setProcessingStage]);
 
   const scheduleTerminalSnapshotFinish = useCallback((stateHint?: string) => {
     const activeRunId = activeRunIdRef.current;

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -320,8 +320,9 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     if (connectionState !== 'connected' || !currentSession) return;
     const stateHint = currentSessionMeta?.state || currentSessionMeta?.status || currentSessionMeta?.agentState || currentSessionMeta?.subagentRunState || currentSessionMeta?.phase;
     if (sessionLooksTerminal(currentSessionMeta)) {
-      const wasActive = isGeneratingRef.current || Boolean(activeRunIdRef.current);
-      finishHydratedSessionRun(stateHint);
+      const hasLiveRun = Boolean(activeRunIdRef.current);
+      const wasActive = isGeneratingRef.current || hasLiveRun;
+      if (!hasLiveRun) finishHydratedSessionRun(stateHint);
       if (wasActive) triggerRecovery('reconnect');
       return;
     }
@@ -407,7 +408,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         if (activeUpdate) {
           hydrateActiveSessionRun(stateHint);
         }
-        if (terminalUpdate) {
+        if (terminalUpdate && !activeRunIdRef.current) {
           finishHydratedSessionRun(stateHint);
         }
         const shouldRecoverFromMessage = msg.event === 'session.message'

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -100,7 +100,7 @@ interface ChatContextValue {
 const ChatContext = createContext<ChatContextValue | null>(null);
 
 const ACTIVE_SESSION_STATES = new Set(['running', 'thinking', 'processing', 'streaming', 'tool_use', 'executing', 'tool', 'delta', 'started', 'active']);
-const TERMINAL_SESSION_STATES = new Set(['idle', 'done', 'error', 'final', 'aborted', 'completed', 'finished', 'ended', 'cancelled', 'timeout', 'stopped']);
+const TERMINAL_SESSION_STATES = new Set(['idle', 'done', 'error', 'failed', 'killed', 'final', 'aborted', 'completed', 'finished', 'ended', 'cancelled', 'timeout', 'stopped']);
 
 function lowerString(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
@@ -115,8 +115,10 @@ function sessionLooksActive(session?: Partial<Session & EventPayload> | null): b
     .some((state) => ACTIVE_SESSION_STATES.has(state));
 }
 
-function sessionLooksTerminal(session?: Partial<EventPayload> | Partial<Session> | null): boolean {
+function sessionLooksTerminal(session?: Partial<Session & EventPayload> | null): boolean {
   if (!session) return false;
+  const phase = lowerString(session.phase);
+  if (phase === 'end' || phase === 'error') return true;
   return [session.state, session.status].map(lowerString).some((state) => TERMINAL_SESSION_STATES.has(state));
 }
 
@@ -221,6 +223,26 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     setLastEventTimestamp(Date.now());
     triggerRecovery('reconnect');
   }, [resetPlayedSounds, setLastEventTimestamp, setProcessingStage, triggerRecovery]);
+
+  const finishHydratedSessionRun = useCallback((stateHint?: string) => {
+    if (!isGeneratingRef.current && !activeRunIdRef.current) return;
+    const state = lowerString(stateHint);
+
+    isGeneratingRef.current = false;
+    setIsGenerating(false);
+    activeRunIdRef.current = null;
+    incrementGeneration();
+    setProcessingStage(null);
+    setActivityLog([]);
+    setLastEventTimestamp(0);
+    clearStreamBuffer();
+    resetThinking();
+    pruneRunRegistry(runsRef.current, activeRunIdRef.current);
+
+    if (state !== 'error' && state !== 'failed') {
+      playCompletionPing();
+    }
+  }, [clearStreamBuffer, incrementGeneration, playCompletionPing, resetThinking, setActivityLog, setLastEventTimestamp, setProcessingStage]);
 
   // ─── Reset transient state on session switch ──────────────────────────────
   useEffect(() => {
@@ -365,10 +387,14 @@ export function ChatProvider({ children }: { children: ReactNode }) {
 
       if ((msg.event === 'sessions.changed' || msg.event === 'session.message') && payload.sessionKey === currentSk) {
         const stateHint = payload.state || payload.status || payload.phase;
+        const terminalUpdate = sessionLooksTerminal(payload);
         if (sessionLooksActive(payload)) {
           hydrateActiveSessionRun(stateHint);
         }
-        if (msg.event === 'session.message' || sessionLooksTerminal(payload)) {
+        if (terminalUpdate) {
+          finishHydratedSessionRun(stateHint);
+        }
+        if (msg.event === 'session.message' || terminalUpdate) {
           triggerRecoveryOnce('reconnect');
         }
       }
@@ -663,6 +689,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     resetPlayedSounds,
     handleFinalTTS,
     hydrateActiveSessionRun,
+    finishHydratedSessionRun,
     subscribe,
     rpc,
   ]);

--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -145,6 +145,48 @@ describe('SessionContext', () => {
     }) as typeof fetch;
   });
 
+  it('subscribes to gateway session events while connected and cleans up', async () => {
+    const { unmount } = render(
+      <SessionProvider>
+        <SessionLabels />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('sessions.subscribe', {});
+    });
+
+    unmount();
+
+    await waitFor(() => {
+      expect(rpcMock).toHaveBeenCalledWith('sessions.unsubscribe', {});
+    });
+  });
+
+  it('hydrates active run status from sessions.list snapshots', async () => {
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            { sessionKey: 'agent:reviewer:main', label: 'Reviewer', hasActiveRun: true, status: 'running' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+    });
+  });
+
   it('calls agents.create when spawning a root agent', async () => {
     function Spawn() {
       const { spawnSession } = useSessionContext();

--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -83,7 +83,25 @@ function SessionUnreadProbe() {
 
 function SessionStatusProbe() {
   const { agentStatus } = useSessionContext();
-  return <div data-testid="reviewer-status">{agentStatus['agent:reviewer:main']?.status ?? 'NONE'}</div>;
+  const status = agentStatus['agent:reviewer:main'];
+  return (
+    <div>
+      <div data-testid="reviewer-status">{status?.status ?? 'NONE'}</div>
+      <div data-testid="reviewer-tool">{status?.toolName ?? 'NONE'}</div>
+    </div>
+  );
+}
+
+function SessionSnapshotProbe() {
+  const { sessions } = useSessionContext();
+  const session = sessions.find((s) => getSessionKey(s) === 'agent:reviewer:main');
+  return (
+    <div>
+      <div data-testid="reviewer-phase">{session?.phase ?? 'NONE'}</div>
+      <div data-testid="reviewer-snapshot-status">{session?.status ?? 'NONE'}</div>
+      <div data-testid="reviewer-active-run">{String(session?.hasActiveRun)}</div>
+    </div>
+  );
 }
 
 function SessionBusyProbe() {
@@ -365,6 +383,182 @@ describe('SessionContext', () => {
     await waitFor(() => {
       expect(screen.getByTestId('reviewer-status').textContent).toBe('ERROR');
       expect(screen.getByTestId('reviewer-busy').textContent).toBe('false');
+    });
+  });
+
+  it('persists phase-only subscribed terminal snapshots so stale running status stays terminal', async () => {
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            { sessionKey: 'agent:reviewer:main', label: 'Reviewer', hasActiveRun: true, status: 'running', phase: 'start' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+        <SessionSnapshotProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+    });
+
+    act(() => {
+      subscribedHandler?.({
+        type: 'event',
+        event: 'sessions.changed',
+        payload: { sessionKey: 'agent:reviewer:main', phase: 'end' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('DONE');
+      expect(screen.getByTestId('reviewer-phase').textContent).toBe('end');
+      expect(screen.getByTestId('reviewer-active-run').textContent).toBe('false');
+    });
+  });
+
+  it('clears stale terminal status when a phase-only subscribed snapshot starts', async () => {
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            { sessionKey: 'agent:reviewer:main', label: 'Reviewer', hasActiveRun: false, status: 'done', phase: 'end' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+        <SessionSnapshotProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-snapshot-status').textContent).toBe('done');
+    });
+
+    act(() => {
+      subscribedHandler?.({
+        type: 'event',
+        event: 'sessions.changed',
+        payload: { sessionKey: 'agent:reviewer:main', phase: 'start' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+      expect(screen.getByTestId('reviewer-phase').textContent).toBe('start');
+      expect(screen.getByTestId('reviewer-snapshot-status').textContent).toBe('running');
+      expect(screen.getByTestId('reviewer-active-run').textContent).toBe('true');
+    });
+  });
+
+  it('does not let stale running status mask terminal agentState snapshots', async () => {
+    let terminal = false;
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            terminal
+              ? { sessionKey: 'agent:reviewer:main', label: 'Reviewer', status: 'running', agentState: 'aborted' }
+              : { sessionKey: 'agent:reviewer:main', label: 'Reviewer', status: 'running' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+        <SessionRefreshProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+    });
+
+    terminal = true;
+    await act(async () => {
+      screen.getByTestId('refresh-sessions').click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('IDLE');
+    });
+  });
+
+  it('maps legacy failed and cancelled agent states to terminal error/idle badges', async () => {
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => expect(subscribedHandler).toBeTruthy());
+
+    act(() => {
+      subscribedHandler?.({
+        type: 'event',
+        event: 'agent',
+        payload: { sessionKey: 'agent:reviewer:main', state: 'failed' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('ERROR');
+    });
+
+    act(() => {
+      subscribedHandler?.({
+        type: 'event',
+        event: 'agent',
+        payload: { sessionKey: 'agent:reviewer:main', state: 'cancelled' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('IDLE');
+    });
+  });
+
+  it('hydrates tool status from session.tool events without a stream discriminator', async () => {
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => expect(subscribedHandler).toBeTruthy());
+
+    act(() => {
+      subscribedHandler?.({
+        type: 'event',
+        event: 'session.tool',
+        payload: {
+          sessionKey: 'agent:reviewer:main',
+          data: { phase: 'start', name: 'read', args: { path: 'README.md' } },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+      expect(screen.getByTestId('reviewer-tool').textContent).toBe('read');
     });
   });
 

--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -506,6 +506,44 @@ describe('SessionContext', () => {
     });
   });
 
+  it('does not promote child-only active snapshots to an own active run', async () => {
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            { sessionKey: 'agent:reviewer:main', label: 'Reviewer', hasActiveRun: false, status: 'done', phase: 'end' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+        <SessionSnapshotProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-active-run').textContent).toBe('false');
+    });
+
+    act(() => {
+      subscribedHandler?.({
+        type: 'event',
+        event: 'sessions.changed',
+        payload: { sessionKey: 'agent:reviewer:main', hasActiveSubagentRun: true, status: 'running' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+      expect(screen.getByTestId('reviewer-active-run').textContent).toBe('false');
+    });
+  });
+
   it('does not let stale running status mask terminal agentState snapshots', async () => {
     let terminal = false;
     rpcMock.mockImplementation(async (method: string) => {

--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -544,6 +544,53 @@ describe('SessionContext', () => {
     });
   });
 
+  it('keeps terminal event snapshots sticky when a delayed refresh returns stale active data', async () => {
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            { sessionKey: 'agent:reviewer:main', label: 'Reviewer', hasActiveRun: true, status: 'running', phase: 'start' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+        <SessionSnapshotProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-active-run').textContent).toBe('true');
+    });
+
+    vi.useFakeTimers();
+
+    act(() => {
+      subscribedHandler?.({
+        type: 'event',
+        event: 'sessions.changed',
+        payload: { sessionKey: 'agent:reviewer:main', hasActiveRun: false, status: 'done', phase: 'end' },
+      });
+    });
+
+    expect(screen.getByTestId('reviewer-status').textContent).toBe('DONE');
+    expect(screen.getByTestId('reviewer-active-run').textContent).toBe('false');
+    expect(screen.getByTestId('reviewer-phase').textContent).toBe('end');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    expect(screen.getByTestId('reviewer-active-run').textContent).toBe('false');
+    expect(screen.getByTestId('reviewer-snapshot-status').textContent).toBe('done');
+    expect(screen.getByTestId('reviewer-phase').textContent).toBe('end');
+  });
+
   it('does not let stale running status mask terminal agentState snapshots', async () => {
     let terminal = false;
     rpcMock.mockImplementation(async (method: string) => {

--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -465,6 +465,47 @@ describe('SessionContext', () => {
     });
   });
 
+  it('clears stale terminal phase and inactive flag when a legacy active event starts', async () => {
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            { sessionKey: 'agent:reviewer:main', label: 'Reviewer', hasActiveRun: false, status: 'done', phase: 'end' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+        <SessionSnapshotProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-phase').textContent).toBe('end');
+      expect(screen.getByTestId('reviewer-active-run').textContent).toBe('false');
+    });
+
+    act(() => {
+      subscribedHandler?.({
+        type: 'event',
+        event: 'chat',
+        payload: { sessionKey: 'agent:reviewer:main', state: 'started' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+      expect(screen.getByTestId('reviewer-phase').textContent).toBe('NONE');
+      expect(screen.getByTestId('reviewer-snapshot-status').textContent).toBe('running');
+      expect(screen.getByTestId('reviewer-active-run').textContent).toBe('true');
+    });
+  });
+
   it('does not let stale running status mask terminal agentState snapshots', async () => {
     let terminal = false;
     rpcMock.mockImplementation(async (method: string) => {

--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -100,6 +100,8 @@ function SessionSnapshotProbe() {
       <div data-testid="reviewer-phase">{session?.phase ?? 'NONE'}</div>
       <div data-testid="reviewer-snapshot-status">{session?.status ?? 'NONE'}</div>
       <div data-testid="reviewer-active-run">{String(session?.hasActiveRun)}</div>
+      <div data-testid="reviewer-busy-flag">{String(session?.busy)}</div>
+      <div data-testid="reviewer-processing-flag">{String(session?.processing)}</div>
     </div>
   );
 }
@@ -676,6 +678,192 @@ describe('SessionContext', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('reviewer-status').textContent).toBe('IDLE');
+    });
+  });
+
+  it('keeps own active sessions running when a child terminal state is present in sessions.list', async () => {
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            { sessionKey: 'agent:reviewer:main', label: 'Reviewer', status: 'running', subagentRunState: 'done' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+    });
+  });
+
+  it('keeps own active sessions running when a subscribed snapshot includes a child terminal state', async () => {
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => expect(subscribedHandler).toBeTruthy());
+
+    act(() => {
+      subscribedHandler?.({
+        type: 'event',
+        event: 'sessions.changed',
+        payload: { sessionKey: 'agent:reviewer:main', hasActiveRun: true, status: 'running' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+    });
+
+    act(() => {
+      subscribedHandler?.({
+        type: 'event',
+        event: 'sessions.changed',
+        payload: { sessionKey: 'agent:reviewer:main', status: 'running', subagentRunState: 'done' },
+      });
+    });
+
+    expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+  });
+
+  it('updates busy and processing fields from sessions.list refreshes', async () => {
+    let terminal = false;
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            terminal
+              ? { sessionKey: 'agent:reviewer:main', label: 'Reviewer', busy: false, processing: false, status: 'running' }
+              : { sessionKey: 'agent:reviewer:main', label: 'Reviewer', busy: true, processing: true, status: 'running' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+        <SessionSnapshotProbe />
+        <SessionRefreshProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+      expect(screen.getByTestId('reviewer-busy-flag').textContent).toBe('true');
+      expect(screen.getByTestId('reviewer-processing-flag').textContent).toBe('true');
+    });
+
+    terminal = true;
+    await act(async () => {
+      screen.getByTestId('refresh-sessions').click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('IDLE');
+      expect(screen.getByTestId('reviewer-busy-flag').textContent).toBe('false');
+      expect(screen.getByTestId('reviewer-processing-flag').textContent).toBe('false');
+    });
+  });
+
+  it('persists busy and processing fields from subscribed session snapshots', async () => {
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            { sessionKey: 'agent:reviewer:main', label: 'Reviewer', busy: true, processing: true, status: 'running' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+        <SessionSnapshotProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+      expect(screen.getByTestId('reviewer-busy-flag').textContent).toBe('true');
+      expect(screen.getByTestId('reviewer-processing-flag').textContent).toBe('true');
+    });
+
+    act(() => {
+      subscribedHandler?.({
+        type: 'event',
+        event: 'sessions.changed',
+        payload: { sessionKey: 'agent:reviewer:main', busy: false, processing: false, status: 'running' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('IDLE');
+      expect(screen.getByTestId('reviewer-busy-flag').textContent).toBe('false');
+      expect(screen.getByTestId('reviewer-processing-flag').textContent).toBe('false');
+    });
+  });
+
+  it('hydrates phase-start snapshots even when stale inactive flags are present', async () => {
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            { sessionKey: 'agent:reviewer:main', label: 'Reviewer', hasActiveRun: false, busy: false, processing: false, status: 'done', phase: 'end' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+        <SessionSnapshotProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => expect(subscribedHandler).toBeTruthy());
+
+    act(() => {
+      subscribedHandler?.({
+        type: 'event',
+        event: 'sessions.changed',
+        payload: {
+          sessionKey: 'agent:reviewer:main',
+          phase: 'start',
+          hasActiveRun: false,
+          busy: false,
+          processing: false,
+          status: 'done',
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+      expect(screen.getByTestId('reviewer-phase').textContent).toBe('start');
+      expect(screen.getByTestId('reviewer-snapshot-status').textContent).toBe('running');
+      expect(screen.getByTestId('reviewer-active-run').textContent).toBe('true');
+      expect(screen.getByTestId('reviewer-busy-flag').textContent).toBe('undefined');
+      expect(screen.getByTestId('reviewer-processing-flag').textContent).toBe('undefined');
     });
   });
 

--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -544,6 +544,57 @@ describe('SessionContext', () => {
     });
   });
 
+  it('keeps lifecycle terminal updates sticky when a delayed refresh returns stale active data', async () => {
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            { sessionKey: 'agent:reviewer:main', label: 'Reviewer', hasActiveRun: true, status: 'running', phase: 'start' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+        <SessionSnapshotProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-active-run').textContent).toBe('true');
+    });
+
+    vi.useFakeTimers();
+
+    act(() => {
+      subscribedHandler?.({
+        type: 'event',
+        event: 'agent',
+        payload: {
+          sessionKey: 'agent:reviewer:main',
+          stream: 'lifecycle',
+          data: { phase: 'end' },
+        },
+      });
+    });
+
+    expect(screen.getByTestId('reviewer-status').textContent).toBe('DONE');
+    expect(screen.getByTestId('reviewer-active-run').textContent).toBe('false');
+    expect(screen.getByTestId('reviewer-phase').textContent).toBe('end');
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    expect(screen.getByTestId('reviewer-active-run').textContent).toBe('false');
+    expect(screen.getByTestId('reviewer-snapshot-status').textContent).toBe('done');
+    expect(screen.getByTestId('reviewer-phase').textContent).toBe('end');
+  });
+
   it('keeps terminal event snapshots sticky when a delayed refresh returns stale active data', async () => {
     rpcMock.mockImplementation(async (method: string) => {
       if (method === 'sessions.list') {

--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -197,6 +197,30 @@ describe('SessionContext', () => {
     });
   });
 
+  it('hydrates active run status from busy sessions.list snapshots', async () => {
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            { sessionKey: 'agent:reviewer:main', label: 'Reviewer', status: 'busy' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+    });
+  });
+
   it('clears active run status from terminal sessions.list snapshots', async () => {
     let terminal = false;
     rpcMock.mockImplementation(async (method: string) => {
@@ -207,6 +231,80 @@ describe('SessionContext', () => {
             terminal
               ? { sessionKey: 'agent:reviewer:main', label: 'Reviewer', hasActiveRun: false, status: 'done' }
               : { sessionKey: 'agent:reviewer:main', label: 'Reviewer', hasActiveRun: true, status: 'running' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+        <SessionRefreshProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+    });
+
+    terminal = true;
+    await act(async () => {
+      screen.getByTestId('refresh-sessions').click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('DONE');
+    });
+  });
+
+  it('clears active run status from terminal agentState sessions.list snapshots', async () => {
+    let terminal = false;
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            terminal
+              ? { sessionKey: 'agent:reviewer:main', label: 'Reviewer', agentState: 'completed' }
+              : { sessionKey: 'agent:reviewer:main', label: 'Reviewer', agentState: 'running' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+        <SessionRefreshProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+    });
+
+    terminal = true;
+    await act(async () => {
+      screen.getByTestId('refresh-sessions').click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('DONE');
+    });
+  });
+
+  it('preserves phase-only session list changes for terminal refresh snapshots', async () => {
+    let terminal = false;
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            terminal
+              ? { sessionKey: 'agent:reviewer:main', label: 'Reviewer', status: 'running', phase: 'end' }
+              : { sessionKey: 'agent:reviewer:main', label: 'Reviewer', status: 'running', phase: 'start' },
           ],
         };
       }

--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -86,6 +86,16 @@ function SessionStatusProbe() {
   return <div data-testid="reviewer-status">{agentStatus['agent:reviewer:main']?.status ?? 'NONE'}</div>;
 }
 
+function SessionBusyProbe() {
+  const { agentStatus, busyState } = useSessionContext();
+  return (
+    <div>
+      <div data-testid="reviewer-status">{agentStatus['agent:reviewer:main']?.status ?? 'NONE'}</div>
+      <div data-testid="reviewer-busy">{String(Boolean(busyState['agent:reviewer:main']))}</div>
+    </div>
+  );
+}
+
 describe('SessionContext', () => {
   afterEach(() => {
     vi.useRealTimers();
@@ -184,6 +194,79 @@ describe('SessionContext', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+    });
+  });
+
+  it('clears active run status from terminal sessions.list snapshots', async () => {
+    let terminal = false;
+    rpcMock.mockImplementation(async (method: string) => {
+      if (method === 'sessions.list') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:main', label: 'Main' },
+            terminal
+              ? { sessionKey: 'agent:reviewer:main', label: 'Reviewer', hasActiveRun: false, status: 'done' }
+              : { sessionKey: 'agent:reviewer:main', label: 'Reviewer', hasActiveRun: true, status: 'running' },
+          ],
+        };
+      }
+      return {};
+    });
+
+    render(
+      <SessionProvider>
+        <SessionStatusProbe />
+        <SessionRefreshProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+    });
+
+    terminal = true;
+    await act(async () => {
+      screen.getByTestId('refresh-sessions').click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('DONE');
+    });
+  });
+
+  it('clears busy state from terminal subscribed session snapshots', async () => {
+    render(
+      <SessionProvider>
+        <SessionBusyProbe />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => expect(subscribedHandler).toBeTruthy());
+
+    act(() => {
+      subscribedHandler?.({
+        type: 'event',
+        event: 'sessions.changed',
+        payload: { sessionKey: 'agent:reviewer:main', hasActiveRun: true, status: 'running' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('THINKING');
+      expect(screen.getByTestId('reviewer-busy').textContent).toBe('true');
+    });
+
+    act(() => {
+      subscribedHandler?.({
+        type: 'event',
+        event: 'sessions.changed',
+        payload: { sessionKey: 'agent:reviewer:main', hasActiveRun: false, status: 'failed' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('reviewer-status').textContent).toBe('ERROR');
+      expect(screen.getByTestId('reviewer-busy').textContent).toBe('false');
     });
   });
 

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -19,8 +19,23 @@ import {
   getRootAgentId,
 } from '@/features/sessions/sessionKeys';
 
-const BUSY_STATES = new Set(['running', 'thinking', 'tool_use', 'delta', 'started']);
-const IDLE_STATES = new Set(['idle', 'done', 'error', 'final', 'aborted', 'completed']);
+const BUSY_STATES = new Set(['running', 'thinking', 'processing', 'streaming', 'tool_use', 'executing', 'tool', 'delta', 'started', 'active']);
+const IDLE_STATES = new Set(['idle', 'done', 'error', 'final', 'aborted', 'completed', 'finished', 'ended', 'cancelled', 'timeout', 'stopped']);
+
+function lowerString(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function sessionSnapshotIsActive(session: Partial<Session>): boolean {
+  if (session.hasActiveRun || session.hasActiveSubagentRun || session.busy || session.processing) return true;
+  return [session.state, session.status, session.agentState, session.subagentRunState]
+    .map(lowerString)
+    .some((state) => BUSY_STATES.has(state));
+}
+
+function sessionPayloadIsTerminal(payload: Partial<EventPayload>): boolean {
+  return [payload.state, payload.status].map(lowerString).some((state) => IDLE_STATES.has(state));
+}
 
 // Use the full session list for the sidebar so older root chats stay visible.
 const FULL_SESSIONS_LIMIT = 1000;
@@ -578,6 +593,14 @@ export function SessionProvider({ children }: { children: ReactNode }) {
           // Compare relevant fields to detect changes
           const changed = (
             existing.state !== newSession.state ||
+            existing.status !== newSession.status ||
+            existing.agentState !== newSession.agentState ||
+            existing.hasActiveRun !== newSession.hasActiveRun ||
+            existing.hasActiveSubagentRun !== newSession.hasActiveSubagentRun ||
+            existing.subagentRunState !== newSession.subagentRunState ||
+            existing.startedAt !== newSession.startedAt ||
+            existing.endedAt !== newSession.endedAt ||
+            existing.runtimeMs !== newSession.runtimeMs ||
             existing.totalTokens !== newSession.totalTokens ||
             existing.contextTokens !== newSession.contextTokens ||
             existing.model !== newSession.model ||
@@ -601,13 +624,24 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         // If nothing changed, return the same array reference
         return hasChanges ? merged : prev;
       });
+
+      for (const session of newSessions) {
+        const key = getSessionKey(session);
+        if (!key || !sessionSnapshotIsActive(session)) continue;
+        const stage = lowerString(session.state || session.status || session.agentState || session.subagentRunState);
+        setGranularStatus(key, {
+          status: stage === 'delta' || stage === 'streaming' ? 'STREAMING' : 'THINKING',
+          since: Date.now(),
+        });
+      }
+
       setCurrentSession(nextCurrentSession);
     } catch (err) {
       console.debug('[SessionContext] Failed to refresh sessions:', err);
     } finally {
       setSessionsLoading(false);
     }
-  }, [connectionState, listAuthoritativeSessions, setCurrentSession]);
+  }, [connectionState, listAuthoritativeSessions, setCurrentSession, setGranularStatus]);
 
   const refreshSessionsRef = useRef(refreshSessions);
   useEffect(() => {
@@ -644,12 +678,26 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
-  // Extract session updates (state + token data) from a typed agent event payload
-  const extractSessionUpdates = useCallback((state: string | undefined, payload: AgentEventPayload | ChatEventPayload): Partial<Session> => {
+  // Extract session updates (state + token data) from gateway payloads.
+  const extractSessionUpdates = useCallback((state: string | undefined, payload: Partial<EventPayload>): Partial<Session> => {
     const updates: Partial<Session> = {};
     if (state) updates.state = state;
+    if (typeof payload.status === 'string') updates.status = payload.status;
+    if (typeof payload.agentState === 'string') updates.agentState = payload.agentState;
+    if (typeof payload.hasActiveRun === 'boolean') updates.hasActiveRun = payload.hasActiveRun;
+    if (typeof payload.hasActiveSubagentRun === 'boolean') updates.hasActiveSubagentRun = payload.hasActiveSubagentRun;
+    if (typeof payload.subagentRunState === 'string') updates.subagentRunState = payload.subagentRunState;
+    if (typeof payload.startedAt === 'number') updates.startedAt = payload.startedAt;
+    if (typeof payload.endedAt === 'number') updates.endedAt = payload.endedAt;
+    if (typeof payload.runtimeMs === 'number') updates.runtimeMs = payload.runtimeMs;
     if ('totalTokens' in payload && typeof payload.totalTokens === 'number') updates.totalTokens = payload.totalTokens;
     if ('contextTokens' in payload && typeof payload.contextTokens === 'number') updates.contextTokens = payload.contextTokens;
+
+    const phase = lowerString(payload.phase);
+    if (phase === 'start') updates.hasActiveRun = true;
+    if (phase === 'end' || phase === 'error') updates.hasActiveRun = false;
+    if (sessionPayloadIsTerminal(payload)) updates.hasActiveRun = false;
+
     return updates;
   }, []);
 
@@ -663,6 +711,17 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     }, 1500);
   }, []);
 
+  // Ask OpenClaw for targeted session lifecycle/tool broadcasts on this connection.
+  useEffect(() => {
+    if (connectionState !== 'connected') return;
+    void rpc('sessions.subscribe', {}).catch((err) => {
+      console.debug('[SessionContext] sessions.subscribe unavailable:', err);
+    });
+    return () => {
+      void rpc('sessions.unsubscribe', {}).catch(() => {});
+    };
+  }, [connectionState, rpc]);
+
   // Subscribe to gateway events for granular status tracking + session state sync + agent log + event log
   useEffect(() => {
     const unsub = subscribe((msg: GatewayEvent) => {
@@ -671,15 +730,53 @@ export function SessionProvider({ children }: { children: ReactNode }) {
 
       addEvent(msg);
 
-      // Session granular status tracking + state sync from agent/chat events
-      if ((evt === 'agent' || evt === 'chat') && p.sessionKey) {
+      // Session snapshot events are only delivered after sessions.subscribe().
+      if ((evt === 'sessions.changed' || evt === 'session.message') && p.sessionKey) {
         const sk = p.sessionKey;
-        const typedPayload = evt === 'agent'
+        const phase = lowerString(p.phase);
+        const state = lowerString(p.state || p.status);
+
+        if (phase === 'start' || sessionSnapshotIsActive(p)) {
+          setGranularStatus(sk, {
+            status: state === 'delta' || state === 'streaming' ? 'STREAMING' : 'THINKING',
+            since: Date.now(),
+          });
+          if (isTopLevelAgentSessionKey(sk)) markSessionUnread(sk);
+        } else if (phase === 'end' || state === 'done' || state === 'final' || state === 'completed') {
+          setGranularStatus(sk, { status: 'DONE', since: Date.now() });
+          if (isTopLevelAgentSessionKey(sk)) {
+            markSessionUnread(sk);
+            pingSession(sk);
+          }
+          refreshSessions();
+          scheduleDelayedRefresh();
+        } else if (phase === 'error' || state === 'error') {
+          setGranularStatus(sk, { status: 'ERROR', since: Date.now() });
+          if (isTopLevelAgentSessionKey(sk)) {
+            markSessionUnread(sk);
+            pingSession(sk);
+          }
+          refreshSessions();
+        }
+
+        const updates = extractSessionUpdates(p.state || p.status, p);
+        if (Object.keys(updates).length > 0) {
+          updateSessionFromEvent(sk, updates);
+        }
+      }
+
+      // Session granular status tracking + state sync from agent/chat events.
+      // session.tool is delivered only to sessions.subscribe() subscribers and
+      // rehydrates tool activity for a page that joined after the run started.
+      if ((evt === 'agent' || evt === 'session.tool' || evt === 'chat') && p.sessionKey) {
+        const sk = p.sessionKey;
+        const isAgentLike = evt === 'agent' || evt === 'session.tool';
+        const typedPayload = isAgentLike
           ? (msg.payload || {}) as AgentEventPayload
           : (msg.payload || {}) as ChatEventPayload;
 
         // Handle lifecycle events from CLI agents (Codex, Claude Code CLI)
-        if (evt === 'agent') {
+        if (isAgentLike) {
           const ap = typedPayload as AgentEventPayload;
 
           if (ap.stream === 'lifecycle') {
@@ -752,12 +849,12 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         }
 
         // Also handle legacy state strings for backward compatibility
-        const state = evt === 'agent'
-          ? ((typedPayload as AgentEventPayload).state || (typedPayload as AgentEventPayload).agentState || '')
-          : ((typedPayload as ChatEventPayload).state || '');
+        const state = isAgentLike
+          ? lowerString((typedPayload as AgentEventPayload).state || (typedPayload as AgentEventPayload).agentState || (typedPayload as AgentEventPayload).status || '')
+          : lowerString((typedPayload as ChatEventPayload).state || (typedPayload as ChatEventPayload).status || '');
 
         // Map legacy state strings to granular status (only if not already handled above)
-        if (evt === 'agent' && !(typedPayload as AgentEventPayload).stream) {
+        if (isAgentLike && !(typedPayload as AgentEventPayload).stream) {
           if (BUSY_STATES.has(state)) {
             setGranularStatus(sk, { status: 'THINKING', since: Date.now() });
           } else if (IDLE_STATES.has(state)) {

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -28,8 +28,25 @@ function lowerString(value: unknown): string {
 
 type SessionSnapshotLike = Partial<Session & EventPayload>;
 
+function snapshotHasExplicitActiveRun(snapshot: SessionSnapshotLike): boolean {
+  return snapshot.hasActiveRun === true
+    || snapshot.hasActiveSubagentRun === true
+    || snapshot.busy === true
+    || snapshot.processing === true;
+}
+
+function snapshotHasExplicitInactiveRun(snapshot: SessionSnapshotLike): boolean {
+  return snapshot.hasActiveRun === false
+    || snapshot.busy === false
+    || snapshot.processing === false;
+}
+
 function sessionSnapshotIsActive(session: SessionSnapshotLike): boolean {
-  if (session.hasActiveRun || session.hasActiveSubagentRun || session.busy || session.processing) return true;
+  const phase = lowerString(session.phase);
+  if (phase === 'end' || phase === 'error') return false;
+  if (snapshotHasExplicitActiveRun(session)) return true;
+  if (snapshotHasExplicitInactiveRun(session)) return false;
+  if (phase === 'start') return true;
   return [session.state, session.status, session.agentState, session.subagentRunState]
     .map(lowerString)
     .some((state) => BUSY_STATES.has(state));
@@ -38,6 +55,8 @@ function sessionSnapshotIsActive(session: SessionSnapshotLike): boolean {
 function sessionSnapshotIsTerminal(snapshot: SessionSnapshotLike): boolean {
   const phase = lowerString(snapshot.phase);
   if (phase === 'end' || phase === 'error') return true;
+  if (snapshotHasExplicitActiveRun(snapshot)) return false;
+  if (snapshotHasExplicitInactiveRun(snapshot)) return true;
   return [snapshot.state, snapshot.status, snapshot.agentState, snapshot.subagentRunState]
     .map(lowerString)
     .some((state) => IDLE_STATES.has(state));
@@ -45,9 +64,16 @@ function sessionSnapshotIsTerminal(snapshot: SessionSnapshotLike): boolean {
 
 function terminalAgentStatus(snapshot: SessionSnapshotLike): GranularAgentState['status'] {
   const phase = lowerString(snapshot.phase);
-  const state = lowerString(snapshot.status || snapshot.state || snapshot.agentState || snapshot.subagentRunState);
-  if (phase === 'error' || state === 'error' || state === 'failed' || state === 'timeout') return 'ERROR';
-  if (state === 'idle' || state === 'aborted' || state === 'cancelled' || state === 'killed' || state === 'stopped') return 'IDLE';
+  const states = [
+    snapshot.status,
+    snapshot.state,
+    snapshot.agentState,
+    snapshot.subagentRunState,
+  ].map(lowerString);
+  if (phase === 'error' || states.some((state) => state === 'error' || state === 'failed' || state === 'timeout')) return 'ERROR';
+  if (states.some((state) => state === 'idle' || state === 'aborted' || state === 'cancelled' || state === 'killed' || state === 'stopped')) return 'IDLE';
+  if (states.some((state) => state === 'done' || state === 'final' || state === 'completed' || state === 'finished' || state === 'ended')) return 'DONE';
+  if (snapshotHasExplicitInactiveRun(snapshot)) return 'IDLE';
   return 'DONE';
 }
 
@@ -721,7 +747,9 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   // Extract session updates (state + token data) from gateway payloads.
   const extractSessionUpdates = useCallback((state: string | undefined, payload: Partial<EventPayload>): Partial<Session> => {
     const updates: Partial<Session> = {};
+    const phase = lowerString(payload.phase);
     if (state) updates.state = state;
+    if (typeof payload.phase === 'string') updates.phase = payload.phase;
     if (typeof payload.status === 'string') updates.status = payload.status;
     if (typeof payload.agentState === 'string') updates.agentState = payload.agentState;
     if (typeof payload.hasActiveRun === 'boolean') updates.hasActiveRun = payload.hasActiveRun;
@@ -733,8 +761,13 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     if ('totalTokens' in payload && typeof payload.totalTokens === 'number') updates.totalTokens = payload.totalTokens;
     if ('contextTokens' in payload && typeof payload.contextTokens === 'number') updates.contextTokens = payload.contextTokens;
 
-    const phase = lowerString(payload.phase);
-    if (phase === 'start') updates.hasActiveRun = true;
+    if (phase === 'start') {
+      updates.hasActiveRun = true;
+      // A lifecycle start may be phase-only. Clear stale terminal strings so
+      // cached snapshots don't look ended until the next full refresh arrives.
+      if (!state) updates.state = 'running';
+      if (typeof payload.status !== 'string') updates.status = 'running';
+    }
     if (phase === 'end' || phase === 'error') updates.hasActiveRun = false;
     if (sessionSnapshotIsTerminal(payload)) updates.hasActiveRun = false;
 
@@ -774,7 +807,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       if ((evt === 'sessions.changed' || evt === 'session.message') && p.sessionKey) {
         const sk = p.sessionKey;
         const phase = lowerString(p.phase);
-        const state = lowerString(p.state || p.status);
+        const state = [p.state, p.status, p.agentState, p.subagentRunState].map(lowerString).find(Boolean) || '';
 
         const terminal = sessionSnapshotIsTerminal(p);
         if (!terminal && (phase === 'start' || sessionSnapshotIsActive(p))) {
@@ -813,8 +846,9 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         // Handle lifecycle events from CLI agents (Codex, Claude Code CLI)
         if (isAgentLike) {
           const ap = typedPayload as AgentEventPayload;
+          const stream = evt === 'session.tool' ? (ap.stream || 'tool') : ap.stream;
 
-          if (ap.stream === 'lifecycle') {
+          if (stream === 'lifecycle') {
             const phase = (ap.data as Record<string, unknown> | undefined)?.phase;
             if (phase === 'start') {
               setGranularStatus(sk, { status: 'THINKING', since: Date.now() });
@@ -834,7 +868,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
               }
               refreshSessions();
             }
-          } else if (ap.stream === 'tool' && ap.data) {
+          } else if (stream === 'tool' && ap.data) {
             if (ap.data.phase === 'start' && ap.data.name) {
               const toolDesc = describeToolUse(ap.data.name, ap.data.args || {});
               setGranularStatus(sk, {
@@ -846,7 +880,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
             } else if (ap.data.phase === 'result') {
               setGranularStatus(sk, { status: 'THINKING', since: Date.now() });
             }
-          } else if (ap.stream === 'assistant') {
+          } else if (stream === 'assistant') {
             setGranularStatus(sk, { status: 'STREAMING', since: Date.now() });
           }
         }
@@ -889,20 +923,18 @@ export function SessionProvider({ children }: { children: ReactNode }) {
           : lowerString((typedPayload as ChatEventPayload).state || (typedPayload as ChatEventPayload).status || '');
 
         // Map legacy state strings to granular status (only if not already handled above)
-        if (isAgentLike && !(typedPayload as AgentEventPayload).stream) {
+        if (isAgentLike && !(evt === 'session.tool' ? 'tool' : (typedPayload as AgentEventPayload).stream)) {
           if (BUSY_STATES.has(state)) {
             setGranularStatus(sk, { status: 'THINKING', since: Date.now() });
           } else if (IDLE_STATES.has(state)) {
-            if (state === 'error') {
-              setGranularStatus(sk, { status: 'ERROR', since: Date.now() });
-            } else if (state === 'aborted') {
-              setGranularStatus(sk, { status: 'IDLE', since: Date.now() });
-            } else {
-              setGranularStatus(sk, { status: 'DONE', since: Date.now() });
+            const nextStatus = terminalAgentStatus({ state });
+            setGranularStatus(sk, { status: nextStatus, since: Date.now() });
+            if (isTopLevelAgentSessionKey(sk) && nextStatus !== 'IDLE') {
+              markSessionUnread(sk);
+              pingSession(sk);
             }
-            if (state === 'final' || state === 'done' || state === 'completed') {
-              refreshSessions();
-            }
+            refreshSessions();
+            if (nextStatus === 'DONE') scheduleDelayedRefresh();
           }
         }
 

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -21,6 +21,7 @@ import {
 
 const BUSY_STATES = new Set(['running', 'busy', 'thinking', 'processing', 'streaming', 'tool_use', 'executing', 'tool', 'delta', 'started', 'active']);
 const IDLE_STATES = new Set(['idle', 'done', 'error', 'failed', 'killed', 'final', 'aborted', 'completed', 'finished', 'ended', 'cancelled', 'timeout', 'stopped']);
+const TERMINAL_SESSION_UPDATE_STICKY_MS = 5_000;
 
 function lowerString(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
@@ -137,6 +138,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const toolSeenRef = useRef<Map<string, number>>(new Map());
   const doneTimeoutsRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
   const delayedRefreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const terminalSessionUpdatesRef = useRef<Record<string, { updates: Partial<Session>; expiresAt: number }>>({});
 
   // Derive busyState from active granular statuses for backward compatibility.
   const busyState = useMemo(() => {
@@ -525,6 +527,40 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     setEventEntries(prev => [{ badge, badgeCls, desc, ts: new Date() }, ...prev].slice(0, 50));
   }, []);
 
+  const rememberSessionEventUpdate = useCallback((sessionKey: string, updates: Partial<Session>) => {
+    if (!sessionKey || Object.keys(updates).length === 0) return;
+    if (sessionSnapshotIsActive(updates)) {
+      delete terminalSessionUpdatesRef.current[sessionKey];
+      return;
+    }
+    if (!sessionSnapshotIsTerminal(updates)) return;
+    terminalSessionUpdatesRef.current[sessionKey] = {
+      updates,
+      expiresAt: Date.now() + TERMINAL_SESSION_UPDATE_STICKY_MS,
+    };
+  }, []);
+
+  const applyRecentTerminalSessionUpdates = useCallback((sessionList: Session[]): Session[] => {
+    const now = Date.now();
+    let changed = false;
+    const next = sessionList.map((session) => {
+      const key = getSessionKey(session);
+      const recent = key ? terminalSessionUpdatesRef.current[key] : undefined;
+      if (!recent) return session;
+      if (recent.expiresAt <= now) {
+        delete terminalSessionUpdatesRef.current[key];
+        return session;
+      }
+      if (sessionSnapshotIsTerminal(session)) {
+        delete terminalSessionUpdatesRef.current[key];
+        return session;
+      }
+      changed = true;
+      return { ...session, ...recent.updates };
+    });
+    return changed ? next : sessionList;
+  }, []);
+
   const feedAgentLog = useCallback((evt: string, p: EventPayload) => {
     const sk = p.sessionKey || '';
     const name = friendlyName(sk);
@@ -616,7 +652,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const refreshSessions = useCallback(async () => {
     if (connectionState !== 'connected') return;
     try {
-      const newSessions = await listAuthoritativeSessions();
+      const newSessions = applyRecentTerminalSessionUpdates(await listAuthoritativeSessions());
       const nextCurrentSession = pickDefaultSessionKey(newSessions, currentSessionRef.current);
       
       // Smart diffing: preserve object references for unchanged sessions.
@@ -707,7 +743,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     } finally {
       setSessionsLoading(false);
     }
-  }, [connectionState, listAuthoritativeSessions, markSessionUnread, pingSession, setCurrentSession, setGranularStatus]);
+  }, [connectionState, listAuthoritativeSessions, markSessionUnread, pingSession, setCurrentSession, setGranularStatus, applyRecentTerminalSessionUpdates]);
 
   const refreshSessionsRef = useRef(refreshSessions);
   useEffect(() => {
@@ -716,6 +752,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
 
   // Update session in list from WebSocket event data
   const updateSessionFromEvent = useCallback((sessionKey: string, updates: Partial<Session>) => {
+    rememberSessionEventUpdate(sessionKey, updates);
     setSessions(prev => {
       const idx = prev.findIndex(s => getSessionKey(s) === sessionKey);
       if (idx === -1) {
@@ -742,7 +779,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         return { ...s, ...updates, lastActivity: Date.now() };
       });
     });
-  }, []);
+  }, [rememberSessionEventUpdate]);
 
   // Extract session updates (state + token data) from gateway payloads.
   const extractSessionUpdates = useCallback((state: string | undefined, payload: SessionSnapshotLike): Partial<Session> => {
@@ -837,8 +874,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
             markSessionUnread(sk);
             pingSession(sk);
           }
-          refreshSessions();
-          if (nextStatus === 'DONE') scheduleDelayedRefresh();
+          scheduleDelayedRefresh();
         }
 
         const updates = extractSessionUpdates(p.state || p.status, p);
@@ -872,7 +908,6 @@ export function SessionProvider({ children }: { children: ReactNode }) {
                 markSessionUnread(sk);
                 pingSession(sk);
               }
-              refreshSessions();
               scheduleDelayedRefresh();
             } else if (phase === 'error') {
               setGranularStatus(sk, { status: 'ERROR', since: Date.now() });
@@ -880,7 +915,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
                 markSessionUnread(sk);
                 pingSession(sk);
               }
-              refreshSessions();
+              scheduleDelayedRefresh();
             }
           } else if (stream === 'tool' && ap.data) {
             if (ap.data.phase === 'start' && ap.data.name) {
@@ -917,7 +952,6 @@ export function SessionProvider({ children }: { children: ReactNode }) {
               markSessionUnread(sk);
               pingSession(sk);
             }
-            refreshSessions();
             // Delayed refresh to catch token counts that may not be available immediately.
             scheduleDelayedRefresh();
           } else if (state === 'error') {
@@ -947,8 +981,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
               markSessionUnread(sk);
               pingSession(sk);
             }
-            refreshSessions();
-            if (nextStatus === 'DONE') scheduleDelayedRefresh();
+            scheduleDelayedRefresh();
           }
         }
 

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -745,16 +745,21 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   }, []);
 
   // Extract session updates (state + token data) from gateway payloads.
-  const extractSessionUpdates = useCallback((state: string | undefined, payload: Partial<EventPayload>): Partial<Session> => {
+  const extractSessionUpdates = useCallback((state: string | undefined, payload: SessionSnapshotLike): Partial<Session> => {
     const updates: Partial<Session> = {};
     const phase = lowerString(payload.phase);
     const stateValue = lowerString(state);
+    const explicitChildOnlyActive = payload.hasActiveSubagentRun === true
+      && payload.hasActiveRun !== true
+      && payload.busy !== true
+      && payload.processing !== true;
     const activeLegacyState = Boolean(stateValue)
       && BUSY_STATES.has(stateValue)
       && phase !== 'start'
       && phase !== 'end'
       && phase !== 'error'
-      && !snapshotHasExplicitInactiveRun(payload);
+      && !snapshotHasExplicitInactiveRun(payload)
+      && !explicitChildOnlyActive;
     if (state) updates.state = state;
     if (typeof payload.phase === 'string') updates.phase = payload.phase;
     if (typeof payload.status === 'string') updates.status = payload.status;

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -19,7 +19,7 @@ import {
   getRootAgentId,
 } from '@/features/sessions/sessionKeys';
 
-const BUSY_STATES = new Set(['running', 'thinking', 'processing', 'streaming', 'tool_use', 'executing', 'tool', 'delta', 'started', 'active']);
+const BUSY_STATES = new Set(['running', 'busy', 'thinking', 'processing', 'streaming', 'tool_use', 'executing', 'tool', 'delta', 'started', 'active']);
 const IDLE_STATES = new Set(['idle', 'done', 'error', 'failed', 'killed', 'final', 'aborted', 'completed', 'finished', 'ended', 'cancelled', 'timeout', 'stopped']);
 
 function lowerString(value: unknown): string {
@@ -38,12 +38,14 @@ function sessionSnapshotIsActive(session: SessionSnapshotLike): boolean {
 function sessionSnapshotIsTerminal(snapshot: SessionSnapshotLike): boolean {
   const phase = lowerString(snapshot.phase);
   if (phase === 'end' || phase === 'error') return true;
-  return [snapshot.state, snapshot.status].map(lowerString).some((state) => IDLE_STATES.has(state));
+  return [snapshot.state, snapshot.status, snapshot.agentState, snapshot.subagentRunState]
+    .map(lowerString)
+    .some((state) => IDLE_STATES.has(state));
 }
 
 function terminalAgentStatus(snapshot: SessionSnapshotLike): GranularAgentState['status'] {
   const phase = lowerString(snapshot.phase);
-  const state = lowerString(snapshot.status || snapshot.state);
+  const state = lowerString(snapshot.status || snapshot.state || snapshot.agentState || snapshot.subagentRunState);
   if (phase === 'error' || state === 'error' || state === 'failed' || state === 'timeout') return 'ERROR';
   if (state === 'idle' || state === 'aborted' || state === 'cancelled' || state === 'killed' || state === 'stopped') return 'IDLE';
   return 'DONE';
@@ -401,6 +403,10 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         delete doneTimeoutsRef.current[sessionKey];
       }, 3000);
     }
+    const currentRefState = agentStatusRef.current[sessionKey];
+    if (!currentRefState || currentRefState.status !== state.status || currentRefState.toolName !== state.toolName) {
+      agentStatusRef.current = { ...agentStatusRef.current, [sessionKey]: state };
+    }
     setAgentStatus(prev => {
       const existing = prev[sessionKey];
       // Optimization: skip update if status/tool haven't changed
@@ -611,6 +617,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
           const changed = (
             existing.state !== newSession.state ||
             existing.status !== newSession.status ||
+            existing.phase !== newSession.phase ||
             existing.agentState !== newSession.agentState ||
             existing.hasActiveRun !== newSession.hasActiveRun ||
             existing.hasActiveSubagentRun !== newSession.hasActiveSubagentRun ||

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/features/sessions/sessionKeys';
 
 const BUSY_STATES = new Set(['running', 'thinking', 'processing', 'streaming', 'tool_use', 'executing', 'tool', 'delta', 'started', 'active']);
-const IDLE_STATES = new Set(['idle', 'done', 'error', 'final', 'aborted', 'completed', 'finished', 'ended', 'cancelled', 'timeout', 'stopped']);
+const IDLE_STATES = new Set(['idle', 'done', 'error', 'failed', 'killed', 'final', 'aborted', 'completed', 'finished', 'ended', 'cancelled', 'timeout', 'stopped']);
 
 function lowerString(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -901,8 +901,10 @@ export function SessionProvider({ children }: { children: ReactNode }) {
           if (stream === 'lifecycle') {
             const phase = (ap.data as Record<string, unknown> | undefined)?.phase;
             if (phase === 'start') {
+              updateSessionFromEvent(sk, { phase: 'start', status: 'running', hasActiveRun: true });
               setGranularStatus(sk, { status: 'THINKING', since: Date.now() });
             } else if (phase === 'end') {
+              updateSessionFromEvent(sk, { phase: 'end', status: 'done', hasActiveRun: false });
               setGranularStatus(sk, { status: 'DONE', since: Date.now() });
               if (isTopLevelAgentSessionKey(sk)) {
                 markSessionUnread(sk);
@@ -910,6 +912,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
               }
               scheduleDelayedRefresh();
             } else if (phase === 'error') {
+              updateSessionFromEvent(sk, { phase: 'error', status: 'error', hasActiveRun: false });
               setGranularStatus(sk, { status: 'ERROR', since: Date.now() });
               if (isTopLevelAgentSessionKey(sk)) {
                 markSessionUnread(sk);

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -26,15 +26,27 @@ function lowerString(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
 
-function sessionSnapshotIsActive(session: Partial<Session>): boolean {
+type SessionSnapshotLike = Partial<Session & EventPayload>;
+
+function sessionSnapshotIsActive(session: SessionSnapshotLike): boolean {
   if (session.hasActiveRun || session.hasActiveSubagentRun || session.busy || session.processing) return true;
   return [session.state, session.status, session.agentState, session.subagentRunState]
     .map(lowerString)
     .some((state) => BUSY_STATES.has(state));
 }
 
-function sessionPayloadIsTerminal(payload: Partial<EventPayload>): boolean {
-  return [payload.state, payload.status].map(lowerString).some((state) => IDLE_STATES.has(state));
+function sessionSnapshotIsTerminal(snapshot: SessionSnapshotLike): boolean {
+  const phase = lowerString(snapshot.phase);
+  if (phase === 'end' || phase === 'error') return true;
+  return [snapshot.state, snapshot.status].map(lowerString).some((state) => IDLE_STATES.has(state));
+}
+
+function terminalAgentStatus(snapshot: SessionSnapshotLike): GranularAgentState['status'] {
+  const phase = lowerString(snapshot.phase);
+  const state = lowerString(snapshot.status || snapshot.state);
+  if (phase === 'error' || state === 'error' || state === 'failed' || state === 'timeout') return 'ERROR';
+  if (state === 'idle' || state === 'aborted' || state === 'cancelled' || state === 'killed' || state === 'stopped') return 'IDLE';
+  return 'DONE';
 }
 
 // Use the full session list for the sidebar so older root chats stay visible.
@@ -98,11 +110,11 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const doneTimeoutsRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
   const delayedRefreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Derive busyState from agentStatus for backward compatibility
+  // Derive busyState from active granular statuses for backward compatibility.
   const busyState = useMemo(() => {
     const result: Record<string, boolean> = {};
     for (const [key, state] of Object.entries(agentStatus)) {
-      result[key] = state.status !== 'IDLE' && state.status !== 'DONE';
+      result[key] = state.status === 'THINKING' || state.status === 'STREAMING';
     }
     return result;
   }, [agentStatus]);
@@ -191,6 +203,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     return () => controller.abort();
   }, []);
   const sessionsRef = useRef(sessions);
+  const agentStatusRef = useRef(agentStatus);
   
   // Update refs in effect to avoid render-time mutations
   useEffect(() => {
@@ -278,6 +291,10 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     sessionsRef.current = displaySessions;
   }, [displaySessions]);
+
+  useEffect(() => {
+    agentStatusRef.current = agentStatus;
+  }, [agentStatus]);
   
   const currentSessionRef = useRef(currentSession);
   useEffect(() => {
@@ -627,12 +644,28 @@ export function SessionProvider({ children }: { children: ReactNode }) {
 
       for (const session of newSessions) {
         const key = getSessionKey(session);
-        if (!key || !sessionSnapshotIsActive(session)) continue;
-        const stage = lowerString(session.state || session.status || session.agentState || session.subagentRunState);
-        setGranularStatus(key, {
-          status: stage === 'delta' || stage === 'streaming' ? 'STREAMING' : 'THINKING',
-          since: Date.now(),
-        });
+        if (!key) continue;
+        const terminal = sessionSnapshotIsTerminal(session);
+        if (!terminal && sessionSnapshotIsActive(session)) {
+          const stage = lowerString(session.state || session.status || session.agentState || session.subagentRunState);
+          setGranularStatus(key, {
+            status: stage === 'delta' || stage === 'streaming' ? 'STREAMING' : 'THINKING',
+            since: Date.now(),
+          });
+          continue;
+        }
+
+        if (terminal) {
+          const existingStatus = agentStatusRef.current[key]?.status;
+          if (existingStatus === 'THINKING' || existingStatus === 'STREAMING' || existingStatus === 'ERROR') {
+            const nextStatus = terminalAgentStatus(session);
+            setGranularStatus(key, { status: nextStatus, since: Date.now() });
+            if (isTopLevelAgentSessionKey(key) && existingStatus !== 'ERROR' && nextStatus !== 'IDLE') {
+              markSessionUnread(key);
+              pingSession(key);
+            }
+          }
+        }
       }
 
       setCurrentSession(nextCurrentSession);
@@ -641,7 +674,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     } finally {
       setSessionsLoading(false);
     }
-  }, [connectionState, listAuthoritativeSessions, setCurrentSession, setGranularStatus]);
+  }, [connectionState, listAuthoritativeSessions, markSessionUnread, pingSession, setCurrentSession, setGranularStatus]);
 
   const refreshSessionsRef = useRef(refreshSessions);
   useEffect(() => {
@@ -696,7 +729,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     const phase = lowerString(payload.phase);
     if (phase === 'start') updates.hasActiveRun = true;
     if (phase === 'end' || phase === 'error') updates.hasActiveRun = false;
-    if (sessionPayloadIsTerminal(payload)) updates.hasActiveRun = false;
+    if (sessionSnapshotIsTerminal(payload)) updates.hasActiveRun = false;
 
     return updates;
   }, []);
@@ -736,27 +769,22 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         const phase = lowerString(p.phase);
         const state = lowerString(p.state || p.status);
 
-        if (phase === 'start' || sessionSnapshotIsActive(p)) {
+        const terminal = sessionSnapshotIsTerminal(p);
+        if (!terminal && (phase === 'start' || sessionSnapshotIsActive(p))) {
           setGranularStatus(sk, {
             status: state === 'delta' || state === 'streaming' ? 'STREAMING' : 'THINKING',
             since: Date.now(),
           });
           if (isTopLevelAgentSessionKey(sk)) markSessionUnread(sk);
-        } else if (phase === 'end' || state === 'done' || state === 'final' || state === 'completed') {
-          setGranularStatus(sk, { status: 'DONE', since: Date.now() });
-          if (isTopLevelAgentSessionKey(sk)) {
+        } else if (terminal) {
+          const nextStatus = terminalAgentStatus(p);
+          setGranularStatus(sk, { status: nextStatus, since: Date.now() });
+          if (isTopLevelAgentSessionKey(sk) && nextStatus !== 'IDLE') {
             markSessionUnread(sk);
             pingSession(sk);
           }
           refreshSessions();
-          scheduleDelayedRefresh();
-        } else if (phase === 'error' || state === 'error') {
-          setGranularStatus(sk, { status: 'ERROR', since: Date.now() });
-          if (isTopLevelAgentSessionKey(sk)) {
-            markSessionUnread(sk);
-            pingSession(sk);
-          }
-          refreshSessions();
+          if (nextStatus === 'DONE') scheduleDelayedRefresh();
         }
 
         const updates = extractSessionUpdates(p.state || p.status, p);

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -748,6 +748,13 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const extractSessionUpdates = useCallback((state: string | undefined, payload: Partial<EventPayload>): Partial<Session> => {
     const updates: Partial<Session> = {};
     const phase = lowerString(payload.phase);
+    const stateValue = lowerString(state);
+    const activeLegacyState = Boolean(stateValue)
+      && BUSY_STATES.has(stateValue)
+      && phase !== 'start'
+      && phase !== 'end'
+      && phase !== 'error'
+      && !snapshotHasExplicitInactiveRun(payload);
     if (state) updates.state = state;
     if (typeof payload.phase === 'string') updates.phase = payload.phase;
     if (typeof payload.status === 'string') updates.status = payload.status;
@@ -761,10 +768,12 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     if ('totalTokens' in payload && typeof payload.totalTokens === 'number') updates.totalTokens = payload.totalTokens;
     if ('contextTokens' in payload && typeof payload.contextTokens === 'number') updates.contextTokens = payload.contextTokens;
 
-    if (phase === 'start') {
+    if (phase === 'start' || activeLegacyState) {
       updates.hasActiveRun = true;
-      // A lifecycle start may be phase-only. Clear stale terminal strings so
-      // cached snapshots don't look ended until the next full refresh arrives.
+      // A lifecycle start may be phase-only, and legacy chat/agent starts may
+      // arrive after a terminal phase-only snapshot. Clear stale terminal
+      // strings/flags so cached snapshots don't look ended until refresh.
+      if (activeLegacyState && typeof payload.phase !== 'string') updates.phase = undefined;
       if (!state) updates.state = 'running';
       if (typeof payload.status !== 'string') updates.status = 'running';
     }

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -42,39 +42,45 @@ function snapshotHasExplicitInactiveRun(snapshot: SessionSnapshotLike): boolean 
     || snapshot.processing === false;
 }
 
+function ownSnapshotStates(snapshot: SessionSnapshotLike): string[] {
+  return [snapshot.state, snapshot.status, snapshot.agentState].map(lowerString);
+}
+
 function sessionSnapshotIsActive(session: SessionSnapshotLike): boolean {
   const phase = lowerString(session.phase);
   if (phase === 'end' || phase === 'error') return false;
   if (snapshotHasExplicitActiveRun(session)) return true;
-  if (snapshotHasExplicitInactiveRun(session)) return false;
   if (phase === 'start') return true;
-  return [session.state, session.status, session.agentState, session.subagentRunState]
-    .map(lowerString)
+  if (snapshotHasExplicitInactiveRun(session)) return false;
+  return [...ownSnapshotStates(session), lowerString(session.subagentRunState)]
     .some((state) => BUSY_STATES.has(state));
 }
 
 function sessionSnapshotIsTerminal(snapshot: SessionSnapshotLike): boolean {
   const phase = lowerString(snapshot.phase);
   if (phase === 'end' || phase === 'error') return true;
+  if (phase === 'start') return false;
   if (snapshotHasExplicitActiveRun(snapshot)) return false;
   if (snapshotHasExplicitInactiveRun(snapshot)) return true;
-  return [snapshot.state, snapshot.status, snapshot.agentState, snapshot.subagentRunState]
-    .map(lowerString)
-    .some((state) => IDLE_STATES.has(state));
+
+  const ownStates = ownSnapshotStates(snapshot);
+  if (ownStates.some((state) => IDLE_STATES.has(state))) return true;
+  if (ownStates.some((state) => BUSY_STATES.has(state))) return false;
+  return IDLE_STATES.has(lowerString(snapshot.subagentRunState));
 }
 
 function terminalAgentStatus(snapshot: SessionSnapshotLike): GranularAgentState['status'] {
   const phase = lowerString(snapshot.phase);
-  const states = [
-    snapshot.status,
-    snapshot.state,
-    snapshot.agentState,
-    snapshot.subagentRunState,
-  ].map(lowerString);
-  if (phase === 'error' || states.some((state) => state === 'error' || state === 'failed' || state === 'timeout')) return 'ERROR';
-  if (states.some((state) => state === 'idle' || state === 'aborted' || state === 'cancelled' || state === 'killed' || state === 'stopped')) return 'IDLE';
-  if (states.some((state) => state === 'done' || state === 'final' || state === 'completed' || state === 'finished' || state === 'ended')) return 'DONE';
+  const ownStates = ownSnapshotStates(snapshot);
+  if (phase === 'error' || ownStates.some((state) => state === 'error' || state === 'failed' || state === 'timeout')) return 'ERROR';
+  if (ownStates.some((state) => state === 'idle' || state === 'aborted' || state === 'cancelled' || state === 'killed' || state === 'stopped')) return 'IDLE';
+  if (ownStates.some((state) => state === 'done' || state === 'final' || state === 'completed' || state === 'finished' || state === 'ended')) return 'DONE';
   if (snapshotHasExplicitInactiveRun(snapshot)) return 'IDLE';
+
+  const childState = lowerString(snapshot.subagentRunState);
+  if (childState === 'error' || childState === 'failed' || childState === 'timeout') return 'ERROR';
+  if (childState === 'idle' || childState === 'aborted' || childState === 'cancelled' || childState === 'killed' || childState === 'stopped') return 'IDLE';
+  if (childState === 'done' || childState === 'final' || childState === 'completed' || childState === 'finished' || childState === 'ended') return 'DONE';
   return 'DONE';
 }
 
@@ -681,6 +687,8 @@ export function SessionProvider({ children }: { children: ReactNode }) {
             existing.status !== newSession.status ||
             existing.phase !== newSession.phase ||
             existing.agentState !== newSession.agentState ||
+            existing.busy !== newSession.busy ||
+            existing.processing !== newSession.processing ||
             existing.hasActiveRun !== newSession.hasActiveRun ||
             existing.hasActiveSubagentRun !== newSession.hasActiveSubagentRun ||
             existing.subagentRunState !== newSession.subagentRunState ||
@@ -801,6 +809,8 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     if (typeof payload.phase === 'string') updates.phase = payload.phase;
     if (typeof payload.status === 'string') updates.status = payload.status;
     if (typeof payload.agentState === 'string') updates.agentState = payload.agentState;
+    if (typeof payload.busy === 'boolean') updates.busy = payload.busy;
+    if (typeof payload.processing === 'boolean') updates.processing = payload.processing;
     if (typeof payload.hasActiveRun === 'boolean') updates.hasActiveRun = payload.hasActiveRun;
     if (typeof payload.hasActiveSubagentRun === 'boolean') updates.hasActiveSubagentRun = payload.hasActiveSubagentRun;
     if (typeof payload.subagentRunState === 'string') updates.subagentRunState = payload.subagentRunState;
@@ -816,11 +826,15 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       // arrive after a terminal phase-only snapshot. Clear stale terminal
       // strings/flags so cached snapshots don't look ended until refresh.
       if (activeLegacyState && typeof payload.phase !== 'string') updates.phase = undefined;
-      if (!state) updates.state = 'running';
-      if (typeof payload.status !== 'string') updates.status = 'running';
+      if (!state || IDLE_STATES.has(stateValue)) updates.state = 'running';
+      if (typeof payload.status !== 'string' || IDLE_STATES.has(lowerString(payload.status))) updates.status = 'running';
+      if (payload.busy !== true) updates.busy = undefined;
+      if (payload.processing !== true) updates.processing = undefined;
+    } else if (phase === 'end' || phase === 'error') {
+      updates.hasActiveRun = false;
+    } else if (sessionSnapshotIsTerminal(payload)) {
+      updates.hasActiveRun = false;
     }
-    if (phase === 'end' || phase === 'error') updates.hasActiveRun = false;
-    if (sessionSnapshotIsTerminal(payload)) updates.hasActiveRun = false;
 
     return updates;
   }, []);

--- a/src/features/chat/operations/streamEventHandler.test.ts
+++ b/src/features/chat/operations/streamEventHandler.test.ts
@@ -90,6 +90,21 @@ describe('classifyStreamEvent', () => {
       expect(classifyStreamEvent(event)?.type).toBe('agent_tool_result');
     });
 
+    it('normalizes subscribed session.tool events as agent tool events', () => {
+      const event: GatewayEvent = {
+        type: 'event', event: 'session.tool',
+        payload: {
+          sessionKey: 'main',
+          stream: 'tool',
+          data: { phase: 'start', name: 'read', toolCallId: 'tc-1' },
+        },
+      };
+      const result = classifyStreamEvent(event);
+      expect(result?.source).toBe('agent');
+      expect(result?.sessionKey).toBe('main');
+      expect(result?.type).toBe('agent_tool_start');
+    });
+
     it('ignores tool events without required fields', () => {
       const event: GatewayEvent = {
         type: 'event', event: 'agent',

--- a/src/features/chat/operations/streamEventHandler.test.ts
+++ b/src/features/chat/operations/streamEventHandler.test.ts
@@ -105,6 +105,20 @@ describe('classifyStreamEvent', () => {
       expect(result?.type).toBe('agent_tool_start');
     });
 
+    it('defaults subscribed session.tool events without stream to tool events', () => {
+      const event: GatewayEvent = {
+        type: 'event', event: 'session.tool',
+        payload: {
+          sessionKey: 'main',
+          data: { phase: 'start', name: 'read', toolCallId: 'tc-1' },
+        },
+      };
+      const result = classifyStreamEvent(event);
+      expect(result?.source).toBe('agent');
+      expect(result?.sessionKey).toBe('main');
+      expect(result?.type).toBe('agent_tool_start');
+    });
+
     it('ignores tool events without required fields', () => {
       const event: GatewayEvent = {
         type: 'event', event: 'agent',

--- a/src/features/chat/operations/streamEventHandler.ts
+++ b/src/features/chat/operations/streamEventHandler.ts
@@ -44,7 +44,7 @@ export type StreamEventType =
 
 export interface ClassifiedEvent {
   type: StreamEventType;
-  /** Original gateway event type ('agent' | 'chat') */
+  /** Original gateway event type ('agent' | 'chat'); session.tool is normalized as agent. */
   source: 'agent' | 'chat';
   /** Session key from the payload */
   sessionKey?: string;
@@ -67,7 +67,7 @@ export interface ClassifiedEvent {
 export function classifyStreamEvent(event: GatewayEvent): ClassifiedEvent | null {
   const evt = event.event;
 
-  if (evt === 'agent') {
+  if (evt === 'agent' || evt === 'session.tool') {
     const ap = (event.payload || {}) as AgentEventPayload;
     const runId = typeof (ap as { runId?: unknown }).runId === 'string'
       ? (ap as { runId: string }).runId

--- a/src/features/chat/operations/streamEventHandler.ts
+++ b/src/features/chat/operations/streamEventHandler.ts
@@ -84,9 +84,10 @@ export function classifyStreamEvent(event: GatewayEvent): ClassifiedEvent | null
       frameSeq: event.seq,
       agentPayload: ap,
     };
+    const stream = evt === 'session.tool' ? (ap.stream || 'tool') : ap.stream;
 
     // Lifecycle events from CLI agents (Codex, Claude Code CLI)
-    if (ap.stream === 'lifecycle') {
+    if (stream === 'lifecycle') {
       const phase = (ap.data as Record<string, unknown> | undefined)?.phase;
       if (phase === 'start') return { ...base, type: 'lifecycle_start' };
       if (phase === 'end' || phase === 'error') return { ...base, type: 'lifecycle_end' };
@@ -94,12 +95,12 @@ export function classifyStreamEvent(event: GatewayEvent): ClassifiedEvent | null
     }
 
     // Assistant stream events from CLI agents
-    if (ap.stream === 'assistant') {
+    if (stream === 'assistant') {
       return { ...base, type: 'assistant_stream' };
     }
 
     // Real-time tool event streaming
-    if (ap.stream === 'tool') {
+    if (stream === 'tool') {
       const data = ap.data;
       if (!data) return { ...base, type: 'ignore' };
       if (data.phase === 'start' && data.name && data.toolCallId) {

--- a/src/features/sessions/SessionList.test.tsx
+++ b/src/features/sessions/SessionList.test.tsx
@@ -32,6 +32,26 @@ describe('SessionList active state detection', () => {
 
     expect(screen.queryByTitle('Abort session')).not.toBeInTheDocument();
   });
+
+  it('does not expose abort when explicit inactive run flags contradict stale running status', () => {
+    const sessions: Session[] = [
+      { sessionKey: 'agent:reviewer:main', label: 'Reviewer', hasActiveRun: false, status: 'running' },
+    ];
+
+    renderSessionList({ sessions, onAbort: vi.fn() });
+
+    expect(screen.queryByTitle('Abort session')).not.toBeInTheDocument();
+  });
+
+  it('does not let an inactive child-run flag suppress a running root session', () => {
+    const sessions: Session[] = [
+      { sessionKey: 'agent:reviewer:main', label: 'Reviewer', hasActiveSubagentRun: false, status: 'running' },
+    ];
+
+    renderSessionList({ sessions, onAbort: vi.fn() });
+
+    expect(screen.getByTitle('Abort session')).toBeInTheDocument();
+  });
 });
 
 describe('SessionList empty state', () => {

--- a/src/features/sessions/SessionList.test.tsx
+++ b/src/features/sessions/SessionList.test.tsx
@@ -52,6 +52,16 @@ describe('SessionList active state detection', () => {
 
     expect(screen.getByTitle('Abort session')).toBeInTheDocument();
   });
+
+  it('exposes abort when live busy state overrides a stale terminal snapshot', () => {
+    const sessions: Session[] = [
+      { sessionKey: 'agent:reviewer:main', label: 'Reviewer', phase: 'end', status: 'done' },
+    ];
+
+    renderSessionList({ sessions, busyState: { 'agent:reviewer:main': true }, onAbort: vi.fn() });
+
+    expect(screen.getByTitle('Abort session')).toBeInTheDocument();
+  });
 });
 
 describe('SessionList empty state', () => {

--- a/src/features/sessions/SessionList.test.tsx
+++ b/src/features/sessions/SessionList.test.tsx
@@ -22,6 +22,18 @@ function renderSessionList(props: Partial<React.ComponentProps<typeof SessionLis
   );
 }
 
+describe('SessionList active state detection', () => {
+  it('does not expose abort for terminal phase snapshots with stale running status', () => {
+    const sessions: Session[] = [
+      { sessionKey: 'agent:reviewer:main', label: 'Reviewer', phase: 'end', status: 'running' },
+    ];
+
+    renderSessionList({ sessions, onAbort: vi.fn() });
+
+    expect(screen.queryByTitle('Abort session')).not.toBeInTheDocument();
+  });
+});
+
 describe('SessionList empty state', () => {
   it('shows the empty state when all sessions are filtered out of the agent sidebar', () => {
     const sessions: Session[] = [

--- a/src/features/sessions/SessionList.tsx
+++ b/src/features/sessions/SessionList.tsx
@@ -59,17 +59,35 @@ function lowerString(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
 
+function sessionHasExplicitActiveRun(session: Session): boolean {
+  return session.hasActiveRun === true
+    || session.hasActiveSubagentRun === true
+    || session.busy === true
+    || session.processing === true;
+}
+
+function sessionHasExplicitInactiveRun(session: Session): boolean {
+  return session.hasActiveRun === false
+    || session.busy === false
+    || session.processing === false;
+}
+
 function sessionLooksTerminal(session: Session): boolean {
   const phase = lowerString(session.phase);
   if (phase === 'end' || phase === 'error') return true;
+  if (sessionHasExplicitActiveRun(session)) return false;
+  if (sessionHasExplicitInactiveRun(session)) return true;
   return [session.state, session.status, session.agentState, session.subagentRunState]
     .map(lowerString)
     .some((state) => TERMINAL_SESSION_STATES.has(state));
 }
 
 function sessionLooksActive(session: Session): boolean {
+  const phase = lowerString(session.phase);
+  if (phase === 'end' || phase === 'error') return false;
+  if (sessionHasExplicitActiveRun(session)) return true;
+  if (sessionHasExplicitInactiveRun(session)) return false;
   if (sessionLooksTerminal(session)) return false;
-  if (session.hasActiveRun || session.hasActiveSubagentRun || session.busy || session.processing) return true;
   return [session.state, session.status, session.agentState, session.subagentRunState]
     .map(lowerString)
     .some((state) => ACTIVE_SESSION_STATES.has(state));

--- a/src/features/sessions/SessionList.tsx
+++ b/src/features/sessions/SessionList.tsx
@@ -52,6 +52,29 @@ function findNodeByKey(nodes: ReturnType<typeof buildSessionTree>, key: string):
 }
 
 /** Sidebar list of agent sessions with tree structure and context menus. */
+const ACTIVE_SESSION_STATES = new Set(['running', 'busy', 'thinking', 'processing', 'streaming', 'tool_use', 'executing', 'tool', 'delta', 'started', 'active']);
+const TERMINAL_SESSION_STATES = new Set(['idle', 'done', 'error', 'failed', 'killed', 'final', 'aborted', 'completed', 'finished', 'ended', 'cancelled', 'timeout', 'stopped']);
+
+function lowerString(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function sessionLooksTerminal(session: Session): boolean {
+  const phase = lowerString(session.phase);
+  if (phase === 'end' || phase === 'error') return true;
+  return [session.state, session.status, session.agentState, session.subagentRunState]
+    .map(lowerString)
+    .some((state) => TERMINAL_SESSION_STATES.has(state));
+}
+
+function sessionLooksActive(session: Session): boolean {
+  if (sessionLooksTerminal(session)) return false;
+  if (session.hasActiveRun || session.hasActiveSubagentRun || session.busy || session.processing) return true;
+  return [session.state, session.status, session.agentState, session.subagentRunState]
+    .map(lowerString)
+    .some((state) => ACTIVE_SESSION_STATES.has(state));
+}
+
 export function SessionList({ sessions, currentSession, busyState, agentStatus, unreadSessions, onSelect, onRefresh, onDelete, onSpawn, onRename, onAbort, isLoading, agentName = 'Agent', compact = false }: SessionListProps) {
   const [deleteTarget, setDeleteTarget] = useState<{ key: string; label: string; descendantCount: number; isRootAgent: boolean } | null>(null);
   const [deleting, setDeleting] = useState(false);
@@ -190,7 +213,7 @@ export function SessionList({ sessions, currentSession, busyState, agentStatus, 
           const isRootAgent = isTopLevelAgentSessionKey(sessionKey);
           const label = getSessionDisplayLabel(node.session, agentName);
           const isGrowing = growingSessions[sessionKey] ?? false;
-          const running = busyState[sessionKey] || node.session.state === 'running' || node.session.agentState === 'running' || node.session.busy || node.session.processing || node.session.status === 'running' || node.session.status === 'busy' || (isGrowing && isSubagent);
+          const running = !sessionLooksTerminal(node.session) && (busyState[sessionKey] || sessionLooksActive(node.session) || (isGrowing && isSubagent));
           const isActive = sessionKey === currentSession;
           const currentTokens = node.session.totalTokens || 0;
           const prevTokens = prevTokensRef.current[sessionKey] || 0;

--- a/src/features/sessions/SessionList.tsx
+++ b/src/features/sessions/SessionList.tsx
@@ -231,7 +231,7 @@ export function SessionList({ sessions, currentSession, busyState, agentStatus, 
           const isRootAgent = isTopLevelAgentSessionKey(sessionKey);
           const label = getSessionDisplayLabel(node.session, agentName);
           const isGrowing = growingSessions[sessionKey] ?? false;
-          const running = !sessionLooksTerminal(node.session) && (busyState[sessionKey] || sessionLooksActive(node.session) || (isGrowing && isSubagent));
+          const running = busyState[sessionKey] || (!sessionLooksTerminal(node.session) && (sessionLooksActive(node.session) || (isGrowing && isSubagent)));
           const isActive = sessionKey === currentSession;
           const currentTokens = node.session.totalTokens || 0;
           const prevTokens = prevTokensRef.current[sessionKey] || 0;

--- a/src/features/sessions/SessionList.tsx
+++ b/src/features/sessions/SessionList.tsx
@@ -72,24 +72,31 @@ function sessionHasExplicitInactiveRun(session: Session): boolean {
     || session.processing === false;
 }
 
+function ownSessionStates(session: Session): string[] {
+  return [session.state, session.status, session.agentState].map(lowerString);
+}
+
 function sessionLooksTerminal(session: Session): boolean {
   const phase = lowerString(session.phase);
   if (phase === 'end' || phase === 'error') return true;
+  if (phase === 'start') return false;
   if (sessionHasExplicitActiveRun(session)) return false;
   if (sessionHasExplicitInactiveRun(session)) return true;
-  return [session.state, session.status, session.agentState, session.subagentRunState]
-    .map(lowerString)
-    .some((state) => TERMINAL_SESSION_STATES.has(state));
+
+  const ownStates = ownSessionStates(session);
+  if (ownStates.some((state) => TERMINAL_SESSION_STATES.has(state))) return true;
+  if (ownStates.some((state) => ACTIVE_SESSION_STATES.has(state))) return false;
+  return TERMINAL_SESSION_STATES.has(lowerString(session.subagentRunState));
 }
 
 function sessionLooksActive(session: Session): boolean {
   const phase = lowerString(session.phase);
   if (phase === 'end' || phase === 'error') return false;
   if (sessionHasExplicitActiveRun(session)) return true;
+  if (phase === 'start') return true;
   if (sessionHasExplicitInactiveRun(session)) return false;
   if (sessionLooksTerminal(session)) return false;
-  return [session.state, session.status, session.agentState, session.subagentRunState]
-    .map(lowerString)
+  return [...ownSessionStates(session), lowerString(session.subagentRunState)]
     .some((state) => ACTIVE_SESSION_STATES.has(state));
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,15 @@ export interface Session {
   agentState?: string;
   busy?: boolean;
   processing?: boolean;
+  /** True when the gateway knows this session currently owns an active run. */
+  hasActiveRun?: boolean;
+  /** True when the gateway knows a child/subagent run is active for this session. */
+  hasActiveSubagentRun?: boolean;
+  subagentRunState?: string;
   status?: string;
+  startedAt?: number;
+  endedAt?: number;
+  runtimeMs?: number;
   lastActivity?: string | number;
   updatedAt?: number;
   abortedLastRun?: boolean;
@@ -181,6 +189,8 @@ export type GatewayMessage = GatewayEvent | GatewayRequest | GatewayResponse;
 export interface EventPayload {
   sessionKey?: string;
   state?: string;
+  status?: string;
+  phase?: string;
   agentState?: string;
   runId?: string;
   seq?: number;
@@ -191,6 +201,15 @@ export interface EventPayload {
   error?: string;
   errorMessage?: string;
   stopReason?: string;
+  hasActiveRun?: boolean;
+  hasActiveSubagentRun?: boolean;
+  subagentRunState?: string;
+  updatedAt?: number;
+  startedAt?: number;
+  endedAt?: number;
+  runtimeMs?: number;
+  totalTokens?: number;
+  contextTokens?: number;
 }
 
 // ─── Typed event payloads ────────────────────────────────────────────
@@ -199,6 +218,8 @@ export interface EventPayload {
 export interface ChatEventPayload {
   sessionKey?: string;
   state?: string;
+  status?: string;
+  phase?: string;
   runId?: string;
   seq?: number;
   message?: ChatMessage | string;
@@ -207,12 +228,19 @@ export interface ChatEventPayload {
   error?: string;
   errorMessage?: string;
   stopReason?: string;
+  hasActiveRun?: boolean;
+  updatedAt?: number;
+  startedAt?: number;
+  endedAt?: number;
+  runtimeMs?: number;
 }
 
 /** Payload for 'agent' events (state changes + tool streaming) */
 export interface AgentEventPayload {
   sessionKey?: string;
   state?: string;
+  status?: string;
+  phase?: string;
   agentState?: string;
   /** Present when stream === 'tool' */
   stream?: string;
@@ -220,6 +248,11 @@ export interface AgentEventPayload {
   data?: AgentToolStreamData;
   totalTokens?: number;
   contextTokens?: number;
+  hasActiveRun?: boolean;
+  updatedAt?: number;
+  startedAt?: number;
+  endedAt?: number;
+  runtimeMs?: number;
 }
 
 /** Data within an agent tool-stream event */

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface Session {
   hasActiveSubagentRun?: boolean;
   subagentRunState?: string;
   status?: string;
+  phase?: string;
   startedAt?: number;
   endedAt?: number;
   runtimeMs?: number;


### PR DESCRIPTION
## Summary
- Hydrate active chat UI from gateway session snapshots/events after a page refresh
- Subscribe to session lifecycle/message broadcasts for the visible session
- Track active/terminal session metadata in session lists and normalize `session.tool` events
- Add regression coverage for active refresh hydration and subscriptions

## Validation
- `npx vitest run src/features/chat/operations/streamEventHandler.test.ts src/contexts/ChatContext.subscription.test.tsx src/contexts/SessionContext.test.tsx`
- `npm run lint`
- `npm test -- --run`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More accurate active vs. terminal session detection so UI shows correct running/abort controls, auto-hydrates or finalizes active runs on reconnect/refresh, and subscribes to live messages for the currently viewed session.
  * Finer-grained generation status (thinking/streaming/busy) for clearer activity indicators and timely pings.
  * Tool-origin events normalized as agent-sourced for consistent behavior.

* **Tests**
  * Expanded coverage for subscriptions, message lifecycle, hydration/clearance logic, reviewer status mapping, and event classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->