### PR TITLE
fix(readme): add next branch install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ curl -fsSL https://raw.githubusercontent.com/daggerhashimoto/openclaw-nerve/mast
 Switch an existing install to `next`:
 
 ```bash
-cd ~/nerve
+cd ~/nerve # installer default; manual clone: cd openclaw-nerve
 git fetch origin
 git switch next || git switch -c next --track origin/next
 git pull --ff-only
@@ -133,8 +133,9 @@ npm run prod
 Keep `next` updated:
 
 ```bash
-cd ~/nerve
+cd ~/nerve # installer default; manual clone: cd openclaw-nerve
 git fetch origin
+git switch next || git switch -c next --track origin/next
 git pull --ff-only
 npm install
 npm run build

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ curl -fsSL https://raw.githubusercontent.com/daggerhashimoto/openclaw-nerve/mast
 
 <details><summary><strong>Try the next branch</strong></summary>
 
-`master` is the stable branch. Use `next` if you want the latest Nerve work before it lands in `master`, including newer chat runtime behavior, live tool/thinking bubble rendering, attachment handling, voice/TTS improvements, and other features still being validated.
+`master` is the stable branch. Use `next` if you want the latest Nerve work before it lands in `master`.
 
 Fresh install from `next`:
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,43 @@ curl -fsSL https://raw.githubusercontent.com/daggerhashimoto/openclaw-nerve/mast
 - **[Hybrid](docs/DEPLOYMENT-B.md)** — Keep Nerve local, run Gateway in the cloud
 - **[Cloud](docs/DEPLOYMENT-C.md)** — Run Nerve and Gateway in the cloud
 
+<details><summary><strong>Try the next branch</strong></summary>
+
+`master` is the stable branch. Use `next` if you want the latest Nerve work before it lands in `master`, including newer chat runtime behavior, live tool/thinking bubble rendering, attachment handling, voice/TTS improvements, and other features still being validated.
+
+Fresh install from `next`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/daggerhashimoto/openclaw-nerve/master/install.sh | bash -s -- --branch next
+```
+
+Switch an existing install to `next`:
+
+```bash
+cd ~/nerve
+git fetch origin
+git switch next || git switch -c next --track origin/next
+git pull --ff-only
+npm install
+npm run build
+npm run prod
+```
+
+Keep `next` updated:
+
+```bash
+cd ~/nerve
+git fetch origin
+git pull --ff-only
+npm install
+npm run build
+npm run prod
+```
+
+`next` can change quickly. Use it if you are comfortable testing early builds.
+
+</details>
+
 <details><summary><strong>Manual install</strong></summary>
 
 ```bash


### PR DESCRIPTION
## Summary
- Add a collapsed README section for trying the `next` branch.
- Include fresh install, existing install, and update commands.

## Validation
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a collapsible "Try the next branch" section explaining stable vs. next and recommended use.
  * Includes step-by-step commands for installing from next, switching an existing install to next, and keeping next updated.
  * Inserted the new section before the existing manual install guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daggerhashimoto/openclaw-nerve/pull/332)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->