### PR TITLE
perf: harden realtime backpressure

### DIFF
--- a/server/lib/sse-backpressure.test.ts
+++ b/server/lib/sse-backpressure.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { BoundedSSEWriter } from './sse-backpressure.js';
+
+function deferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('BoundedSSEWriter', () => {
+  it('serializes writes so a slow stream cannot create parallel write pressure', async () => {
+    const first = deferred<void>();
+    const writeSSE = vi.fn()
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValue(undefined);
+    const writer = new BoundedSSEWriter({ writeSSE }, {
+      label: 'sse-test',
+      maxQueueMessages: 4,
+      maxQueueBytes: 1024,
+      writeTimeoutMs: 1000,
+    });
+
+    expect(writer.enqueue({ event: 'one', data: '1' })).toBe(true);
+    expect(writer.enqueue({ event: 'two', data: '2' })).toBe(true);
+    expect(writer.enqueue({ event: 'three', data: '3' })).toBe(true);
+    expect(writeSSE).toHaveBeenCalledTimes(1);
+    expect(writer.stats()).toMatchObject({ queuedMessages: 2 });
+
+    first.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(writeSSE).toHaveBeenCalledTimes(3);
+    expect(writer.stats()).toMatchObject({ queuedMessages: 0 });
+  });
+
+  it('disconnects slow clients when the bounded queue overflows', () => {
+    const writeSSE = vi.fn().mockReturnValue(new Promise(() => {}));
+    const onDisconnect = vi.fn();
+    const writer = new BoundedSSEWriter({ writeSSE }, {
+      label: 'sse-overflow',
+      maxQueueMessages: 1,
+      maxQueueBytes: 1024,
+      writeTimeoutMs: 1000,
+      onDisconnect,
+    });
+
+    expect(writer.enqueue({ event: 'one', data: '1' })).toBe(true);
+    expect(writer.enqueue({ event: 'two', data: '2' })).toBe(true);
+    expect(writer.enqueue({ event: 'three', data: '3' })).toBe(false);
+
+    expect(onDisconnect).toHaveBeenCalledWith('queue overflow');
+    expect(writer.stats()).toMatchObject({ closed: true });
+  });
+
+  it('disconnects when a stream write does not settle before the timeout', async () => {
+    vi.useFakeTimers();
+    const onDisconnect = vi.fn();
+    const writer = new BoundedSSEWriter({ writeSSE: vi.fn().mockReturnValue(new Promise(() => {})) }, {
+      label: 'sse-timeout',
+      maxQueueMessages: 4,
+      maxQueueBytes: 1024,
+      writeTimeoutMs: 25,
+      onDisconnect,
+    });
+
+    expect(writer.enqueue({ event: 'one', data: '1' })).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(26);
+
+    expect(onDisconnect).toHaveBeenCalledWith('write timeout');
+    expect(writer.stats()).toMatchObject({ closed: true });
+    vi.useRealTimers();
+  });
+});

--- a/server/lib/sse-backpressure.test.ts
+++ b/server/lib/sse-backpressure.test.ts
@@ -58,21 +58,24 @@ describe('BoundedSSEWriter', () => {
 
   it('disconnects when a stream write does not settle before the timeout', async () => {
     vi.useFakeTimers();
-    const onDisconnect = vi.fn();
-    const writer = new BoundedSSEWriter({ writeSSE: vi.fn().mockReturnValue(new Promise(() => {})) }, {
-      label: 'sse-timeout',
-      maxQueueMessages: 4,
-      maxQueueBytes: 1024,
-      writeTimeoutMs: 25,
-      onDisconnect,
-    });
+    try {
+      const onDisconnect = vi.fn();
+      const writer = new BoundedSSEWriter({ writeSSE: vi.fn().mockReturnValue(new Promise(() => {})) }, {
+        label: 'sse-timeout',
+        maxQueueMessages: 4,
+        maxQueueBytes: 1024,
+        writeTimeoutMs: 25,
+        onDisconnect,
+      });
 
-    expect(writer.enqueue({ event: 'one', data: '1' })).toBe(true);
+      expect(writer.enqueue({ event: 'one', data: '1' })).toBe(true);
 
-    await vi.advanceTimersByTimeAsync(26);
+      await vi.advanceTimersByTimeAsync(26);
 
-    expect(onDisconnect).toHaveBeenCalledWith('write timeout');
-    expect(writer.stats()).toMatchObject({ closed: true });
-    vi.useRealTimers();
+      expect(onDisconnect).toHaveBeenCalledWith('write timeout');
+      expect(writer.stats()).toMatchObject({ closed: true });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/server/lib/sse-backpressure.ts
+++ b/server/lib/sse-backpressure.ts
@@ -1,0 +1,124 @@
+interface SSEMessage {
+  event?: string;
+  data: string;
+  id?: string;
+  retry?: number;
+}
+
+interface SSEStreamLike {
+  writeSSE(message: SSEMessage): Promise<void>;
+  abort?: () => void;
+}
+
+export interface SSEBackpressureOptions {
+  label: string;
+  maxQueueMessages?: number;
+  maxQueueBytes?: number;
+  writeTimeoutMs?: number;
+  onDisconnect?: (reason: string) => void;
+  logger?: Pick<Console, 'warn' | 'debug'>;
+}
+
+const DEFAULT_MAX_QUEUE_MESSAGES = 64;
+const DEFAULT_MAX_QUEUE_BYTES = 256 * 1024;
+const DEFAULT_WRITE_TIMEOUT_MS = 5_000;
+
+function messageBytes(message: SSEMessage): number {
+  return Buffer.byteLength(message.event ?? '') +
+    Buffer.byteLength(message.id ?? '') +
+    Buffer.byteLength(String(message.retry ?? '')) +
+    Buffer.byteLength(message.data);
+}
+
+export class BoundedSSEWriter {
+  private readonly stream: SSEStreamLike;
+  private readonly label: string;
+  private readonly maxQueueMessages: number;
+  private readonly maxQueueBytes: number;
+  private readonly writeTimeoutMs: number;
+  private readonly onDisconnect?: (reason: string) => void;
+  private readonly logger: Pick<Console, 'warn' | 'debug'>;
+  private queue: Array<{ message: SSEMessage; bytes: number }> = [];
+  private queuedBytes = 0;
+  private writing = false;
+  private closed = false;
+
+  constructor(stream: SSEStreamLike, options: SSEBackpressureOptions) {
+    this.stream = stream;
+    this.label = options.label;
+    this.maxQueueMessages = options.maxQueueMessages ?? DEFAULT_MAX_QUEUE_MESSAGES;
+    this.maxQueueBytes = options.maxQueueBytes ?? DEFAULT_MAX_QUEUE_BYTES;
+    this.writeTimeoutMs = options.writeTimeoutMs ?? DEFAULT_WRITE_TIMEOUT_MS;
+    this.onDisconnect = options.onDisconnect;
+    this.logger = options.logger ?? console;
+  }
+
+  enqueue(message: SSEMessage): boolean {
+    if (this.closed) return false;
+    const bytes = messageBytes(message);
+    if (this.queue.length >= this.maxQueueMessages || this.queuedBytes + bytes > this.maxQueueBytes) {
+      this.disconnect('queue overflow');
+      return false;
+    }
+
+    this.queue.push({ message, bytes });
+    this.queuedBytes += bytes;
+    void this.drain();
+    return true;
+  }
+
+  close(): void {
+    this.closed = true;
+    this.queue = [];
+    this.queuedBytes = 0;
+  }
+
+  stats() {
+    return {
+      queuedMessages: this.queue.length,
+      queuedBytes: this.queuedBytes,
+      closed: this.closed,
+    };
+  }
+
+  private async drain(): Promise<void> {
+    if (this.writing || this.closed) return;
+    this.writing = true;
+
+    try {
+      while (!this.closed && this.queue.length > 0) {
+        const next = this.queue.shift()!;
+        this.queuedBytes -= next.bytes;
+        await this.writeWithTimeout(next.message);
+      }
+    } catch (err) {
+      this.disconnect(err instanceof Error ? err.message : String(err));
+    } finally {
+      this.writing = false;
+    }
+  }
+
+  private async writeWithTimeout(message: SSEMessage): Promise<void> {
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    try {
+      await Promise.race([
+        this.stream.writeSSE(message),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(() => reject(new Error('write timeout')), this.writeTimeoutMs);
+        }),
+      ]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+  }
+
+  private disconnect(reason: string): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.queue = [];
+    this.queuedBytes = 0;
+    this.logger.warn(`[sse] closing ${this.label}: ${reason}`);
+    this.stream.abort?.();
+    this.onDisconnect?.(reason);
+  }
+}

--- a/server/lib/ws-backpressure.test.ts
+++ b/server/lib/ws-backpressure.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import { WebSocket } from 'ws';
+import { BoundedWebSocketSender } from './ws-backpressure.js';
+
+class MockSocket {
+  readyState = WebSocket.OPEN;
+  bufferedAmount = 0;
+  sent: Array<{ data: Buffer | string; binary: boolean }> = [];
+  close = vi.fn((code?: number, reason?: string) => {
+    this.readyState = WebSocket.CLOSED;
+    this.closeCode = code;
+    this.closeReason = reason;
+  });
+  closeCode?: number;
+  closeReason?: string;
+  private callbacks: Array<(err?: Error) => void> = [];
+
+  send(data: Buffer | string, options: { binary?: boolean }, callback?: (err?: Error) => void) {
+    this.sent.push({ data, binary: options.binary ?? false });
+    if (callback) this.callbacks.push(callback);
+  }
+
+  flushOne() {
+    this.callbacks.shift()?.();
+  }
+}
+
+describe('BoundedWebSocketSender', () => {
+  it('queues while the peer is above the buffered threshold and drains when it recovers', () => {
+    const socket = new MockSocket();
+    socket.bufferedAmount = 32;
+    const sender = new BoundedWebSocketSender(socket, {
+      label: 'test-peer',
+      maxBufferedBytes: 16,
+      resumeBufferedBytes: 8,
+      maxQueueMessages: 4,
+      maxQueueBytes: 1024,
+    });
+
+    expect(sender.send('queued-one', false)).toBe(true);
+    expect(socket.sent).toHaveLength(0);
+    expect(sender.stats()).toMatchObject({ queuedMessages: 1 });
+
+    socket.bufferedAmount = 0;
+    sender.drain();
+
+    expect(socket.sent).toEqual([{ data: 'queued-one', binary: false }]);
+    expect(sender.stats()).toMatchObject({ queuedMessages: 0 });
+  });
+
+  it('closes a slow peer instead of growing an unbounded queue', () => {
+    const socket = new MockSocket();
+    socket.bufferedAmount = 32;
+    const onOverflow = vi.fn();
+    const sender = new BoundedWebSocketSender(socket, {
+      label: 'slow-peer',
+      maxBufferedBytes: 16,
+      resumeBufferedBytes: 8,
+      maxQueueMessages: 1,
+      maxQueueBytes: 12,
+      closeCode: 1013,
+      closeReason: 'Backpressure overflow',
+      onOverflow,
+    });
+
+    expect(sender.send('first', false)).toBe(true);
+    expect(sender.send('second', false)).toBe(false);
+
+    expect(onOverflow).toHaveBeenCalledTimes(1);
+    expect(socket.close).toHaveBeenCalledWith(1013, 'Backpressure overflow');
+    expect(sender.stats()).toMatchObject({ closed: true });
+  });
+
+  it('preserves binary framing for queued data', () => {
+    const socket = new MockSocket();
+    socket.bufferedAmount = 32;
+    const sender = new BoundedWebSocketSender(socket, {
+      label: 'binary-peer',
+      maxBufferedBytes: 16,
+      resumeBufferedBytes: 8,
+      maxQueueMessages: 4,
+      maxQueueBytes: 1024,
+    });
+    const payload = Buffer.from([1, 2, 3]);
+
+    expect(sender.send(payload, true)).toBe(true);
+    socket.bufferedAmount = 0;
+    sender.drain();
+
+    expect(socket.sent).toEqual([{ data: payload, binary: true }]);
+  });
+});

--- a/server/lib/ws-backpressure.ts
+++ b/server/lib/ws-backpressure.ts
@@ -1,0 +1,180 @@
+import { WebSocket } from 'ws';
+
+type WebSocketData = Buffer | string;
+
+interface WebSocketFrame {
+  data: WebSocketData;
+  isBinary: boolean;
+  bytes: number;
+}
+
+interface WebSocketLike {
+  readonly readyState: number;
+  readonly bufferedAmount: number;
+  send(data: WebSocketData, options: { binary?: boolean }, callback?: (err?: Error) => void): void;
+  close(code?: number, reason?: string): void;
+}
+
+export interface WebSocketBackpressureOptions {
+  label: string;
+  maxBufferedBytes?: number;
+  resumeBufferedBytes?: number;
+  maxQueueMessages?: number;
+  maxQueueBytes?: number;
+  closeCode?: number;
+  closeReason?: string;
+  onOverflow?: () => void;
+  logger?: Pick<Console, 'warn' | 'debug'>;
+}
+
+const DEFAULT_MAX_BUFFERED_BYTES = 2 * 1024 * 1024;
+const DEFAULT_RESUME_BUFFERED_BYTES = 512 * 1024;
+const DEFAULT_MAX_QUEUE_MESSAGES = 128;
+const DEFAULT_MAX_QUEUE_BYTES = 1024 * 1024;
+const DEFAULT_CLOSE_CODE = 1013;
+const DEFAULT_CLOSE_REASON = 'Peer backlog exceeded';
+const RETRY_DRAIN_MS = 100;
+
+function frameBytes(data: WebSocketData): number {
+  return typeof data === 'string' ? Buffer.byteLength(data) : data.length;
+}
+
+function toOutboundData(data: Buffer | string, isBinary: boolean): WebSocketData {
+  return isBinary ? data : data.toString();
+}
+
+export class BoundedWebSocketSender {
+  private readonly socket: WebSocketLike;
+  private readonly label: string;
+  private readonly maxBufferedBytes: number;
+  private readonly resumeBufferedBytes: number;
+  private readonly maxQueueMessages: number;
+  private readonly maxQueueBytes: number;
+  private readonly closeCode: number;
+  private readonly closeReason: string;
+  private readonly onOverflow?: () => void;
+  private readonly logger: Pick<Console, 'warn' | 'debug'>;
+  private queue: WebSocketFrame[] = [];
+  private queuedBytes = 0;
+  private closed = false;
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(socket: WebSocketLike, options: WebSocketBackpressureOptions) {
+    this.socket = socket;
+    this.label = options.label;
+    this.maxBufferedBytes = options.maxBufferedBytes ?? DEFAULT_MAX_BUFFERED_BYTES;
+    this.resumeBufferedBytes = options.resumeBufferedBytes ?? DEFAULT_RESUME_BUFFERED_BYTES;
+    this.maxQueueMessages = options.maxQueueMessages ?? DEFAULT_MAX_QUEUE_MESSAGES;
+    this.maxQueueBytes = options.maxQueueBytes ?? DEFAULT_MAX_QUEUE_BYTES;
+    this.closeCode = options.closeCode ?? DEFAULT_CLOSE_CODE;
+    this.closeReason = options.closeReason ?? DEFAULT_CLOSE_REASON;
+    this.onOverflow = options.onOverflow;
+    this.logger = options.logger ?? console;
+  }
+
+  send(data: Buffer | string, isBinary: boolean): boolean {
+    if (this.closed || this.socket.readyState !== WebSocket.OPEN) return false;
+
+    const outbound = toOutboundData(data, isBinary);
+    const frame: WebSocketFrame = {
+      data: outbound,
+      isBinary,
+      bytes: frameBytes(outbound),
+    };
+
+    if (this.queue.length > 0 || this.socket.bufferedAmount > this.maxBufferedBytes) {
+      return this.enqueue(frame);
+    }
+
+    this.sendNow(frame);
+    return true;
+  }
+
+  drain(): void {
+    if (this.closed) return;
+    this.clearRetryTimer();
+
+    while (
+      this.queue.length > 0 &&
+      this.socket.readyState === WebSocket.OPEN &&
+      this.socket.bufferedAmount <= this.resumeBufferedBytes
+    ) {
+      const next = this.queue.shift()!;
+      this.queuedBytes -= next.bytes;
+      this.sendNow(next);
+    }
+
+    if (this.queue.length > 0) this.scheduleDrain();
+  }
+
+  dispose(): void {
+    this.closed = true;
+    this.queue = [];
+    this.queuedBytes = 0;
+    this.clearRetryTimer();
+  }
+
+  stats() {
+    return {
+      queuedMessages: this.queue.length,
+      queuedBytes: this.queuedBytes,
+      closed: this.closed,
+    };
+  }
+
+  private enqueue(frame: WebSocketFrame): boolean {
+    if (
+      this.queue.length >= this.maxQueueMessages ||
+      this.queuedBytes + frame.bytes > this.maxQueueBytes
+    ) {
+      this.closeForOverflow();
+      return false;
+    }
+
+    this.queue.push(frame);
+    this.queuedBytes += frame.bytes;
+    this.scheduleDrain();
+    return true;
+  }
+
+  private sendNow(frame: WebSocketFrame): void {
+    try {
+      this.socket.send(frame.data, { binary: frame.isBinary }, (err?: Error) => {
+        if (err) {
+          this.closeForOverflow(err.message);
+          return;
+        }
+        this.drain();
+      });
+    } catch (err) {
+      this.closeForOverflow(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  private scheduleDrain(): void {
+    if (this.retryTimer || this.closed) return;
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      this.drain();
+    }, RETRY_DRAIN_MS);
+  }
+
+  private closeForOverflow(detail?: string): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.clearRetryTimer();
+    this.queue = [];
+    this.queuedBytes = 0;
+    this.logger.warn(`[backpressure] closing ${this.label}: ${detail || this.closeReason}`);
+    this.onOverflow?.();
+    if (this.socket.readyState === WebSocket.OPEN || this.socket.readyState === WebSocket.CONNECTING) {
+      this.socket.close(this.closeCode, this.closeReason);
+    }
+  }
+
+  private clearRetryTimer(): void {
+    if (!this.retryTimer) return;
+    clearTimeout(this.retryTimer);
+    this.retryTimer = null;
+  }
+}

--- a/server/lib/ws-backpressure.ts
+++ b/server/lib/ws-backpressure.ts
@@ -141,13 +141,29 @@ export class BoundedWebSocketSender {
     try {
       this.socket.send(frame.data, { binary: frame.isBinary }, (err?: Error) => {
         if (err) {
-          this.closeForOverflow(err.message);
+          this.closeForSendError(err);
           return;
         }
         this.drain();
       });
     } catch (err) {
-      this.closeForOverflow(err instanceof Error ? err.message : String(err));
+      this.closeForSendError(err);
+    }
+  }
+
+  /** Transport-level send failure. Distinct from queue overflow — does NOT
+   *  fire `onOverflow` and closes with a generic code, not 1013. */
+  private closeForSendError(err: unknown): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.clearRetryTimer();
+    this.queue = [];
+    this.queuedBytes = 0;
+    this.logger.warn(
+      `[backpressure] send failed for ${this.label}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    if (this.socket.readyState === WebSocket.OPEN || this.socket.readyState === WebSocket.CONNECTING) {
+      this.socket.close();
     }
   }
 

--- a/server/lib/ws-proxy.ts
+++ b/server/lib/ws-proxy.ts
@@ -25,6 +25,7 @@ import { createDeviceBlock, getDeviceIdentity } from './device-identity.js';
 import { gatewayRpcCall } from './gateway-rpc.js';
 import { canInjectGatewayToken } from './trust-utils.js';
 import { isAllowedOrigin } from './origin-utils.js';
+import { BoundedWebSocketSender } from './ws-backpressure.js';
 
 /** @internal — exported for test overrides */
 export const _internals = { challengeTimeoutMs: 5_000 };
@@ -166,6 +167,15 @@ function createGatewayRelay(
   const connStartTime = Date.now();
   let clientToGatewayCount = 0;
   let gatewayToClientCount = 0;
+  let gwWs: WebSocket;
+  let gwSender: BoundedWebSocketSender | null = null;
+  const clientSender = new BoundedWebSocketSender(clientWs, {
+    label: `${tag} gateway->client`,
+    closeReason: 'Client backlog exceeded',
+    onOverflow: () => {
+      if (gwWs?.readyState === WebSocket.OPEN) gwWs.close(1013, 'Client backlog exceeded');
+    },
+  });
 
   // ─── Keepalive: ping both sides every 30s, kill dead connections ────────
   const PING_INTERVAL = 30_000;
@@ -194,7 +204,6 @@ function createGatewayRelay(
     if (gwWs?.readyState === WebSocket.OPEN) gwWs.ping();
   }, PING_INTERVAL);
 
-  let gwWs: WebSocket;
   let challengeNonce: string | null = null;
   let handshakeComplete = false;
   let useDeviceIdentity = true;
@@ -227,9 +236,9 @@ function createGatewayRelay(
 
   /** Flush buffered messages to gateway in FIFO order. */
   function flushPending(): void {
-    if (!gwWs || gwWs.readyState !== WebSocket.OPEN) return;
+    if (!gwWs || gwWs.readyState !== WebSocket.OPEN || !gwSender) return;
     for (const msg of pending) {
-      gwWs.send(msg.isBinary ? msg.data : msg.data.toString());
+      if (!sendToGateway(msg.data, msg.isBinary)) break;
     }
     pending = [];
     pendingBytes = 0;
@@ -277,9 +286,28 @@ function createGatewayRelay(
       ? injectDeviceIdentity(modified, nonce)
       : modified;
 
-    gwWs.send(JSON.stringify(final));
+    if (!sendToGateway(JSON.stringify(final), false)) return;
     handshakeComplete = true;
     flushPending();
+  }
+
+  function closeClientForGatewayBackpressure(): void {
+    if (clientWs.readyState === WebSocket.OPEN || clientWs.readyState === WebSocket.CONNECTING) {
+      clientWs.close(1013, 'Gateway backlog exceeded');
+    }
+  }
+
+  function sendToGateway(data: Buffer | string, isBinary: boolean): boolean {
+    if (!gwSender) return false;
+    const sent = gwSender.send(data, isBinary);
+    if (sent) clientToGatewayCount++;
+    return sent;
+  }
+
+  function sendToClient(data: Buffer | string, isBinary: boolean): boolean {
+    const sent = clientSender.send(data, isBinary);
+    if (sent) gatewayToClientCount++;
+    return sent;
   }
 
   /** Start a deadline timer — sends connect without identity on expiry. */
@@ -292,6 +320,8 @@ function createGatewayRelay(
   }
 
   function openGateway(): void {
+    gwSender?.dispose();
+    gwSender = null;
     gatewayAlive = true;
     challengeNonce = null;
     handshakeComplete = false;
@@ -300,6 +330,11 @@ function createGatewayRelay(
 
     gwWs = new WebSocket(targetUrl.toString(), {
       headers: { Origin: clientOrigin },
+    });
+    gwSender = new BoundedWebSocketSender(gwWs, {
+      label: `${tag} client->gateway`,
+      closeReason: 'Gateway backlog exceeded',
+      onOverflow: closeClientForGatewayBackpressure,
     });
 
     gwWs.on('pong', () => { gatewayAlive = true; });
@@ -320,10 +355,7 @@ function createGatewayRelay(
         } catch { /* ignore */ }
       }
 
-      if (clientWs.readyState === WebSocket.OPEN) {
-        gatewayToClientCount++;
-        clientWs.send(isBinary ? data : data.toString());
-      }
+      if (clientWs.readyState === WebSocket.OPEN) sendToClient(data, isBinary);
     });
 
     gwWs.on('open', () => {
@@ -449,17 +481,17 @@ function createGatewayRelay(
           gatewayCall(msg.method, msg.params || {})
             .then((result) => {
               if (clientWs.readyState === WebSocket.OPEN) {
-                clientWs.send(JSON.stringify({ type: 'res', id: reqId, ok: true, payload: result }));
+                sendToClient(JSON.stringify({ type: 'res', id: reqId, ok: true, payload: result }), false);
               }
             })
             .catch((err) => {
               if (clientWs.readyState === WebSocket.OPEN) {
-                clientWs.send(JSON.stringify({
+                sendToClient(JSON.stringify({
                   type: 'res',
                   id: reqId,
                   ok: false,
                   error: { code: -32000, message: (err as Error).message },
-                }));
+                }), false);
               }
             });
           return;
@@ -467,13 +499,14 @@ function createGatewayRelay(
       } catch { /* pass through */ }
     }
 
-    clientToGatewayCount++;
-    gwWs.send(isBinary ? data : data.toString());
+    sendToGateway(data, isBinary);
   });
 
   clientWs.on('close', (code, reason) => {
     clearInterval(pingTimer);
     clearChallengeTimer();
+    clientSender.dispose();
+    gwSender?.dispose();
     const duration = Date.now() - connStartTime;
     console.log(`${tag} Client closed: code=${code}, reason=${reason?.toString()}`);
     console.log(`${tag} Summary: duration=${duration}ms, client->gw=${clientToGatewayCount}, gw->client=${gatewayToClientCount}`);
@@ -482,6 +515,8 @@ function createGatewayRelay(
   clientWs.on('error', (err) => {
     clearInterval(pingTimer);
     clearChallengeTimer();
+    clientSender.dispose();
+    gwSender?.dispose();
     console.error(`${tag} Client error:`, err.message);
     if (gwWs) gwWs.close();
   });

--- a/server/lib/ws-proxy.ts
+++ b/server/lib/ws-proxy.ts
@@ -234,14 +234,18 @@ function createGatewayRelay(
     return true;
   }
 
-  /** Flush buffered messages to gateway in FIFO order. */
+  /** Flush buffered messages to gateway in FIFO order. Preserves the unsent tail
+   *  if `sendToGateway` returns false (e.g., backpressure), so frames aren't dropped. */
   function flushPending(): void {
     if (!gwWs || gwWs.readyState !== WebSocket.OPEN || !gwSender) return;
-    for (const msg of pending) {
+    let flushed = 0;
+    while (flushed < pending.length) {
+      const msg = pending[flushed]!;
       if (!sendToGateway(msg.data, msg.isBinary)) break;
+      pendingBytes -= typeof msg.data === 'string' ? Buffer.byteLength(msg.data) : msg.data.length;
+      flushed++;
     }
-    pending = [];
-    pendingBytes = 0;
+    pending = pending.slice(flushed);
   }
 
   /** Clear the challenge nonce timeout if active. */

--- a/server/routes/events.ts
+++ b/server/routes/events.ts
@@ -15,6 +15,7 @@ import { Hono } from 'hono';
 import { streamSSE } from 'hono/streaming';
 import { EventEmitter } from 'node:events';
 import { randomUUID } from 'node:crypto';
+import { BoundedSSEWriter } from '../lib/sse-backpressure.js';
 
 const app = new Hono();
 
@@ -71,46 +72,49 @@ app.get('/api/events', async (c) => {
     const tag = `[sse:${clientId}]`;
     let connected = true;
     let resolveDisconnect: (() => void) | undefined;
+    let writer: BoundedSSEWriter | null = null;
+    let pingTimer: ReturnType<typeof setInterval> | null = null;
 
     _sseClients.set(clientId, { connectedAt: Date.now() });
     console.log(`${tag} Client connected (active=${_sseClients.size})`);
 
     const onMessage = (payload: SSEEvent) => {
       if (!connected) return;
-      try {
-        stream.writeSSE({ event: payload.event, data: JSON.stringify(payload) });
-      } catch {
-        disconnect();
-      }
+      writer?.enqueue({ event: payload.event, data: JSON.stringify(payload) });
     };
 
-    function disconnect() {
+    function disconnect(reason = 'client disconnect') {
       if (!connected) return;
       connected = false;
-      clearInterval(pingTimer);
+      if (pingTimer) clearInterval(pingTimer);
       broadcaster.off('message', onMessage);
       _sseClients.delete(clientId);
-      console.log(`${tag} Client disconnected (active=${_sseClients.size})`);
+      writer?.close();
+      console.log(`${tag} Client disconnected: ${reason} (active=${_sseClients.size})`);
       resolveDisconnect?.();
     }
 
+    writer = new BoundedSSEWriter(stream, {
+      label: tag,
+      onDisconnect: disconnect,
+    });
+
     broadcaster.on('message', onMessage);
 
-    await stream.writeSSE({
+    writer.enqueue({
       event: 'connected',
       data: JSON.stringify({ event: 'connected', ts: Date.now() }),
     });
 
-    const pingTimer = setInterval(() => {
-      if (!connected) { clearInterval(pingTimer); return; }
-      try {
-        stream.writeSSE({ event: 'ping', data: JSON.stringify({ event: 'ping', ts: Date.now() }) });
-      } catch {
-        disconnect();
+    pingTimer = setInterval(() => {
+      if (!connected) {
+        if (pingTimer) clearInterval(pingTimer);
+        return;
       }
+      writer?.enqueue({ event: 'ping', data: JSON.stringify({ event: 'ping', ts: Date.now() }) });
     }, PING_INTERVAL_MS);
 
-    stream.onAbort(() => disconnect());
+    stream.onAbort(() => disconnect('abort'));
 
     // Keep stream open until client disconnects (no polling needed)
     await new Promise<void>((resolve) => {


### PR DESCRIPTION
## Summary
- add bounded WebSocket relay senders for gateway->client and client->gateway traffic
- close slow peers with 1013 once buffered/queued traffic exceeds caps instead of allowing unbounded memory growth
- add a serialized bounded SSE writer with queue caps and write timeouts for slow EventSource clients

## Validation
- npm exec vitest -- run server/lib/ws-backpressure.test.ts server/lib/sse-backpressure.test.ts server/lib/ws-proxy.test.ts server/routes/events.test.ts src/hooks/useWebSocket.test.ts src/hooks/useServerEvents.test.ts
- npm run lint
- npm test -- --run
- npm run build
- git diff --check

Note: the production build still reports the existing bundle-splitting warnings from origin/next; that repair is isolated in PR #336.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced server connection handling with backpressure management for both WebSocket and Server-Sent Events streams to improve stability under high-load conditions.
  * Implemented queue overflow detection and graceful connection cleanup on timeout or buffer limits exceeded.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daggerhashimoto/openclaw-nerve/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->