### PR TITLE
perf(chat): window runtime timeline projection

### DIFF
--- a/src/features/chat/runtime/projection.test.ts
+++ b/src/features/chat/runtime/projection.test.ts
@@ -317,6 +317,53 @@ describe('chat runtime projection', () => {
     });
     expect(projection.messages[0].html).not.toContain('[tts:');
   });
+
+  it.each([500, 2_000, 10_000])(
+    'projects only the visible tail for a %i-turn timeline while preserving total count',
+    (turnCount) => {
+      const timeline = makeLargeTimeline('session-scale', turnCount);
+
+      const projection = projectTimeline(timeline, { visibleCount: 50 });
+
+      expect(projection.totalMessages).toBe(turnCount * 2);
+      expect(projection.messages).toHaveLength(50);
+      expect(projection.messages[0]).toMatchObject({
+        msgId: `user-${turnCount - 25}`,
+        rawText: `prompt ${turnCount - 25}`,
+      });
+      expect(projection.messages.at(-1)).toMatchObject({
+        msgId: `assistant-${turnCount - 1}`,
+        rawText: `answer ${turnCount - 1}`,
+      });
+      expect(projection.isGenerating).toBe(false);
+    },
+  );
+
+  it('keeps grouped tools and intermediate tagging intact when projecting a visible window', () => {
+    const firstTurn = makeTurn('session-1', 'run-1', 0, 'finalized');
+    const liveTurn = makeTurn('session-1', 'run-2', 1, 'running');
+    const timeline = makeTimeline('session-1', [firstTurn, liveTurn], {
+      'user-old': userItem(firstTurn, 'user-old', 'old prompt', 0),
+      'assistant-old': assistantItem(firstTurn, 'assistant-old', 'old answer', 1, false),
+      'user-live': userItem(liveTurn, 'user-live', 'inspect please', 10),
+      'assistant-plan': assistantItem(liveTurn, 'assistant-plan', 'I will inspect.', 11, false),
+      'tool-read': toolItem(liveTurn, 'tool-read', 'read', { path: '/tmp/a' }, 12, 'complete'),
+      'tool-exec': toolItem(liveTurn, 'tool-exec', 'exec', { command: 'pwd' }, 13, 'complete'),
+      'assistant-final': assistantItem(liveTurn, 'assistant-final', 'Done.', 100, true),
+    });
+
+    const projection = projectTimeline(timeline, { visibleCount: 3 });
+
+    expect(projection.totalMessages).toBe(6);
+    expect(projection.messages.map((message) => message.msgId)).toEqual([
+      'assistant-plan',
+      'tool-group:tool-read:tool-exec',
+      'assistant-final',
+    ]);
+    expect(projection.messages[0]).toMatchObject({ intermediate: true });
+    expect(projection.messages[1].toolGroup).toHaveLength(2);
+    expect(projection.processingStage).toBe('streaming');
+  });
 });
 
 function makeTimeline(
@@ -462,4 +509,18 @@ function assistantItem(
     status: isStreaming ? 'running' : 'complete',
     source: isStreaming ? 'live' : 'history',
   };
+}
+
+function makeLargeTimeline(sessionKey: string, turnCount: number): SessionTimeline {
+  const turns: TimelineTurn[] = [];
+  const items: Record<string, TimelineItem> = {};
+
+  for (let index = 0; index < turnCount; index++) {
+    const turn = makeTurn(sessionKey, `run-${index}`, index, 'finalized');
+    turns.push(turn);
+    items[`user-${index}`] = userItem(turn, `user-${index}`, `prompt ${index}`, 0);
+    items[`assistant-${index}`] = assistantItem(turn, `assistant-${index}`, `answer ${index}`, 1, false);
+  }
+
+  return makeTimeline(sessionKey, turns, items);
 }

--- a/src/features/chat/runtime/projection.ts
+++ b/src/features/chat/runtime/projection.ts
@@ -1,5 +1,5 @@
 import type { ChatMessage } from '@/types';
-import { splitToolCallMessage, tagIntermediateMessages } from '@/features/chat/operations';
+import { splitToolCallMessage } from '@/features/chat/operations';
 import type { ChatMsg, ToolGroupEntry } from '@/features/chat/types';
 import { extractTTSMarkers } from '@/features/tts/useTTS';
 import { describeToolUse, renderMarkdown, renderToolResults } from '@/utils/helpers';
@@ -14,22 +14,21 @@ import type {
   ToolResultTimelineItem,
   UserTimelineItem,
 } from './types';
-import { orderedTimelineItems } from './reducer';
+import { orderedTimelineItems, timelineItemsByTurnId } from './reducer';
 
 export function projectTimeline(
   timeline: SessionTimeline,
   options: TimelineProjectionOptions = {},
 ): TimelineProjection {
   const orderedItems = orderedTimelineItems(timeline);
+  const itemsByTurnId = timelineItemsByTurnId(timeline);
   const activeTurnIds = new Set(
     timeline.turns
-      .filter((turn) => isActiveTurn(turn, orderedItems, options.failedIdempotencyKeys))
+      .filter((turn) => isActiveTurn(turn, itemsByTurnId[turn.id] ?? [], options.failedIdempotencyKeys))
       .map((turn) => turn.id),
   );
   const projectionContext = { ...options, activeTurnIds };
-  const messages = tagIntermediateMessages(groupConsecutiveToolCalls(
-    orderedItems.flatMap((item) => projectItem(item, projectionContext)),
-  ));
+  const { messages, totalMessages } = projectMessages(orderedItems, projectionContext, options.visibleCount);
   const runningTool = findLastRunningTool(orderedItems, activeTurnIds);
   const streamingAssistant = orderedItems.some((item) =>
     (item.kind === 'assistant_message' || item.kind === 'assistant_segment') &&
@@ -43,6 +42,7 @@ export function projectTimeline(
 
   return {
     messages,
+    totalMessages,
     isGenerating,
     processingStage: runningTool
       ? 'tool_use'
@@ -82,6 +82,68 @@ function projectItem(
     case 'system_event':
       return projectSystemItem(item);
   }
+}
+
+function projectMessages(
+  orderedItems: TimelineItem[],
+  options: ProjectionContext,
+  visibleCount?: number,
+): { messages: ChatMsg[]; totalMessages: number } {
+  if (!Number.isFinite(visibleCount) || visibleCount === undefined || visibleCount < 0) {
+    const messages = tagIntermediateMessagesLinear(groupConsecutiveToolCalls(
+      orderedItems.flatMap((item) => projectItem(item, options)),
+    ));
+    return { messages, totalMessages: messages.length };
+  }
+
+  if (visibleCount === 0) {
+    return { messages: [], totalMessages: countProjectedMessages(orderedItems) };
+  }
+
+  const visibleMessages: ChatMsg[] = [];
+  let totalMessages = 0;
+  let index = orderedItems.length - 1;
+
+  while (index >= 0) {
+    const item = orderedItems[index];
+    if (item.kind === 'tool_group') {
+      index--;
+      continue;
+    }
+
+    if (item.kind === 'tool_call') {
+      const toolItems: ToolCallTimelineItem[] = [];
+      let nextIndex = index;
+      for (; nextIndex >= 0; nextIndex--) {
+        const candidate = orderedItems[nextIndex];
+        if (candidate.kind === 'tool_group') continue;
+        if (candidate.kind !== 'tool_call') break;
+        toolItems.unshift(candidate);
+      }
+
+      totalMessages += 1;
+      if (visibleMessages.length < visibleCount) {
+        const grouped = groupConsecutiveToolCalls(toolItems.map(projectToolCallItem));
+        visibleMessages.unshift(...grouped);
+      }
+      index = nextIndex;
+      continue;
+    }
+
+    const messageCount = countProjectedItemMessages(item);
+    totalMessages += messageCount;
+    if (messageCount > 0 && visibleMessages.length < visibleCount) {
+      const remaining = visibleCount - visibleMessages.length;
+      const projected = projectItem(item, options);
+      visibleMessages.unshift(...projected.slice(-remaining));
+    }
+    index--;
+  }
+
+  return {
+    messages: tagIntermediateMessagesLinear(visibleMessages),
+    totalMessages,
+  };
 }
 
 function projectUserItem(
@@ -256,6 +318,69 @@ function groupConsecutiveToolCalls(messages: ChatMsg[]): ChatMsg[] {
   return grouped;
 }
 
+function tagIntermediateMessagesLinear(messages: ChatMsg[]): ChatMsg[] {
+  const tagged = messages.map((message) => ({ ...message }));
+  let hasToolAfterBeforeNextUser = false;
+
+  for (let index = tagged.length - 1; index >= 0; index--) {
+    const message = tagged[index];
+    if (message.role === 'user') {
+      hasToolAfterBeforeNextUser = false;
+      continue;
+    }
+    if (message.role === 'tool' || message.role === 'toolResult' || message.toolGroup) {
+      hasToolAfterBeforeNextUser = true;
+      continue;
+    }
+    if (
+      message.role === 'assistant' &&
+      !message.isThinking &&
+      hasToolAfterBeforeNextUser &&
+      !(message.charts?.length)
+    ) {
+      message.intermediate = true;
+    }
+  }
+
+  return tagged;
+}
+
+function countProjectedMessages(orderedItems: TimelineItem[]): number {
+  let count = 0;
+  let inToolRun = false;
+
+  for (const item of orderedItems) {
+    if (item.kind === 'tool_group') continue;
+    if (item.kind === 'tool_call') {
+      if (!inToolRun) count += 1;
+      inToolRun = true;
+      continue;
+    }
+    inToolRun = false;
+    count += countProjectedItemMessages(item);
+  }
+
+  return count;
+}
+
+function countProjectedItemMessages(item: TimelineItem): number {
+  switch (item.kind) {
+    case 'tool_group':
+    case 'tool_call':
+      return 0;
+    case 'assistant_message':
+    case 'assistant_segment':
+      return item.text.trim() || item.isStreaming ? 1 : 0;
+    case 'thinking':
+      return item.text.trim() ? 1 : 0;
+    case 'user_message':
+      return item.text.trim() || item.images?.length || item.uploadAttachments?.length ? 1 : 0;
+    case 'tool_result':
+    case 'system_event':
+      return 1;
+  }
+}
+
 function buildActivityLog(
   orderedItems: TimelineItem[],
   activeTurnIds: ReadonlySet<string>,
@@ -293,12 +418,11 @@ function findLastRunningTool(
 
 function isActiveTurn(
   turn: TimelineTurn,
-  orderedItems: TimelineItem[],
+  turnItems: TimelineItem[],
   failedIdempotencyKeys?: ReadonlySet<string>,
 ): boolean {
   if (turn.status !== 'running') return false;
 
-  const turnItems = orderedItems.filter((item) => item.turnId === turn.id);
   if (turnItems.length === 0) return true;
 
   const onlyCompletedHistoryInputs = turnItems.every((item) =>

--- a/src/features/chat/runtime/reducer.test.ts
+++ b/src/features/chat/runtime/reducer.test.ts
@@ -175,6 +175,38 @@ describe('chat runtime client reducer', () => {
     expect(afterSnapshot.cursor).toBe('10');
     expect(afterSnapshot.timeline.items['user-1']).toMatchObject({ text: 'fresh live patch' });
   });
+
+  it('preserves unchanged timeline item references and ordered indexes across patches', () => {
+    const state = createEmptyRuntimeTimelineState('session-1');
+    const turnA = makeTurn('session-1', 'run-a', 0);
+    const turnB = makeTurn('session-1', 'run-b', 1);
+    const initial = applyTimelinePatch(state, {
+      sessionKey: 'session-1',
+      cursor: '1',
+      createdAt: 1,
+      ops: [
+        { op: 'upsert_turn', turn: turnA },
+        { op: 'upsert_turn', turn: turnB },
+        { op: 'upsert_item', item: makeUserItem('session-1', turnA, 'user-a', 'first', 1) },
+        { op: 'upsert_item', item: makeUserItem('session-1', turnB, 'user-b', 'second', 2) },
+      ],
+    });
+    const unchanged = initial.timeline.items['user-a'];
+
+    const afterPatch = applyTimelinePatch(initial, {
+      sessionKey: 'session-1',
+      cursor: '2',
+      createdAt: 2,
+      ops: [
+        { op: 'upsert_item', item: makeUserItem('session-1', turnB, 'user-b', 'second updated', 3) },
+      ],
+    });
+
+    expect(afterPatch.timeline.items['user-a']).toBe(unchanged);
+    expect(orderedTimelineItems(afterPatch.timeline).map((item) => item.id)).toEqual(['user-a', 'user-b']);
+    expect(afterPatch.timeline.itemsByTurnId?.[turnA.id].map((item) => item.id)).toEqual(['user-a']);
+    expect(afterPatch.timeline.itemsByTurnId?.[turnB.id].map((item) => item.id)).toEqual(['user-b']);
+  });
 });
 
 function makePatch(sessionKey: string, cursor: string, ops: TimelinePatch['ops']): TimelinePatch {

--- a/src/features/chat/runtime/reducer.test.ts
+++ b/src/features/chat/runtime/reducer.test.ts
@@ -192,6 +192,7 @@ describe('chat runtime client reducer', () => {
       ],
     });
     const unchanged = initial.timeline.items['user-a'];
+    const changedBefore = initial.timeline.items['user-b'];
 
     const afterPatch = applyTimelinePatch(initial, {
       sessionKey: 'session-1',
@@ -203,6 +204,8 @@ describe('chat runtime client reducer', () => {
     });
 
     expect(afterPatch.timeline.items['user-a']).toBe(unchanged);
+    expect(afterPatch.timeline.items['user-b']).not.toBe(changedBefore);
+    expect(afterPatch.timeline.items['user-b']).toMatchObject({ text: 'second updated' });
     expect(orderedTimelineItems(afterPatch.timeline).map((item) => item.id)).toEqual(['user-a', 'user-b']);
     expect(afterPatch.timeline.itemsByTurnId?.[turnA.id].map((item) => item.id)).toEqual(['user-a']);
     expect(afterPatch.timeline.itemsByTurnId?.[turnB.id].map((item) => item.id)).toEqual(['user-b']);

--- a/src/features/chat/runtime/reducer.ts
+++ b/src/features/chat/runtime/reducer.ts
@@ -24,6 +24,10 @@ export function createEmptyTimeline(sessionKey: string): SessionTimeline {
     turns: [],
     items: {},
     updatedAt: 0,
+    orderedItems: [],
+    itemIndexById: {},
+    itemsByTurnId: {},
+    turnIndexById: {},
   };
 }
 
@@ -36,7 +40,7 @@ export function applyTimelineSnapshot(
   if (cursorComparison < 0) return state;
   if (cursorComparison === 0 && state.timeline.hydrationState !== 'cold') return state;
 
-  const timeline = cloneTimeline(snapshot.timeline);
+  const timeline = cloneTimeline(snapshot.timeline, { cloneItems: true });
   return {
     sessionKey: state.sessionKey,
     cursor: snapshot.cursor,
@@ -60,7 +64,7 @@ export function applyTimelinePatch(
     if (op.op === 'upsert_turn') {
       upsertTurn(timeline, op.turn);
     } else if (op.op === 'upsert_item') {
-      timeline.items[op.item.id] = cloneItem(op.item);
+      upsertItem(timeline, op.item);
     } else if (op.op === 'bind_user_message_run') {
       bindUserMessageRun(timeline, op);
     } else if (op.op === 'remove_item') {
@@ -72,7 +76,6 @@ export function applyTimelinePatch(
     }
   }
 
-  timeline.turns.sort(compareTurns);
   timeline.cursor = patch.cursor;
   timeline.version = cursorToVersion(patch.cursor, timeline.version);
   timeline.updatedAt = Math.max(timeline.updatedAt, patch.createdAt);
@@ -85,7 +88,18 @@ export function applyTimelinePatch(
 }
 
 export function orderedTimelineItems(timeline: SessionTimeline): TimelineItem[] {
-  return Object.values(timeline.items).sort(compareItems);
+  if (timeline.orderedItems) return timeline.orderedItems;
+  const orderedItems = Object.values(timeline.items).sort(compareItems);
+  timeline.orderedItems = orderedItems;
+  timeline.itemIndexById = buildItemIndex(orderedItems);
+  timeline.itemsByTurnId = buildItemsByTurnId(orderedItems);
+  return orderedItems;
+}
+
+export function timelineItemsByTurnId(timeline: SessionTimeline): Record<string, TimelineItem[]> {
+  if (timeline.itemsByTurnId) return timeline.itemsByTurnId;
+  timeline.itemsByTurnId = buildItemsByTurnId(orderedTimelineItems(timeline));
+  return timeline.itemsByTurnId;
 }
 
 export function compareCursor(left: string, right: string): number {
@@ -105,17 +119,35 @@ export function compareCursor(left: string, right: string): number {
 }
 
 function upsertTurn(timeline: SessionTimeline, turn: TimelineTurn): void {
-  const index = timeline.turns.findIndex((candidate) => candidate.id === turn.id);
+  const turnIndexById = ensureTurnIndex(timeline);
+  const index = turnIndexById[turn.id] ?? -1;
   const cloned = cloneTurn(turn);
-  if (index === -1) {
-    timeline.turns.push(cloned);
-  } else {
-    timeline.turns[index] = cloned;
+  if (index !== -1) timeline.turns.splice(index, 1);
+  const nextIndex = insertionIndex(timeline.turns, cloned, compareTurns);
+  timeline.turns.splice(nextIndex, 0, cloned);
+  rebuildTurnIndexFrom(timeline, Math.min(index === -1 ? nextIndex : index, nextIndex));
+}
+
+function upsertItem(timeline: SessionTimeline, item: TimelineItem): void {
+  const cloned = cloneItem(item);
+  const previous = timeline.items[item.id];
+  timeline.items[item.id] = cloned;
+  removeFromOrderedItems(timeline, item.id);
+  insertOrderedItem(timeline, cloned);
+  if (previous?.turnId && previous.turnId !== cloned.turnId) {
+    removeFromTurnItems(timeline, previous.turnId, item.id);
+  }
+  if (cloned.turnId) {
+    removeFromTurnItems(timeline, cloned.turnId, item.id);
+    insertTurnItem(timeline, cloned.turnId, cloned);
   }
 }
 
 function removeItem(timeline: SessionTimeline, itemId: string): void {
+  const previous = timeline.items[itemId];
   delete timeline.items[itemId];
+  removeFromOrderedItems(timeline, itemId);
+  if (previous?.turnId) removeFromTurnItems(timeline, previous.turnId, itemId);
   for (const turn of timeline.turns) {
     turn.inputItemIds = turn.inputItemIds.filter((candidate) => candidate !== itemId);
     turn.outputItemIds = turn.outputItemIds.filter((candidate) => candidate !== itemId);
@@ -124,9 +156,19 @@ function removeItem(timeline: SessionTimeline, itemId: string): void {
 
 function removeTurn(timeline: SessionTimeline, turnId: string): void {
   timeline.turns = timeline.turns.filter((turn) => turn.id !== turnId);
+  timeline.turnIndexById = buildTurnIndex(timeline.turns);
+  const removedItemIds = new Set<string>();
   for (const [itemId, item] of Object.entries(timeline.items)) {
-    if (item.turnId === turnId) delete timeline.items[itemId];
+    if (item.turnId === turnId) {
+      delete timeline.items[itemId];
+      removedItemIds.add(itemId);
+    }
   }
+  if (removedItemIds.size > 0 && timeline.orderedItems) {
+    timeline.orderedItems = timeline.orderedItems.filter((item) => !removedItemIds.has(item.id));
+    timeline.itemIndexById = buildItemIndex(timeline.orderedItems);
+  }
+  if (timeline.itemsByTurnId) delete timeline.itemsByTurnId[turnId];
 }
 
 function bindUserMessageRun(
@@ -139,27 +181,42 @@ function bindUserMessageRun(
   );
   if (!item || item.kind !== 'user_message') return;
 
-  timeline.items[item.id] = {
+  upsertItem(timeline, {
     ...item,
     runId: op.runId,
     updatedAt: Math.max(item.updatedAt, op.at),
-  };
+  });
 
   const turn = item.turnId
-    ? timeline.turns.find((candidate) => candidate.id === item.turnId)
+    ? timeline.turns[ensureTurnIndex(timeline)[item.turnId]]
     : undefined;
   if (turn && !isTerminalTurnStatus(turn.status)) {
     turn.runId = op.runId;
   }
 }
 
-function cloneTimeline(timeline: SessionTimeline): SessionTimeline {
+function cloneTimeline(
+  timeline: SessionTimeline,
+  options: { cloneItems?: boolean } = {},
+): SessionTimeline {
+  const orderedItems = timeline.orderedItems
+    ? timeline.orderedItems
+    : Object.values(timeline.items).sort(compareItems);
+  const items = options.cloneItems
+    ? Object.fromEntries(Object.entries(timeline.items).map(([id, item]) => [id, cloneItem(item)]))
+    : { ...timeline.items };
+  const nextOrderedItems = options.cloneItems
+    ? orderedItems.map((item) => items[item.id])
+    : [...orderedItems];
+
   return {
     ...timeline,
     turns: timeline.turns.map(cloneTurn),
-    items: Object.fromEntries(
-      Object.entries(timeline.items).map(([id, item]) => [id, cloneItem(item)]),
-    ),
+    items,
+    orderedItems: nextOrderedItems,
+    itemIndexById: buildItemIndex(nextOrderedItems),
+    itemsByTurnId: buildItemsByTurnId(nextOrderedItems),
+    turnIndexById: buildTurnIndex(timeline.turns),
   };
 }
 
@@ -207,6 +264,107 @@ function compareItems(left: TimelineItem, right: TimelineItem): number {
 
 function isTerminalTurnStatus(status: TimelineTurn['status']): boolean {
   return status === 'finalized' || status === 'failed' || status === 'aborted';
+}
+
+function ensureItemIndex(timeline: SessionTimeline): Record<string, number> {
+  if (timeline.itemIndexById) return timeline.itemIndexById;
+  timeline.itemIndexById = buildItemIndex(orderedTimelineItems(timeline));
+  return timeline.itemIndexById;
+}
+
+function ensureTurnIndex(timeline: SessionTimeline): Record<string, number> {
+  if (timeline.turnIndexById) return timeline.turnIndexById;
+  timeline.turnIndexById = buildTurnIndex(timeline.turns);
+  return timeline.turnIndexById;
+}
+
+function removeFromOrderedItems(timeline: SessionTimeline, itemId: string): void {
+  const orderedItems = orderedTimelineItems(timeline);
+  const indexById = ensureItemIndex(timeline);
+  const index = indexById[itemId];
+  if (index === undefined) return;
+  orderedItems.splice(index, 1);
+  delete indexById[itemId];
+  rebuildItemIndexFrom(timeline, index);
+}
+
+function insertOrderedItem(timeline: SessionTimeline, item: TimelineItem): void {
+  const orderedItems = orderedTimelineItems(timeline);
+  const index = insertionIndex(orderedItems, item, compareItems);
+  orderedItems.splice(index, 0, item);
+  rebuildItemIndexFrom(timeline, index);
+}
+
+function insertTurnItem(timeline: SessionTimeline, turnId: string, item: TimelineItem): void {
+  const itemsByTurnId = timelineItemsByTurnId(timeline);
+  const turnItems = itemsByTurnId[turnId] ? [...itemsByTurnId[turnId]] : [];
+  const index = insertionIndex(turnItems, item, compareItems);
+  turnItems.splice(index, 0, item);
+  itemsByTurnId[turnId] = turnItems;
+}
+
+function removeFromTurnItems(timeline: SessionTimeline, turnId: string, itemId: string): void {
+  const itemsByTurnId = timelineItemsByTurnId(timeline);
+  const current = itemsByTurnId[turnId];
+  if (!current) return;
+  const next = current.filter((item) => item.id !== itemId);
+  if (next.length === 0) {
+    delete itemsByTurnId[turnId];
+  } else {
+    itemsByTurnId[turnId] = next;
+  }
+}
+
+function buildItemIndex(items: TimelineItem[]): Record<string, number> {
+  const index: Record<string, number> = {};
+  items.forEach((item, itemIndex) => { index[item.id] = itemIndex; });
+  return index;
+}
+
+function buildTurnIndex(turns: TimelineTurn[]): Record<string, number> {
+  const index: Record<string, number> = {};
+  turns.forEach((turn, turnIndex) => { index[turn.id] = turnIndex; });
+  return index;
+}
+
+function buildItemsByTurnId(items: TimelineItem[]): Record<string, TimelineItem[]> {
+  const byTurnId: Record<string, TimelineItem[]> = {};
+  for (const item of items) {
+    if (!item.turnId) continue;
+    const turnItems = byTurnId[item.turnId] ?? [];
+    turnItems.push(item);
+    byTurnId[item.turnId] = turnItems;
+  }
+  return byTurnId;
+}
+
+function rebuildItemIndexFrom(timeline: SessionTimeline, startIndex: number): void {
+  const orderedItems = orderedTimelineItems(timeline);
+  const itemIndexById = ensureItemIndex(timeline);
+  for (let index = Math.max(0, startIndex); index < orderedItems.length; index++) {
+    itemIndexById[orderedItems[index].id] = index;
+  }
+}
+
+function rebuildTurnIndexFrom(timeline: SessionTimeline, startIndex: number): void {
+  const turnIndexById = ensureTurnIndex(timeline);
+  for (let index = Math.max(0, startIndex); index < timeline.turns.length; index++) {
+    turnIndexById[timeline.turns[index].id] = index;
+  }
+}
+
+function insertionIndex<T>(items: T[], value: T, compare: (left: T, right: T) => number): number {
+  let low = 0;
+  let high = items.length;
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    if (compare(items[mid], value) <= 0) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+  return low;
 }
 
 function cursorToVersion(cursor: string, fallback: number): number {

--- a/src/features/chat/runtime/types.ts
+++ b/src/features/chat/runtime/types.ts
@@ -117,6 +117,10 @@ export interface SessionTimeline {
   turns: TimelineTurn[];
   items: Record<string, TimelineItem>;
   updatedAt: number;
+  orderedItems?: TimelineItem[];
+  itemIndexById?: Record<string, number>;
+  itemsByTurnId?: Record<string, TimelineItem[]>;
+  turnIndexById?: Record<string, number>;
 }
 
 export type TimelinePatchOp =
@@ -150,6 +154,7 @@ export interface RuntimeTimelineState {
 
 export interface TimelineProjection {
   messages: ChatMsg[];
+  totalMessages: number;
   isGenerating: boolean;
   processingStage: ProcessingStage;
   lastEventTimestamp: number;
@@ -159,4 +164,5 @@ export interface TimelineProjection {
 
 export interface TimelineProjectionOptions {
   failedIdempotencyKeys?: ReadonlySet<string>;
+  visibleCount?: number;
 }

--- a/src/features/chat/runtime/useChatRuntime.ts
+++ b/src/features/chat/runtime/useChatRuntime.ts
@@ -227,25 +227,22 @@ export function useChatRuntime({
   }, [clearReconnectTimer, closeEventSource, enabled, sessionKey]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
+  const currentVisible = timelineState.timeline.orderedItems?.length === 0
+    ? 0
+    : Math.max(DEFAULT_VISIBLE_COUNT, visibleCount);
   const projection = useMemo(() => projectTimeline(timelineState.timeline, {
     failedIdempotencyKeys,
-  }), [failedIdempotencyKeys, timelineState.timeline]);
+    visibleCount: currentVisible,
+  }), [currentVisible, failedIdempotencyKeys, timelineState.timeline]);
 
-  const visibleMessages = useMemo(() => {
-    const currentVisible = projection.messages.length === 0
-      ? 0
-      : Math.max(DEFAULT_VISIBLE_COUNT, Math.min(visibleCount, projection.messages.length));
-    return projection.messages.slice(-currentVisible);
-  }, [projection.messages, visibleCount]);
-
-  const hasMore = projection.messages.length > visibleMessages.length;
+  const hasMore = projection.totalMessages > projection.messages.length;
 
   const loadMore = useCallback(() => {
-    if (projection.messages.length <= visibleCount) return false;
-    const nextVisible = Math.min(projection.messages.length, visibleCount + LOAD_MORE_BATCH);
+    if (projection.totalMessages <= visibleCount) return false;
+    const nextVisible = Math.min(projection.totalMessages, visibleCount + LOAD_MORE_BATCH);
     setVisibleCount(nextVisible);
-    return nextVisible < projection.messages.length;
-  }, [projection.messages.length, visibleCount]);
+    return nextVisible < projection.totalMessages;
+  }, [projection.totalMessages, visibleCount]);
 
   const reload = useCallback(() => {
     scheduleReconnect(0);
@@ -272,7 +269,7 @@ export function useChatRuntime({
   }, []);
 
   return {
-    messages: visibleMessages,
+    messages: projection.messages,
     isGenerating: projection.isGenerating,
     processingStage: projection.processingStage,
     lastEventTimestamp: projection.lastEventTimestamp,


### PR DESCRIPTION
## Summary
- Add windowed chat runtime projection so the UI only renders the visible transcript tail while preserving total message count for Load more.
- Maintain client-side ordered timeline indexes incrementally across patches instead of cloning/sorting/projecting the full timeline for every live update.
- Replace runtime projection intermediate-message tagging with a single reverse pass and add 500 / 2k / 10k synthetic timeline coverage.

## Validation
- npm exec vitest -- run src/features/chat/runtime/projection.test.ts src/features/chat/runtime/reducer.test.ts src/features/chat/runtime/useChatRuntime.test.tsx
- npm run lint
- npm test -- --run
- npm run build
- git diff --check

## Notes
- Targets `next` as PR 1 for the chat runtime performance item.
- The remaining Vite markdown/editor chunk warnings are intentionally left for the separate bundle split PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added message visibility window option to control how many messages are displayed, enabling more efficient chat pagination.
  * Chat projections now include total message count alongside visible messages for accurate pagination handling.

* **Improvements**
  * Optimized internal data structure caching for better performance.

* **Tests**
  * Added comprehensive test coverage for message visibility window functionality.
  * Added test coverage for timeline updates and item preservation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daggerhashimoto/openclaw-nerve/pull/335?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->