### PR TITLE
perf(bundle): repair lazy split boundaries

### DIFF
--- a/src/features/beads/BeadViewerTab.test.tsx
+++ b/src/features/beads/BeadViewerTab.test.tsx
@@ -59,7 +59,7 @@ describe('BeadViewerTab', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: /Dependency/ }));
-    fireEvent.click(screen.getByRole('link', { name: 'related' }));
+    fireEvent.click(await screen.findByRole('link', { name: 'related' }));
 
     await waitFor(() => {
       expect(onOpenBeadId).toHaveBeenNthCalledWith(1, {
@@ -88,8 +88,8 @@ describe('BeadViewerTab', () => {
       />,
     );
 
-    const plainLink = screen.getByRole('link', { name: '/workspace/src/plain.tsx' });
-    const codeLink = screen.getByRole('link', { name: '/workspace/src/code.tsx' });
+    const plainLink = await screen.findByRole('link', { name: '/workspace/src/plain.tsx' });
+    const codeLink = await screen.findByRole('link', { name: '/workspace/src/code.tsx' });
 
     expect(codeLink.closest('code')).not.toBeNull();
 

--- a/src/features/beads/BeadViewerTab.tsx
+++ b/src/features/beads/BeadViewerTab.tsx
@@ -1,8 +1,13 @@
-import { useCallback } from 'react';
+import { lazy, Suspense, useCallback } from 'react';
 import { AlertTriangle, ArrowUpRight, CircleDot, FileText, GitBranch, Loader2 } from 'lucide-react';
-import { MarkdownRenderer } from '@/features/markdown/MarkdownRenderer';
 import { useBeadDetail } from './useBeadDetail';
 import type { BeadLinkTarget } from './links';
+
+const MarkdownRenderer = lazy(() =>
+  import('@/features/markdown/MarkdownRenderer').then((module) => ({
+    default: module.MarkdownRenderer,
+  })),
+);
 
 interface BeadViewerTabProps {
   beadTarget: BeadLinkTarget;
@@ -138,15 +143,24 @@ export function BeadViewerTab({ beadTarget, onOpenBeadId, onOpenWorkspacePath, p
                 <CircleDot size={13} />
                 <span>Notes</span>
               </div>
-              <MarkdownRenderer
-                content={bead.notes}
-                currentDocumentPath={beadTarget.currentDocumentPath}
-                workspaceAgentId={beadTarget.workspaceAgentId}
-                onOpenBeadId={openBeadWithContext}
-                onOpenWorkspacePath={onOpenWorkspacePath}
-                pathLinkPrefixes={pathLinkPrefixes}
-                pathLinkAliases={pathLinkAliases}
-              />
+              <Suspense
+                fallback={(
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <Loader2 size={14} className="animate-spin" />
+                    Loading notes...
+                  </div>
+                )}
+              >
+                <MarkdownRenderer
+                  content={bead.notes}
+                  currentDocumentPath={beadTarget.currentDocumentPath}
+                  workspaceAgentId={beadTarget.workspaceAgentId}
+                  onOpenBeadId={openBeadWithContext}
+                  onOpenWorkspacePath={onOpenWorkspacePath}
+                  pathLinkPrefixes={pathLinkPrefixes}
+                  pathLinkAliases={pathLinkAliases}
+                />
+              </Suspense>
             </div>
           ) : null}
 

--- a/src/features/chat/ToolCallBlock.tsx
+++ b/src/features/chat/ToolCallBlock.tsx
@@ -1,14 +1,17 @@
-import React, { useMemo, memo } from 'react';
+import React, { lazy, Suspense, useMemo, memo } from 'react';
 import { ChevronRight } from 'lucide-react';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
 import { Card, CardContent } from '@/components/ui/card';
 import { sanitizeHtml } from '@/lib/sanitize';
 import { decodeHtmlEntities } from '@/lib/formatting';
 import { escapeRegex } from '@/lib/constants';
-import { DiffView } from './DiffView';
-import { FileContentView } from './FileContentView';
 import { extractEditBlocks, extractWriteBlocks } from './edit-blocks';
 import type { ChatMsg } from './types';
+
+const DiffView = lazy(() => import('./DiffView').then((module) => ({ default: module.DiffView })));
+const FileContentView = lazy(() =>
+  import('./FileContentView').then((module) => ({ default: module.FileContentView })),
+);
 
 interface ToolCallBlockProps {
   msg: ChatMsg;
@@ -57,17 +60,21 @@ function ToolCallBlockInner({ msg, index, isCollapsed, onToggleCollapse, searchQ
           <CollapsibleContent>
             <CardContent className="border-t border-border/40 bg-background/42 px-3 py-3">
               {editBlocks.length > 0 ? (
-                <div className="space-y-2">
-                  {editBlocks.map((block, i) => (
-                    <DiffView key={i} oldText={block.oldText} newText={block.newText} filePath={block.filePath} />
-                  ))}
-                </div>
+                <Suspense fallback={<div className="text-xs text-muted-foreground">Loading diff...</div>}>
+                  <div className="space-y-2">
+                    {editBlocks.map((block, i) => (
+                      <DiffView key={i} oldText={block.oldText} newText={block.newText} filePath={block.filePath} />
+                    ))}
+                  </div>
+                </Suspense>
               ) : writeBlocks.length > 0 ? (
-                <div className="space-y-2">
-                  {writeBlocks.map((block, i) => (
-                    <FileContentView key={i} content={block.content} filePath={block.filePath} />
-                  ))}
-                </div>
+                <Suspense fallback={<div className="text-xs text-muted-foreground">Loading file preview...</div>}>
+                  <div className="space-y-2">
+                    {writeBlocks.map((block, i) => (
+                      <FileContentView key={i} content={block.content} filePath={block.filePath} />
+                    ))}
+                  </div>
+                </Suspense>
               ) : (
                 <div
                   className="msg-body whitespace-pre-wrap text-[0.8rem] font-mono opacity-85 max-h-[300px] overflow-y-auto"

--- a/src/features/chat/components/ToolGroupBlock.tsx
+++ b/src/features/chat/components/ToolGroupBlock.tsx
@@ -1,11 +1,14 @@
-import { useState, useMemo, memo } from 'react';
+import { lazy, Suspense, useState, useMemo, memo } from 'react';
 import { ChevronRight, Wrench } from 'lucide-react';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
 import { Card, CardContent } from '@/components/ui/card';
-import { DiffView } from '../DiffView';
-import { FileContentView } from '../FileContentView';
 import { extractEditBlocks, extractWriteBlocks } from '../edit-blocks';
 import type { ChatMsg, ToolGroupEntry } from '../types';
+
+const DiffView = lazy(() => import('../DiffView').then((module) => ({ default: module.DiffView })));
+const FileContentView = lazy(() =>
+  import('../FileContentView').then((module) => ({ default: module.FileContentView })),
+);
 
 interface ToolGroupBlockProps {
   msg: ChatMsg;
@@ -49,17 +52,21 @@ function ToolEntryRow({ entry }: { entry: ToolGroupEntry }) {
       <CollapsibleContent>
         <div className="ml-6 mr-2 mb-2 mt-1 border-l-2 border-border/40 pl-3">
           {editBlocks.length > 0 ? (
-            <div className="space-y-2">
-              {editBlocks.map((block, i) => (
-                <DiffView key={i} oldText={block.oldText} newText={block.newText} filePath={block.filePath} />
-              ))}
-            </div>
+            <Suspense fallback={<div className="text-xs text-muted-foreground">Loading diff...</div>}>
+              <div className="space-y-2">
+                {editBlocks.map((block, i) => (
+                  <DiffView key={i} oldText={block.oldText} newText={block.newText} filePath={block.filePath} />
+                ))}
+              </div>
+            </Suspense>
           ) : (
-            <div className="space-y-2">
-              {writeBlocks.map((block, i) => (
-                <FileContentView key={i} content={block.content} filePath={block.filePath} />
-              ))}
-            </div>
+            <Suspense fallback={<div className="text-xs text-muted-foreground">Loading file preview...</div>}>
+              <div className="space-y-2">
+                {writeBlocks.map((block, i) => (
+                  <FileContentView key={i} content={block.content} filePath={block.filePath} />
+                ))}
+              </div>
+            </Suspense>
           )}
         </div>
       </CollapsibleContent>

--- a/src/features/file-browser/MarkdownDocumentView.test.tsx
+++ b/src/features/file-browser/MarkdownDocumentView.test.tsx
@@ -46,7 +46,7 @@ describe('MarkdownDocumentView', () => {
     markdownRendererSpy.mockClear();
   });
 
-  it('renders preview mode with light full-width gutters and no nested card', () => {
+  it('renders preview mode with light full-width gutters and no nested card', async () => {
     render(
       <MarkdownDocumentView
         file={file}
@@ -56,13 +56,13 @@ describe('MarkdownDocumentView', () => {
       />,
     );
 
-    const renderer = screen.getByTestId('markdown-renderer');
+    const renderer = await screen.findByTestId('markdown-renderer');
     expect(renderer.closest('article')).toBeNull();
     expect(renderer.parentElement).toHaveClass('px-4');
     expect(renderer.parentElement).toHaveClass('md:px-6');
   });
 
-  it('uses a segmented button switcher to toggle between preview and edit', () => {
+  it('uses a segmented button switcher to toggle between preview and edit', async () => {
     render(
       <MarkdownDocumentView
         file={file}
@@ -79,16 +79,16 @@ describe('MarkdownDocumentView', () => {
 
     expect(previewButton).toHaveAttribute('aria-pressed', 'true');
     expect(editButton).toHaveAttribute('aria-pressed', 'false');
-    expect(screen.getByTestId('markdown-renderer')).toBeInTheDocument();
+    expect(await screen.findByTestId('markdown-renderer')).toBeInTheDocument();
 
     fireEvent.click(editButton);
 
     expect(editButton).toHaveAttribute('aria-pressed', 'true');
     expect(previewButton).toHaveAttribute('aria-pressed', 'false');
-    expect(screen.getByTestId('file-editor')).toBeInTheDocument();
+    expect(await screen.findByTestId('file-editor')).toBeInTheDocument();
   });
 
-  it('passes bead and workspace handlers through to the markdown renderer while preserving document path fallback', () => {
+  it('passes bead and workspace handlers through to the markdown renderer while preserving document path fallback', async () => {
     const onOpenBeadId = vi.fn();
     const onOpenWorkspacePath = vi.fn();
 
@@ -104,6 +104,7 @@ describe('MarkdownDocumentView', () => {
       />,
     );
 
+    await screen.findByTestId('markdown-renderer');
     expect(markdownRendererSpy).toHaveBeenCalled();
     const props = markdownRendererSpy.mock.calls.at(-1)?.[0];
     expect(props.currentDocumentPath).toBe('docs/guide.md');

--- a/src/features/file-browser/MarkdownDocumentView.tsx
+++ b/src/features/file-browser/MarkdownDocumentView.tsx
@@ -1,8 +1,17 @@
-import { useState } from 'react';
+import { lazy, Suspense, useState } from 'react';
 import { AlertTriangle, Eye, Loader2, PencilLine, RotateCw } from 'lucide-react';
-import { MarkdownRenderer } from '@/features/markdown/MarkdownRenderer';
 import type { OpenFile } from './types';
-import { FileEditor } from './FileEditor';
+
+const MarkdownRenderer = lazy(() =>
+  import('@/features/markdown/MarkdownRenderer').then((module) => ({
+    default: module.MarkdownRenderer,
+  })),
+);
+const FileEditor = lazy(() =>
+  import('./FileEditor').then((module) => ({
+    default: module.FileEditor,
+  })),
+);
 
 interface MarkdownDocumentViewProps {
   file: OpenFile;
@@ -13,6 +22,15 @@ interface MarkdownDocumentViewProps {
   onOpenBeadId?: (target: import('@/features/beads').BeadLinkTarget) => void | Promise<void>;
   pathLinkAliases?: Record<string, string>;
   workspaceAgentId?: string;
+}
+
+function PaneFallback({ label }: { label: string }) {
+  return (
+    <div className="flex h-full items-center justify-center gap-2 text-xs text-muted-foreground">
+      <Loader2 className="animate-spin" size={14} />
+      {label}
+    </div>
+  );
 }
 
 export function MarkdownDocumentView({
@@ -92,25 +110,29 @@ export function MarkdownDocumentView({
               </button>
             </div>
           ) : (
-            <MarkdownRenderer
-              content={file.content}
-              className="markdown-document-content"
-              currentDocumentPath={file.path}
-              onOpenBeadId={onOpenBeadId}
-              onOpenWorkspacePath={(targetPath, basePath) => onOpenWorkspacePath?.(targetPath, basePath ?? file.path)}
-              pathLinkAliases={pathLinkAliases}
-              workspaceAgentId={workspaceAgentId}
-            />
+            <Suspense fallback={<PaneFallback label="Loading preview..." />}>
+              <MarkdownRenderer
+                content={file.content}
+                className="markdown-document-content"
+                currentDocumentPath={file.path}
+                onOpenBeadId={onOpenBeadId}
+                onOpenWorkspacePath={(targetPath, basePath) => onOpenWorkspacePath?.(targetPath, basePath ?? file.path)}
+                pathLinkAliases={pathLinkAliases}
+                workspaceAgentId={workspaceAgentId}
+              />
+            </Suspense>
           )}
         </div>
       ) : (
         <div className="flex-1 min-h-0">
-          <FileEditor
-            file={file}
-            onContentChange={onContentChange}
-            onSave={onSave}
-            onRetry={onRetry}
-          />
+          <Suspense fallback={<PaneFallback label="Loading editor..." />}>
+            <FileEditor
+              file={file}
+              onContentChange={onContentChange}
+              onSave={onSave}
+              onRetry={onRetry}
+            />
+          </Suspense>
         </div>
       )}
     </div>

--- a/src/features/file-browser/utils/languageMap.ts
+++ b/src/features/file-browser/utils/languageMap.ts
@@ -1,4 +1,5 @@
 import type { Extension } from '@codemirror/state';
+import { LanguageSupport, StreamLanguage } from '@codemirror/language';
 
 type LanguageLoader = () => Promise<Extension>;
 
@@ -28,37 +29,32 @@ const LANG_MAP: Record<string, LanguageLoader> = {
   '.sh': () =>
     Promise.all([
       import('@codemirror/legacy-modes/mode/shell'),
-      import('@codemirror/language'),
-    ]).then(([shell, lang]) =>
-      new lang.LanguageSupport(lang.StreamLanguage.define(shell.shell)),
+    ]).then(([shell]) =>
+      new LanguageSupport(StreamLanguage.define(shell.shell)),
     ),
   '.bash': () =>
     Promise.all([
       import('@codemirror/legacy-modes/mode/shell'),
-      import('@codemirror/language'),
-    ]).then(([shell, lang]) =>
-      new lang.LanguageSupport(lang.StreamLanguage.define(shell.shell)),
+    ]).then(([shell]) =>
+      new LanguageSupport(StreamLanguage.define(shell.shell)),
     ),
   '.zsh': () =>
     Promise.all([
       import('@codemirror/legacy-modes/mode/shell'),
-      import('@codemirror/language'),
-    ]).then(([shell, lang]) =>
-      new lang.LanguageSupport(lang.StreamLanguage.define(shell.shell)),
+    ]).then(([shell]) =>
+      new LanguageSupport(StreamLanguage.define(shell.shell)),
     ),
   '.rb': () =>
     Promise.all([
       import('@codemirror/legacy-modes/mode/ruby'),
-      import('@codemirror/language'),
-    ]).then(([ruby, lang]) =>
-      new lang.LanguageSupport(lang.StreamLanguage.define(ruby.ruby)),
+    ]).then(([ruby]) =>
+      new LanguageSupport(StreamLanguage.define(ruby.ruby)),
     ),
   '.pl': () =>
     Promise.all([
       import('@codemirror/legacy-modes/mode/perl'),
-      import('@codemirror/language'),
-    ]).then(([perl, lang]) =>
-      new lang.LanguageSupport(lang.StreamLanguage.define(perl.perl)),
+    ]).then(([perl]) =>
+      new LanguageSupport(StreamLanguage.define(perl.perl)),
     ),
 };
 

--- a/src/features/workspace/WorkspacePanel.test.tsx
+++ b/src/features/workspace/WorkspacePanel.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/contexts/SettingsContext', () => ({
   useSettings: () => mockUseSettings(),
 }));
 
-vi.mock('@/features/kanban', () => ({
+vi.mock('@/features/kanban/KanbanQuickView', () => ({
   KanbanQuickView: () => <div data-testid="kanban-tab" />,
 }));
 

--- a/src/features/workspace/WorkspacePanel.tsx
+++ b/src/features/workspace/WorkspacePanel.tsx
@@ -9,12 +9,16 @@ import { useState, useCallback, lazy, Suspense, useEffect } from 'react';
 import { WorkspaceTabs, type TabId } from './WorkspaceTabs';
 import { CronsTab, ConfigTab, SkillsTab } from './tabs';
 import { useCrons } from './hooks/useCrons';
-import { KanbanQuickView } from '@/features/kanban';
 import { getWorkspaceStorageKey } from './workspaceScope';
 import { useSettings } from '@/contexts/SettingsContext';
 import type { Memory } from '@/types';
 
 const MemoryList = lazy(() => import('@/features/dashboard/MemoryList').then(m => ({ default: m.MemoryList })));
+const KanbanQuickView = lazy(() =>
+  import('@/features/kanban/KanbanQuickView').then((module) => ({
+    default: module.KanbanQuickView,
+  })),
+);
 
 const CONFIG_VIEW_KEY = 'nerve-config-view';
 
@@ -202,10 +206,12 @@ export function WorkspacePanel({
         {kanbanVisible && (
           <div className={activeTab === 'kanban' ? 'h-full' : 'hidden'} hidden={activeTab !== 'kanban'} role="tabpanel" id="workspace-tabpanel-kanban" aria-labelledby="workspace-tab-kanban">
             {visitedTabs.has('kanban') && (
-              <KanbanQuickView
-                onOpenBoard={onOpenBoard ?? (() => {})}
-                onOpenTask={(task) => onOpenTask ? onOpenTask(task.id) : onOpenBoard?.()}
-              />
+              <Suspense fallback={<div className="flex items-center justify-center text-muted-foreground text-xs p-4">Loading...</div>}>
+                <KanbanQuickView
+                  onOpenBoard={onOpenBoard ?? (() => {})}
+                  onOpenTask={(task) => onOpenTask ? onOpenTask(task.id) : onOpenBoard?.()}
+                />
+              </Suspense>
             )}
           </div>
         )}

--- a/src/hooks/useChatStreaming.ts
+++ b/src/hooks/useChatStreaming.ts
@@ -61,7 +61,7 @@ export function useChatStreaming() {
     const flush = streamFlushRef.current;
     clearScheduledStreamFlush();
 
-    const html = renderToolResults(renderMarkdown(flush.text, { highlight: false }));
+    const html = renderToolResults(renderMarkdown(flush.text));
     setStream(prev => ({
       ...prev,
       html,

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -3,11 +3,9 @@
  * 
  * For formatting utilities, import directly from:
  *   - @/lib/formatting (esc, timeAgo, fmtTokens, fmtK)
- *   - @/lib/highlight (hljs, highlightCode)
  *   - @/features/voice/audio-feedback (playPing, playWakePing, etc.)
  */
 import { esc } from '@/lib/formatting';
-import { highlightCode } from '@/lib/highlight';
 import type { ContentBlock } from '@/types';
 
 // ─── Markdown cache ───
@@ -33,21 +31,22 @@ function setMarkdownCache(key: string, value: string): void {
 /**
  * Lightweight regex-based markdown renderer for streaming and tool results.
  *
- * Supports fenced code blocks (with syntax highlighting), inline code,
- * bold, italic, links, and unordered lists. Results are cached (LRU, max 200).
+ * Supports fenced code blocks, inline code, bold, italic, links, and unordered
+ * lists. Rich syntax highlighting lives in lazy-rendered markdown and diff
+ * components so chat runtime projection does not pull highlight.js into the
+ * initial bundle. Results are cached (LRU, max 200).
  */
 export function renderMarkdown(text: string, opts: { highlight?: boolean } = {}): string {
   if (!text) return '';
-  const highlight = opts.highlight !== false;
-  const cacheKey = (highlight ? 'h:' : 'nh:') + text;
+  void opts;
+  const cacheKey = 'nh:' + text;
   const cached = getMarkdownCache(cacheKey);
   if (cached) return cached;
 
   let s = esc(text);
   s = s.replace(/```(\w*)\n([\s\S]*?)```/g, (_, lang, code) => {
-    const highlighted = highlight ? highlightCode(code, lang) : code;
     const langLabel = lang ? `<span class="code-lang">${esc(lang)}</span>` : '';
-    return `<pre class="hljs">${langLabel}<code>${highlighted}</code></pre>`;
+    return `<pre class="hljs">${langLabel}<code>${code}</code></pre>`;
   });
   s = s.replace(/`([^`]+)`/g, '<code>$1</code>');
   s = s.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -36,9 +36,8 @@ function setMarkdownCache(key: string, value: string): void {
  * components so chat runtime projection does not pull highlight.js into the
  * initial bundle. Results are cached (LRU, max 200).
  */
-export function renderMarkdown(text: string, opts: { highlight?: boolean } = {}): string {
+export function renderMarkdown(text: string): string {
   if (!text) return '';
-  void opts;
   const cacheKey = 'nh:' + text;
   const cached = getMarkdownCache(cacheKey);
   if (cached) return cached;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,18 +45,71 @@ export default defineConfig({
     sourcemap: false, // No sourcemaps in production
     rollupOptions: {
       output: {
-        manualChunks: {
+        manualChunks(id) {
+          const normalized = id.split(path.sep).join('/');
+          if (!normalized.includes('/node_modules/')) return undefined;
+
           // Core React libraries (most stable, cache-friendly)
-          'react-vendor': ['react', 'react-dom'],
-          
+          if (
+            normalized.includes('/node_modules/react/') ||
+            normalized.includes('/node_modules/react-dom/') ||
+            normalized.includes('/node_modules/scheduler/')
+          ) {
+            return 'react-vendor';
+          }
+
           // Markdown rendering (heavy with highlight.js)
-          'markdown': ['react-markdown', 'remark-gfm', 'highlight.js'],
-          
+          if (
+            normalized.includes('/node_modules/react-markdown/') ||
+            normalized.includes('/node_modules/remark-gfm/') ||
+            normalized.includes('/node_modules/highlight.js/')
+          ) {
+            return 'markdown';
+          }
+
+          // Charts (loaded only when chat messages contain chart blocks)
+          if (
+            normalized.includes('/node_modules/recharts/') ||
+            normalized.includes('/node_modules/victory-vendor/') ||
+            normalized.includes('/node_modules/d3-')
+          ) {
+            return 'charts-vendor';
+          }
+          if (normalized.includes('/node_modules/lightweight-charts/')) {
+            return 'lightweight-charts';
+          }
+
+          // CodeMirror editor shell (loaded only when file editing is opened)
+          if (
+            normalized.includes('/node_modules/@codemirror/state/') ||
+            normalized.includes('/node_modules/@codemirror/view/') ||
+            normalized.includes('/node_modules/@codemirror/commands/') ||
+            normalized.includes('/node_modules/@codemirror/search/') ||
+            normalized.includes('/node_modules/@codemirror/language/') ||
+            normalized.includes('/node_modules/@lezer/highlight/') ||
+            normalized.includes('/node_modules/style-mod/') ||
+            normalized.includes('/node_modules/w3c-keyname/') ||
+            normalized.includes('/node_modules/crelt/')
+          ) {
+            return 'editor-vendor';
+          }
+
           // UI components (radix + lucide icons)
-          'ui-vendor': ['lucide-react'],
-          
+          if (normalized.includes('/node_modules/lucide-react/')) {
+            return 'ui-vendor';
+          }
+
           // Utility libraries
-          'utils': ['clsx', 'tailwind-merge', 'class-variance-authority', 'dompurify'],
+          if (
+            normalized.includes('/node_modules/clsx/') ||
+            normalized.includes('/node_modules/tailwind-merge/') ||
+            normalized.includes('/node_modules/class-variance-authority/') ||
+            normalized.includes('/node_modules/dompurify/')
+          ) {
+            return 'utils';
+          }
+
+          return undefined;
         },
       },
     },


### PR DESCRIPTION
## Summary
- lazy-load markdown rendering in bead notes and markdown document preview/edit paths so the markdown vendor chunk is no longer an initial preload
- lazy-load CodeMirror edit mode, tool diff/file preview highlighters, and workspace Kanban quick view through direct non-barrel imports
- replace the static manual chunk object with package-aware chunk routing for React, markdown, charts, editor, UI, and utility vendors

## Bundle comparison
- Before: initial HTML preloaded `ui-vendor`, `markdown`, `react-vendor`, and `utils`; entry chunk was `962.08 kB / 300.83 kB gzip` and Vite reported defeated lazy imports plus a `>600 kB` entry warning.
- After: initial HTML preloads only `react-vendor`, `utils`, and `ui-vendor`; entry chunk is `372.50 kB / 111.70 kB gzip`; no Vite lazy-boundary or chunk-size warnings.
- Deferred chunks now include markdown/highlight, charts, CodeMirror editor, file diff/file preview, and Kanban quick view boundaries.

## Validation
- `npm exec vitest -- run src/features/file-browser/MarkdownDocumentView.test.tsx src/features/file-browser/TabbedContentArea.test.tsx src/features/beads/BeadViewerTab.test.tsx src/features/workspace/WorkspacePanel.test.tsx src/features/charts/InlineChart.test.tsx src/features/chat/MessageBubble.test.tsx src/features/chat/runtime/projection.test.ts src/features/chat/operations/loadHistory.test.ts src/features/chat/operations/sendMessage.test.ts`
- `npm run lint`
- `npm test -- --run`
- `npm run build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Implemented lazy loading for multiple UI components with loading indicators
  * Optimized application build through improved code splitting and vendor chunking

* **User Experience**
  * Loading messages now display when rendering notes, code diffs, file previews, and workspace content
  * Streamlined markdown rendering process

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daggerhashimoto/openclaw-nerve/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->