### PR TITLE
perf: add idle performance mode

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -35,6 +35,7 @@ const {
   const settingsContext = {
     kanbanVisible: true,
     commandPaletteButtonVisible: true,
+    performanceMode: false,
   };
   const uploadConfigState = {
     fileReferenceEnabled: true,
@@ -187,6 +188,7 @@ vi.mock('@/contexts/SettingsContext', () => ({
     setFont: vi.fn(),
     kanbanVisible: settingsContext.kanbanVisible,
     commandPaletteButtonVisible: settingsContext.commandPaletteButtonVisible,
+    performanceMode: settingsContext.performanceMode,
   }),
 }));
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -126,6 +126,7 @@ export default function App({ onLogout }: AppProps) {
     setTheme, setFont,
     kanbanVisible,
     commandPaletteButtonVisible,
+    performanceMode,
   } = useSettings();
 
   // Connection management (extracted hook)
@@ -986,6 +987,7 @@ export default function App({ onLogout }: AppProps) {
           viewMode={viewMode}
           onViewModeChange={setViewMode}
           showKanbanView={kanbanVisible}
+          performanceMode={performanceMode}
         />
       )}
 
@@ -1119,6 +1121,7 @@ export default function App({ onLogout }: AppProps) {
           sparkline={sparkline}
           contextTokens={contextTokens}
           contextLimit={contextLimit}
+          performanceMode={performanceMode}
         />
       </div>
 

--- a/src/components/NerveLogo.test.tsx
+++ b/src/components/NerveLogo.test.tsx
@@ -1,0 +1,68 @@
+import '@testing-library/jest-dom';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import NerveLogo from './NerveLogo';
+
+function mockMatchMedia(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+describe('NerveLogo', () => {
+  const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+
+  beforeEach(() => {
+    localStorage.clear();
+    mockMatchMedia(false);
+    globalThis.requestAnimationFrame = vi.fn(() => 1) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = vi.fn() as typeof cancelAnimationFrame;
+  });
+
+  afterEach(() => {
+    cleanup();
+    globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
+    vi.restoreAllMocks();
+  });
+
+  it('renders a static logo without canvas work when animation is disabled', () => {
+    render(<NerveLogo size={24} static />);
+
+    expect(screen.getByRole('img', { name: /nerve logo/i })).toBeInTheDocument();
+    expect(document.querySelector('canvas')).not.toBeInTheDocument();
+    expect(globalThis.requestAnimationFrame).not.toHaveBeenCalled();
+  });
+
+  it('respects reduced motion without scheduling animation frames', () => {
+    mockMatchMedia(true);
+
+    render(<NerveLogo size={24} />);
+
+    expect(screen.getByRole('img', { name: /nerve logo/i })).toBeInTheDocument();
+    expect(document.querySelector('canvas')).not.toBeInTheDocument();
+    expect(globalThis.requestAnimationFrame).not.toHaveBeenCalled();
+  });
+
+  it('uses the static logo when persisted performance mode is enabled', () => {
+    localStorage.setItem('nerve:performanceMode', 'true');
+
+    render(<NerveLogo size={24} />);
+
+    expect(screen.getByRole('img', { name: /nerve logo/i })).toBeInTheDocument();
+    expect(document.querySelector('canvas')).not.toBeInTheDocument();
+    expect(globalThis.requestAnimationFrame).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/NerveLogo.tsx
+++ b/src/components/NerveLogo.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { isPerformanceModePreferenceEnabled } from '@/lib/performanceMode';
 
 const TAU = Math.PI * 2;
 function lerp(a: number, b: number, t: number) { return a + (b - a) * t; }
@@ -60,6 +61,102 @@ function glowLine(ctx: CanvasRenderingContext2D, x1: number, y1: number, x2: num
 interface NerveLogoProps {
   /** Logical size in CSS pixels (canvas is rendered at 2× for retina). @default 28 */
   size?: number;
+  /** Render the non-animated logo variant without a canvas animation loop. */
+  static?: boolean;
+}
+
+function usePrefersReducedMotion(): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  ));
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const updatePreference = () => setPrefersReducedMotion(media.matches);
+    updatePreference();
+
+    if (typeof media.addEventListener === 'function') {
+      media.addEventListener('change', updatePreference);
+      return () => media.removeEventListener('change', updatePreference);
+    }
+
+    media.addListener(updatePreference);
+    return () => media.removeListener(updatePreference);
+  }, []);
+
+  return prefersReducedMotion;
+}
+
+function StaticNerveLogo({ size }: { size: number }) {
+  const pad = 2;
+  const boxSize = size * pad;
+  const center = boxSize / 2;
+  const radius = size * 0.31;
+  const nodeRadius = Math.max(2.5, size * 0.13);
+  const outerRadius = Math.max(2, size * 0.09);
+  const negativeMargin = -size * (pad - 1) / 2;
+  const outer = Array.from({ length: 6 }, (_, index) => {
+    const angle = (index / 6) * TAU - Math.PI / 2;
+    return {
+      x: center + Math.cos(angle) * radius,
+      y: center + Math.sin(angle) * radius,
+    };
+  });
+
+  return (
+    <span
+      role="img"
+      aria-label="Nerve logo"
+      data-static-logo="true"
+      className="relative block"
+      style={{
+        width: boxSize,
+        height: boxSize,
+        margin: negativeMargin,
+      }}
+    >
+      {outer.map((node, index) => (
+        <span
+          key={`line-${index}`}
+          aria-hidden="true"
+          className="absolute block origin-left rounded-full bg-primary/35"
+          style={{
+            left: center,
+            top: center,
+            width: Math.hypot(node.x - center, node.y - center),
+            height: 1,
+            transform: `rotate(${Math.atan2(node.y - center, node.x - center)}rad)`,
+          }}
+        />
+      ))}
+      {outer.map((node, index) => (
+        <span
+          key={`node-${index}`}
+          aria-hidden="true"
+          className="absolute rounded-full border border-primary/45 bg-primary/25 shadow-[0_0_10px_rgba(255,140,50,0.25)]"
+          style={{
+            left: node.x - outerRadius,
+            top: node.y - outerRadius,
+            width: outerRadius * 2,
+            height: outerRadius * 2,
+          }}
+        />
+      ))}
+      <span
+        aria-hidden="true"
+        className="absolute rounded-full border border-primary/70 bg-primary/35 shadow-[0_0_14px_rgba(255,140,50,0.32)]"
+        style={{
+          left: center - nodeRadius,
+          top: center - nodeRadius,
+          width: nodeRadius * 2,
+          height: nodeRadius * 2,
+        }}
+      />
+    </span>
+  );
 }
 
 /**
@@ -69,8 +166,10 @@ interface NerveLogoProps {
  * center ignition → outward propagation → return fire → ring chain.
  * The animation loops on a ~4.2 s cycle and includes ambient breathing.
  */
-export default function NerveLogo({ size = 28 }: NerveLogoProps) {
+export default function NerveLogo({ size = 28, static: staticLogo = false }: NerveLogoProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const shouldRenderStatic = staticLogo || prefersReducedMotion || isPerformanceModePreferenceEnabled();
   const stateRef = useRef<{
     trails: Trail[];
     ripples: Ripple[];
@@ -80,6 +179,7 @@ export default function NerveLogo({ size = 28 }: NerveLogoProps) {
   } | null>(null);
 
   useEffect(() => {
+    if (shouldRenderStatic) return;
     const canvas = canvasRef.current;
     if (!canvas) return;
 
@@ -100,8 +200,6 @@ export default function NerveLogo({ size = 28 }: NerveLogoProps) {
     const cx = W / 2;
     const cy = W / 2;
 
-    // Respect prefers-reduced-motion: render a single static frame
-    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     const R = size * 0.31 * S;
     const CYCLE = 4.2;
 
@@ -240,18 +338,16 @@ export default function NerveLogo({ size = 28 }: NerveLogoProps) {
       if (stateRef.current) stateRef.current.rafId = requestAnimationFrame(animate);
     }
 
-    if (prefersReducedMotion) {
-      // Render a single static frame — structure with gentle ambient glow, no animation
-      animate(0);
-      return;
-    }
-
     stateRef.current.rafId = requestAnimationFrame(animate);
 
     return () => {
       if (stateRef.current) cancelAnimationFrame(stateRef.current.rafId);
     };
-  }, [size]);
+  }, [shouldRenderStatic, size]);
+
+  if (shouldRenderStatic) {
+    return <StaticNerveLogo size={size} />;
+  }
 
   return <canvas ref={canvasRef} role="img" aria-label="Nerve logo" style={{ display: 'block' }} />;
 }

--- a/src/components/StatusBar.test.tsx
+++ b/src/components/StatusBar.test.tsx
@@ -1,0 +1,89 @@
+import '@testing-library/jest-dom';
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { StatusBar } from './StatusBar';
+
+vi.mock('@/contexts/GatewayContext', () => ({
+  useGateway: () => ({}),
+}));
+
+vi.mock('./UpdateBadge', () => ({
+  UpdateBadge: () => <span data-testid="update-badge" />,
+}));
+
+function renderStatusBar(performanceMode = false) {
+  return render(
+    <StatusBar
+      connectionState="connected"
+      sessionCount={2}
+      sparkline="▁▂▃▄"
+      performanceMode={performanceMode}
+    />,
+  );
+}
+
+function expectedServerTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString('en-GB', { hour12: false });
+}
+
+async function flushServerInfo() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('StatusBar', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-13T12:00:00Z'));
+    vi.stubGlobal('__APP_VERSION__', '1.5.3');
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        serverTime: Date.now(),
+        gatewayStartedAt: Date.now() - 5_000,
+      }),
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('hides sparkline telemetry in performance mode', async () => {
+    renderStatusBar(true);
+
+    await flushServerInfo();
+    expect(screen.getByText(expectedServerTime('2026-05-13T12:00:00Z'))).toBeInTheDocument();
+    expect(screen.queryByText('▁▂▃▄')).not.toBeInTheDocument();
+    expect(screen.getByText('v1.5.3')).toBeInTheDocument();
+  });
+
+  it('updates clock and uptime only on a slow interval in performance mode', async () => {
+    renderStatusBar(true);
+
+    await flushServerInfo();
+    expect(screen.getByText(expectedServerTime('2026-05-13T12:00:00Z'))).toBeInTheDocument();
+    expect(screen.getByText('00:00:05')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+
+    expect(screen.getByText(expectedServerTime('2026-05-13T12:00:00Z'))).toBeInTheDocument();
+    expect(screen.getByText('00:00:05')).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(59_000);
+    });
+
+    expect(screen.getByText(expectedServerTime('2026-05-13T12:01:00Z'))).toBeInTheDocument();
+    expect(screen.getByText('00:01:05')).toBeInTheDocument();
+  });
+});

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -15,6 +15,8 @@ interface StatusBarProps {
   contextTokens?: number;
   /** Context window limit in tokens (omit to hide the meter). */
   contextLimit?: number;
+  /** Freeze non-essential live telemetry for lower idle repaint cost. */
+  performanceMode?: boolean;
 }
 
 function formatUptime(seconds: number): string {
@@ -47,7 +49,7 @@ async function fetchServerInfo(): Promise<{ serverTime?: number; gatewayStartedA
  * Shows connection state, server time, session count, gateway uptime,
  * an optional context-window meter, a sparkline, and the app version.
  */
-export function StatusBar({ connectionState, sessionCount, sparkline, contextTokens, contextLimit }: StatusBarProps) {
+export function StatusBar({ connectionState, sessionCount, sparkline, contextTokens, contextLimit, performanceMode = false }: StatusBarProps) {
   useGateway(); // Keep gateway context connected
 
   // Server time: offset between local clock and server clock
@@ -56,6 +58,9 @@ export function StatusBar({ connectionState, sessionCount, sparkline, contextTok
   const [gatewayStartedAt, setGatewayStartedAt] = useState<number | null>(null);
   // Ticking display values
   const [now, setNow] = useState(() => Date.now());
+  const [documentVisible, setDocumentVisible] = useState(() => (
+    typeof document === 'undefined' || document.visibilityState !== 'hidden'
+  ));
 
   // Use connectionState as key to trigger CSS animation on change
   const flashKey = connectionState;
@@ -83,11 +88,24 @@ export function StatusBar({ connectionState, sessionCount, sparkline, contextTok
     return () => { signal.cancelled = true; };
   }, [connectionState, syncServerInfo]);
 
-  // Tick every second
+  // Pause decorative ticking while hidden; performance mode uses a slow visible tick.
   useEffect(() => {
-    const iv = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(iv);
+    if (typeof document === 'undefined') return;
+    const handleVisibility = () => {
+      const visible = document.visibilityState !== 'hidden';
+      setDocumentVisible(visible);
+      if (visible) setNow(Date.now());
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
   }, []);
+
+  useEffect(() => {
+    if (!documentVisible) return;
+    const intervalMs = performanceMode ? 60_000 : 1000;
+    const iv = setInterval(() => setNow(Date.now()), intervalMs);
+    return () => clearInterval(iv);
+  }, [documentVisible, performanceMode]);
 
   const statusColor = connectionState === 'connected'
     ? 'border-green/30 bg-green/10 text-green'
@@ -164,9 +182,11 @@ export function StatusBar({ connectionState, sessionCount, sparkline, contextTok
 
       {/* Right side telemetry (hidden on smaller screens) */}
       <div className="ml-3 hidden shrink-0 items-center gap-2 lg:flex">
-        <span className="rounded-full border border-border/70 bg-background/75 px-2.5 py-1 font-mono text-[0.667rem] tracking-[-0.08em] text-muted-foreground">
-          {sparkline}<span className="ml-1 text-primary animate-alive">_</span>
-        </span>
+        {!performanceMode && (
+          <span className="rounded-full border border-border/70 bg-background/75 px-2.5 py-1 font-mono text-[0.667rem] tracking-[-0.08em] text-muted-foreground">
+            {sparkline}<span className="ml-1 text-primary animate-alive">_</span>
+          </span>
+        )}
         <span className="text-[0.6rem] font-medium uppercase tracking-[0.18em] text-muted-foreground/55">v{__APP_VERSION__}</span>
         <UpdateBadge />
       </div>

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -110,6 +110,8 @@ interface TopBarProps {
   onViewModeChange?: (mode: ViewMode) => void;
   /** Whether the Tasks/Kanban view toggle should be shown. */
   showKanbanView?: boolean;
+  /** Freeze non-essential animated chrome for lower idle repaint cost. */
+  performanceMode?: boolean;
 }
 
 /**
@@ -133,6 +135,7 @@ export function TopBar({
   viewMode = "chat",
   onViewModeChange,
   showKanbanView = true,
+  performanceMode = false,
 }: TopBarProps) {
   const [activePanel, setActivePanel] = useState<PanelId>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -236,7 +239,7 @@ export function TopBar({
       <header className="topbar-mobile-compact shell-panel flex min-h-14 flex-wrap items-center gap-x-3 gap-y-2 rounded-2xl px-3 py-2 shrink-0 max-[371px]:gap-x-1.5 max-[371px]:px-2 sm:flex-nowrap sm:px-4">
         <div className="flex min-w-0 items-center gap-3 max-[371px]:gap-2">
           <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-primary/20 bg-background/55 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] max-[371px]:h-9 max-[371px]:w-9">
-            <NerveLogo size={24} />
+            <NerveLogo size={24} static={performanceMode} />
           </div>
           <div className="min-w-0">
             <div className="flex items-center gap-2">

--- a/src/contexts/GatewayContext.tsx
+++ b/src/contexts/GatewayContext.tsx
@@ -3,6 +3,7 @@ import { createContext, useContext, useCallback, useRef, useEffect, useState, us
 import { useWebSocket } from '@/hooks/useWebSocket';
 import type { GatewayEvent } from '@/types';
 import { isTopLevelAgentSessionKey } from '@/features/sessions/sessionKeys';
+import { isPerformanceModePreferenceEnabled } from '@/lib/performanceMode';
 
 type EventHandler = (msg: GatewayEvent) => void;
 
@@ -122,7 +123,9 @@ export function GatewayProvider({ children }: { children: ReactNode }) {
     if (activityBuckets.current.length > 30) activityBuckets.current.shift();
     const blocks = '▁▂▃▄▅▆▇█';
     const max = Math.max(1, ...activityBuckets.current);
-    setSparkline(activityBuckets.current.slice(-15).map(v => blocks[Math.min(7, Math.floor((v / max) * 7))]).join(''));
+    if (!isPerformanceModePreferenceEnabled()) {
+      setSparkline(activityBuckets.current.slice(-15).map(v => blocks[Math.min(7, Math.floor((v / max) * 7))]).join(''));
+    }
   }, []);
 
   // Poll status when connected

--- a/src/contexts/GatewayContext.tsx
+++ b/src/contexts/GatewayContext.tsx
@@ -117,15 +117,17 @@ export function GatewayProvider({ children }: { children: ReactNode }) {
       console.debug('[GatewayContext] Failed to poll status:', err);
     }
 
-    // Update activity sparkline
+    // Update activity sparkline (skip all tracking + math in performance mode)
+    if (isPerformanceModePreferenceEnabled()) {
+      currentBucketEvents.current = 0;
+      return;
+    }
     activityBuckets.current.push(currentBucketEvents.current);
     currentBucketEvents.current = 0;
     if (activityBuckets.current.length > 30) activityBuckets.current.shift();
     const blocks = '▁▂▃▄▅▆▇█';
     const max = Math.max(1, ...activityBuckets.current);
-    if (!isPerformanceModePreferenceEnabled()) {
-      setSparkline(activityBuckets.current.slice(-15).map(v => blocks[Math.min(7, Math.floor((v / max) * 7))]).join(''));
-    }
+    setSparkline(activityBuckets.current.slice(-15).map(v => blocks[Math.min(7, Math.floor((v / max) * 7))]).join(''));
   }, []);
 
   // Poll status when connected

--- a/src/contexts/SettingsContext.test.tsx
+++ b/src/contexts/SettingsContext.test.tsx
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SettingsProvider, useSettings } from './SettingsContext';
+
+vi.mock('@/features/tts/useTTS', () => ({
+  migrateTTSProvider: (provider: string) => provider,
+  useTTS: () => ({ speak: vi.fn() }),
+}));
+
+vi.mock('@/lib/themes', () => ({
+  themeNames: ['ayu-dark'],
+  applyTheme: vi.fn(),
+}));
+
+vi.mock('@/lib/fonts', () => ({
+  fontNames: ['instrument-sans'],
+  applyFont: vi.fn(),
+}));
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <SettingsProvider>{children}</SettingsProvider>;
+}
+
+describe('SettingsContext performance mode', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults performance mode off', () => {
+    const { result } = renderHook(() => useSettings(), { wrapper });
+
+    expect(result.current.performanceMode).toBe(false);
+  });
+
+  it('loads and persists performance mode', () => {
+    localStorage.setItem('nerve:performanceMode', 'true');
+
+    const { result } = renderHook(() => useSettings(), { wrapper });
+
+    expect(result.current.performanceMode).toBe(true);
+
+    act(() => result.current.togglePerformanceMode());
+
+    expect(result.current.performanceMode).toBe(false);
+    expect(localStorage.getItem('nerve:performanceMode')).toBe('false');
+  });
+});

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -3,6 +3,7 @@ import { createContext, useContext, useCallback, useRef, useState, useEffect, us
 import { useTTS, migrateTTSProvider, type TTSProvider } from '@/features/tts/useTTS';
 import { type ThemeName, applyTheme, themeNames } from '@/lib/themes';
 import { type FontName, applyFont, fontNames } from '@/lib/fonts';
+import { PERFORMANCE_MODE_STORAGE_KEY, isPerformanceModePreferenceEnabled } from '@/lib/performanceMode';
 
 export type STTProvider = 'local' | 'openai';
 export type STTInputMode = 'browser' | 'local' | 'hybrid';
@@ -50,6 +51,8 @@ interface SettingsContextValue {
   setEditorFontSize: (size: number) => void;
   kanbanVisible: boolean;
   toggleKanbanVisible: () => void;
+  performanceMode: boolean;
+  togglePerformanceMode: () => void;
 }
 
 const SettingsContext = createContext<SettingsContextValue | null>(null);
@@ -164,6 +167,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     const saved = localStorage.getItem(KANBAN_VISIBILITY_STORAGE_KEY);
     return saved !== 'false';
   });
+  const [performanceMode, setPerformanceMode] = useState(isPerformanceModePreferenceEnabled);
   const { speak } = useTTS(soundEnabled, ttsProvider, ttsModel || undefined);
   const wakeWordToggleRef = useRef<(() => void) | null>(null);
 
@@ -365,6 +369,14 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
+  const togglePerformanceMode = useCallback(() => {
+    setPerformanceMode(prev => {
+      const next = !prev;
+      localStorage.setItem(PERFORMANCE_MODE_STORAGE_KEY, String(next));
+      return next;
+    });
+  }, []);
+
   const value = useMemo<SettingsContextValue>(() => ({
     soundEnabled,
     toggleSound,
@@ -408,6 +420,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     setEditorFontSize,
     kanbanVisible,
     toggleKanbanVisible,
+    performanceMode,
+    togglePerformanceMode,
   }), [
     soundEnabled, toggleSound, ttsProvider, ttsModel, changeTtsProvider, changeTtsModel, toggleTtsProvider,
     sttProvider, changeSttProvider, sttInputMode, changeSttInputMode, sttModel, changeSttModel,
@@ -418,6 +432,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     commandPaletteButtonVisible, toggleCommandPaletteButtonVisible,
     theme, setTheme, font, setFont,
     fontSize, setFontSize, editorFontSize, setEditorFontSize, kanbanVisible, toggleKanbanVisible,
+    performanceMode, togglePerformanceMode,
   ]);
 
   return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>;

--- a/src/features/settings/AppearanceSettings.test.tsx
+++ b/src/features/settings/AppearanceSettings.test.tsx
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppearanceSettings } from './AppearanceSettings';
+
+const mockTogglePerformanceMode = vi.fn();
+let performanceMode = false;
+
+vi.mock('@/contexts/SettingsContext', () => ({
+  useSettings: () => ({
+    eventsVisible: false,
+    toggleEvents: vi.fn(),
+    logVisible: false,
+    toggleLog: vi.fn(),
+    showHiddenWorkspaceEntries: false,
+    toggleShowHiddenWorkspaceEntries: vi.fn(),
+    commandPaletteButtonVisible: true,
+    toggleCommandPaletteButtonVisible: vi.fn(),
+    kanbanVisible: true,
+    toggleKanbanVisible: vi.fn(),
+    performanceMode,
+    togglePerformanceMode: mockTogglePerformanceMode,
+    theme: 'ayu-dark',
+    setTheme: vi.fn(),
+    font: 'instrument-sans',
+    setFont: vi.fn(),
+    fontSize: 15,
+    setFontSize: vi.fn(),
+    editorFontSize: 13,
+    setEditorFontSize: vi.fn(),
+  }),
+}));
+
+describe('AppearanceSettings', () => {
+  beforeEach(() => {
+    performanceMode = false;
+    mockTogglePerformanceMode.mockClear();
+  });
+
+  it('renders the performance mode toggle', () => {
+    render(<AppearanceSettings />);
+
+    const toggle = screen.getByRole('switch', { name: /performance mode/i });
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+    fireEvent.click(toggle);
+
+    expect(mockTogglePerformanceMode).toHaveBeenCalledTimes(1);
+  });
+
+  it('reflects enabled performance mode', () => {
+    performanceMode = true;
+
+    render(<AppearanceSettings />);
+
+    expect(screen.getByRole('switch', { name: /performance mode/i })).toHaveAttribute('aria-checked', 'true');
+  });
+});

--- a/src/features/settings/AppearanceSettings.tsx
+++ b/src/features/settings/AppearanceSettings.tsx
@@ -1,4 +1,4 @@
-import { Monitor, Eye, Type, Activity, ALargeSmall, Code2, Columns3, Command } from 'lucide-react';
+import { Monitor, Eye, Type, Activity, ALargeSmall, Code2, Columns3, Command, Gauge } from 'lucide-react';
 import { Switch } from '@/components/ui/switch';
 import { InlineSelect } from '@/components/ui/InlineSelect';
 import { useSettings } from '@/contexts/SettingsContext';
@@ -53,6 +53,8 @@ export function AppearanceSettings() {
     toggleCommandPaletteButtonVisible,
     kanbanVisible,
     toggleKanbanVisible,
+    performanceMode,
+    togglePerformanceMode,
     theme,
     setTheme,
     font,
@@ -78,6 +80,22 @@ export function AppearanceSettings() {
           <span className="text-primary">◆</span>
           Appearance
         </span>
+      </div>
+
+      {/* Performance mode */}
+      <div className="cockpit-row items-start justify-between">
+        <div className="flex items-center gap-3">
+          <Gauge size={14} className={performanceMode ? 'text-green' : 'text-muted-foreground'} aria-hidden="true" />
+          <div className="flex flex-col">
+            <span className="text-sm font-medium text-foreground" id="performance-mode-label">Performance mode</span>
+            <span className="text-xs text-muted-foreground">Freeze cosmetic live visuals and use slower shell timers.</span>
+          </div>
+        </div>
+        <Switch
+          checked={performanceMode}
+          onCheckedChange={togglePerformanceMode}
+          aria-labelledby="performance-mode-label"
+        />
       </div>
 
       {/* Theme selector */}

--- a/src/lib/performanceMode.ts
+++ b/src/lib/performanceMode.ts
@@ -1,0 +1,9 @@
+export const PERFORMANCE_MODE_STORAGE_KEY = 'nerve:performanceMode';
+
+export function isPerformanceModePreferenceEnabled(): boolean {
+  try {
+    return typeof localStorage !== 'undefined' && localStorage.getItem(PERFORMANCE_MODE_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- adds a persisted Appearance setting for Performance mode
- renders the Nerve logo as static DOM instead of animated canvas when Performance mode or reduced motion is active
- slows status clock/uptime updates in Performance mode, pauses decorative ticking while the document is hidden, and hides sparkline telemetry in Performance mode
- avoids sparkline state churn when the persisted preference is enabled

## Validation

- npm exec vitest -- run src/components/NerveLogo.test.tsx src/components/StatusBar.test.tsx src/components/TopBar.test.tsx src/contexts/SettingsContext.test.tsx src/features/settings/AppearanceSettings.test.tsx
- npm run lint
- npm test -- --run
- npm run build
- git diff --check

Note: build still reports the existing bundle-split warnings from origin/next; those are handled separately in PR #336.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new performance mode toggle in the appearance settings panel
  * When enabled, the logo displays as a static image instead of animating
  * When enabled, real-time activity telemetry visualization is hidden from the status bar
  * When enabled, status updates occur at a reduced frequency
  * Performance mode preference is automatically saved and restored

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daggerhashimoto/openclaw-nerve/pull/337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->