### PR TITLE
perf: bound file browser tree rendering

### DIFF
--- a/server/routes/file-browser.test.ts
+++ b/server/routes/file-browser.test.ts
@@ -144,6 +144,47 @@ describe('file-browser routes', () => {
       expect(names).toContain('.plans');
     });
 
+    it('caps tree responses and reports pagination metadata', async () => {
+      for (let index = 0; index < 12; index += 1) {
+        await fs.writeFile(path.join(tmpDir, `file-${String(index).padStart(2, '0')}.txt`), 'x');
+      }
+
+      const app = await buildApp();
+      const firstPage = await app.request('/api/files/tree?limit=5');
+      expect(firstPage.status).toBe(200);
+      const firstJson = (await firstPage.json()) as {
+        ok: boolean;
+        entries: Array<{ name: string }>;
+        totalEntries: number;
+        returnedEntries: number;
+        limit: number;
+        cursor: number;
+        truncated: boolean;
+        nextCursor?: string;
+      };
+
+      expect(firstJson.ok).toBe(true);
+      expect(firstJson.entries).toHaveLength(5);
+      expect(firstJson.returnedEntries).toBe(5);
+      expect(firstJson.totalEntries).toBeGreaterThan(5);
+      expect(firstJson.limit).toBe(5);
+      expect(firstJson.cursor).toBe(0);
+      expect(firstJson.truncated).toBe(true);
+      expect(firstJson.nextCursor).toBe('5');
+
+      const secondPage = await app.request(`/api/files/tree?limit=5&cursor=${firstJson.nextCursor}`);
+      expect(secondPage.status).toBe(200);
+      const secondJson = (await secondPage.json()) as {
+        entries: Array<{ name: string }>;
+        cursor: number;
+      };
+
+      expect(secondJson.cursor).toBe(5);
+      expect(secondJson.entries.map((entry) => entry.name)).not.toEqual(
+        firstJson.entries.map((entry) => entry.name),
+      );
+    });
+
     it('includes hidden workspace entries when showHidden=true via remote gateway fallback', async () => {
       const app = await buildApp({
         remote: true,

--- a/server/routes/file-browser.ts
+++ b/server/routes/file-browser.ts
@@ -425,15 +425,20 @@ app.get('/api/files/tree', async (c) => {
   try {
     const remoteFiles = await gatewayFilesList(workspace.agentId);
     const entries = gatewayFilesToTree(remoteFiles, showHidden);
+    const start = Math.min(cursor, entries.length);
+    const pagedEntries = entries.slice(start, start + limit);
+    const nextCursor =
+      start + pagedEntries.length < entries.length ? String(start + pagedEntries.length) : undefined;
     return c.json({
       ok: true,
       root: '.',
-      entries,
+      entries: pagedEntries,
       totalEntries: entries.length,
-      returnedEntries: entries.length,
+      returnedEntries: pagedEntries.length,
       limit,
-      cursor: 0,
-      truncated: false,
+      cursor: start,
+      truncated: Boolean(nextCursor),
+      ...(nextCursor ? { nextCursor } : {}),
       remoteWorkspace: true,
       workspaceInfo: {
         isCustomWorkspace: workspace.isCustomWorkspace,

--- a/server/routes/file-browser.ts
+++ b/server/routes/file-browser.ts
@@ -18,6 +18,7 @@
 import { Hono, type Context } from 'hono';
 import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
+import type { Dirent } from 'node:fs';
 import { Readable } from 'node:stream';
 import path from 'node:path';
 import {
@@ -59,6 +60,26 @@ interface ScopedWorkspace {
   isCustomWorkspace: boolean;
 }
 
+interface DirectoryListing {
+  entries: TreeEntry[];
+  totalEntries: number;
+  returnedEntries: number;
+  limit: number;
+  cursor: number;
+  truncated: boolean;
+  nextCursor?: string;
+}
+
+interface ListingBudget {
+  remaining: number;
+  truncated: boolean;
+}
+
+const DEFAULT_TREE_LIMIT = 1_000;
+const MAX_TREE_LIMIT = 5_000;
+const MAX_TREE_RESPONSE_ENTRIES = 5_000;
+const STAT_CONCURRENCY = 16;
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 function resolveScopedWorkspace(agentId?: string): ScopedWorkspace {
@@ -87,72 +108,178 @@ function handleAgentWorkspaceError(c: Context, err: unknown) {
   return c.json({ ok: false, error: message }, 500);
 }
 
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function parseTreeLimit(value: string | undefined): number {
+  return Math.min(parsePositiveInt(value, DEFAULT_TREE_LIMIT), MAX_TREE_LIMIT);
+}
+
+function parseTreeCursor(value: string | undefined): number {
+  return parsePositiveInt(value, 0);
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      results[currentIndex] = await mapper(items[currentIndex]!);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+}
+
+function shouldIncludeDirent(item: Dirent, basePath: string, showHidden: boolean): boolean {
+  if (isExcluded(item.name)) return false;
+
+  const inTrash = basePath === '.trash' || basePath.startsWith('.trash/');
+  if (inTrash) {
+    return item.name !== '.index.json';
+  }
+
+  if (!showHidden && item.name.startsWith('.') && item.name !== '.nerveignore' && item.name !== '.trash') {
+    return false;
+  }
+
+  return !(config.fileBrowserRoot && item.name === '.trash');
+}
+
+async function listDirectoryPage(
+  dirPath: string,
+  basePath: string,
+  depth: number,
+  showHidden: boolean,
+  options: {
+    cursor: number;
+    limit: number;
+    budget: ListingBudget;
+  },
+): Promise<DirectoryListing> {
+  let items;
+  try {
+    items = await fs.readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return {
+      entries: [],
+      totalEntries: 0,
+      returnedEntries: 0,
+      limit: options.limit,
+      cursor: options.cursor,
+      truncated: false,
+    };
+  }
+
+  const visibleItems = items
+    .filter((item) => shouldIncludeDirent(item, basePath, showHidden))
+    // Sort: directories first, then alphabetical (case-insensitive)
+    .sort((a, b) => {
+      if (a.isDirectory() !== b.isDirectory()) return a.isDirectory() ? -1 : 1;
+      return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+    });
+
+  const totalEntries = visibleItems.length;
+  const start = Math.min(options.cursor, totalEntries);
+  const pageItems = visibleItems.slice(start, start + options.limit);
+  const nextCursor = start + pageItems.length < totalEntries ? String(start + pageItems.length) : undefined;
+  const entries: TreeEntry[] = [];
+
+  const directories = pageItems.filter((item) => item.isDirectory());
+  const files = pageItems.filter((item) => item.isFile());
+
+  for (const item of directories) {
+    if (options.budget.remaining <= 0) {
+      options.budget.truncated = true;
+      break;
+    }
+    options.budget.remaining -= 1;
+    const relativePath = basePath ? path.join(basePath, item.name) : item.name;
+    const fullPath = path.join(dirPath, item.name);
+
+    const childListing = depth > 1
+      ? await listDirectoryPage(fullPath, relativePath, depth - 1, showHidden, {
+          cursor: 0,
+          limit: options.limit,
+          budget: options.budget,
+        })
+      : null;
+
+    entries.push({
+      name: item.name,
+      path: relativePath,
+      type: 'directory',
+      children: childListing?.entries ?? null,
+    });
+  }
+
+  const allowedFileCount = Math.min(files.length, Math.max(0, options.budget.remaining));
+  if (allowedFileCount < files.length) {
+    options.budget.truncated = true;
+  }
+  options.budget.remaining -= allowedFileCount;
+
+  const fileEntries = await mapWithConcurrency<Dirent, TreeEntry | null>(
+    files.slice(0, allowedFileCount),
+    STAT_CONCURRENCY,
+    async (item) => {
+      const relativePath = basePath ? path.join(basePath, item.name) : item.name;
+      const fullPath = path.join(dirPath, item.name);
+      try {
+        const stat = await fs.stat(fullPath);
+        return {
+          name: item.name,
+          path: relativePath,
+          type: 'file' as const,
+          size: stat.size,
+          mtime: Math.floor(stat.mtimeMs),
+          binary: isBinary(item.name) || undefined,
+        };
+      } catch {
+        return null;
+      }
+    },
+  );
+
+  entries.push(...fileEntries.filter((entry): entry is TreeEntry => Boolean(entry)));
+
+  return {
+    entries,
+    totalEntries,
+    returnedEntries: entries.length,
+    limit: options.limit,
+    cursor: start,
+    truncated: Boolean(nextCursor) || options.budget.truncated,
+    nextCursor,
+  };
+}
+
 async function listDirectory(
   dirPath: string,
   basePath: string,
   depth: number,
   showHidden: boolean,
-): Promise<TreeEntry[]> {
-  const entries: TreeEntry[] = [];
-
-  let items;
-  try {
-    items = await fs.readdir(dirPath, { withFileTypes: true });
-  } catch {
-    return entries;
-  }
-
-  // Sort: directories first, then alphabetical (case-insensitive)
-  items.sort((a, b) => {
-    if (a.isDirectory() !== b.isDirectory()) return a.isDirectory() ? -1 : 1;
-    return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+  cursor: number,
+  limit: number,
+): Promise<DirectoryListing> {
+  return listDirectoryPage(dirPath, basePath, depth, showHidden, {
+    cursor,
+    limit,
+    budget: {
+      remaining: MAX_TREE_RESPONSE_ENTRIES,
+      truncated: false,
+    },
   });
-
-  for (const item of items) {
-    // Skip excluded names and hidden files (except specific ones)
-    if (isExcluded(item.name)) continue;
-
-    const inTrash = basePath === '.trash' || basePath.startsWith('.trash/');
-    if (inTrash) {
-      // Internal metadata file for restore bookkeeping.
-      if (item.name === '.index.json') continue;
-    // Hide dotfiles unless showHidden=true, except for .nerveignore and .trash; custom roots still hide .trash.
-    } else if (!showHidden && item.name.startsWith('.') && item.name !== '.nerveignore' && item.name !== '.trash') {
-      continue;
-    } else if (config.fileBrowserRoot && item.name === '.trash') {
-      continue;
-    }
-
-    const relativePath = basePath ? path.join(basePath, item.name) : item.name;
-    const fullPath = path.join(dirPath, item.name);
-
-    if (item.isDirectory()) {
-      entries.push({
-        name: item.name,
-        path: relativePath,
-        type: 'directory',
-        children: depth > 1
-          ? await listDirectory(fullPath, relativePath, depth - 1, showHidden)
-          : null,
-      });
-    } else if (item.isFile()) {
-      try {
-        const stat = await fs.stat(fullPath);
-        entries.push({
-          name: item.name,
-          path: relativePath,
-          type: 'file',
-          size: stat.size,
-          mtime: Math.floor(stat.mtimeMs),
-          binary: isBinary(item.name) || undefined,
-        });
-      } catch {
-        // Skip files we can't stat
-      }
-    }
-  }
-
-  return entries;
 }
 
 function handleFileOpError(c: Context, err: unknown) {
@@ -226,6 +353,8 @@ app.get('/api/files/tree', async (c) => {
   const root = workspace.workspaceRoot;
   const subPath = c.req.query('path') || '';
   const depth = Math.min(Math.max(Number(c.req.query('depth')) || 1, 1), 5);
+  const limit = parseTreeLimit(c.req.query('limit'));
+  const cursor = parseTreeCursor(c.req.query('cursor'));
   const showHidden = c.req.query('showHidden') === 'true';
 
   // Check if workspace is local
@@ -254,12 +383,18 @@ app.get('/api/files/tree', async (c) => {
       targetDir = root;
     }
 
-    const entries = await listDirectory(targetDir, subPath, depth, showHidden);
+    const listing = await listDirectory(targetDir, subPath, depth, showHidden, cursor, limit);
 
     return c.json({
       ok: true,
       root: subPath || '.',
-      entries,
+      entries: listing.entries,
+      totalEntries: listing.totalEntries,
+      returnedEntries: listing.returnedEntries,
+      limit: listing.limit,
+      cursor: listing.cursor,
+      truncated: listing.truncated,
+      nextCursor: listing.nextCursor,
       workspaceInfo: {
         isCustomWorkspace: workspace.isCustomWorkspace,
         rootPath: root,
@@ -274,6 +409,11 @@ app.get('/api/files/tree', async (c) => {
       ok: true,
       root: subPath,
       entries: [],
+      totalEntries: 0,
+      returnedEntries: 0,
+      limit,
+      cursor,
+      truncated: false,
       remoteWorkspace: true,
       workspaceInfo: {
         isCustomWorkspace: workspace.isCustomWorkspace,
@@ -289,6 +429,11 @@ app.get('/api/files/tree', async (c) => {
       ok: true,
       root: '.',
       entries,
+      totalEntries: entries.length,
+      returnedEntries: entries.length,
+      limit,
+      cursor: 0,
+      truncated: false,
       remoteWorkspace: true,
       workspaceInfo: {
         isCustomWorkspace: workspace.isCustomWorkspace,
@@ -301,6 +446,11 @@ app.get('/api/files/tree', async (c) => {
       ok: true,
       root: '.',
       entries: [],
+      totalEntries: 0,
+      returnedEntries: 0,
+      limit,
+      cursor: 0,
+      truncated: false,
       remoteWorkspace: true,
       workspaceInfo: {
         isCustomWorkspace: workspace.isCustomWorkspace,

--- a/src/features/file-browser/FileTreeNode.tsx
+++ b/src/features/file-browser/FileTreeNode.tsx
@@ -30,6 +30,7 @@ interface FileTreeNodeProps {
   onRenameChange: (value: string) => void;
   onRenameCommit: () => void;
   onRenameCancel: () => void;
+  renderChildren?: boolean;
   compact?: boolean;
   onOpenActions?: (entry: TreeEntry, anchorRect: DOMRect) => void;
 }
@@ -57,6 +58,7 @@ export function FileTreeNode({
   onRenameChange,
   onRenameCommit,
   onRenameCancel,
+  renderChildren = true,
   compact,
   onOpenActions,
 }: FileTreeNodeProps) {
@@ -276,7 +278,7 @@ export function FileTreeNode({
       </div>
 
       {/* Children */}
-      {isDir && isExpanded && entry.children && (
+      {renderChildren && isDir && isExpanded && entry.children && (
         <div role="group">
           {entry.children.map((child) => (
             <FileTreeNode

--- a/src/features/file-browser/FileTreePanel.test.tsx
+++ b/src/features/file-browser/FileTreePanel.test.tsx
@@ -149,6 +149,32 @@ describe('FileTreePanel', () => {
 
       expect(revealPath).toHaveBeenCalledTimes(1);
     });
+
+    it('virtualizes large root lists instead of rendering every row', () => {
+      const entries = Array.from({ length: 120 }, (_, index) => ({
+        name: `file-${String(index).padStart(3, '0')}.txt`,
+        path: `file-${String(index).padStart(3, '0')}.txt`,
+        type: 'file' as const,
+        children: null,
+      }));
+      mockUseFileTree.mockReturnValue({
+        ...defaultMockHook,
+        entries,
+      });
+
+      render(
+        <FileTreePanel
+          workspaceAgentId="main"
+          onOpenFile={mockOnOpenFile}
+          onRemapOpenPaths={mockOnRemapOpenPaths}
+          onCloseOpenPaths={mockOnCloseOpenPaths}
+          collapsed={false}
+        />,
+      );
+
+      expect(screen.getByText('file-000.txt')).toBeInTheDocument();
+      expect(screen.queryByText('file-119.txt')).toBeNull();
+    });
   });
 
   describe('header display', () => {

--- a/src/features/file-browser/FileTreePanel.tsx
+++ b/src/features/file-browser/FileTreePanel.tsx
@@ -5,10 +5,15 @@
  * Double-click a file to open it as an editor tab.
  */
 
-import { useRef, useState, useCallback, useEffect } from 'react';
+import { useRef, useState, useCallback, useEffect, useMemo } from 'react';
 import { PanelLeftClose, RefreshCw, X } from 'lucide-react';
 import { FileTreeNode } from './FileTreeNode';
 import { buildFileTreeMenuActions } from './fileTreeMenuActions';
+import {
+  FILE_TREE_OVERSCAN_ROWS,
+  FILE_TREE_ROW_HEIGHT,
+  flattenVisibleFileTree,
+} from './fileTreeRows';
 import { useFileTree } from './hooks/useFileTree';
 import { ConfirmDialog } from '../../components/ConfirmDialog';
 import { useSettings } from '@/contexts/SettingsContext';
@@ -146,16 +151,41 @@ export function FileTreePanel({
   }, [revealPath, revealRequest, workspaceAgentId]);
 
   const panelRef = useRef<HTMLDivElement>(null);
+  const treeScrollRef = useRef<HTMLDivElement>(null);
   const widthRef = useRef(loadWidth());
   const draggingRef = useRef(false);
   const [width, setWidth] = useState(() => {
     return collapsed ? COLLAPSED_WIDTH : loadWidth();
   });
+  const [treeScrollTop, setTreeScrollTop] = useState(0);
+  const [treeViewportHeight, setTreeViewportHeight] = useState(0);
 
   // Handle external collapsed state changes (e.g., from mobile button)
   useEffect(() => {
     const targetWidth = collapsed ? COLLAPSED_WIDTH : widthRef.current;
     setWidth(targetWidth);
+  }, [collapsed]);
+
+  useEffect(() => {
+    const scrollEl = treeScrollRef.current;
+    if (!scrollEl) return undefined;
+
+    const updateViewport = () => {
+      setTreeViewportHeight(scrollEl.clientHeight);
+    };
+
+    updateViewport();
+
+    const resizeObserver = typeof ResizeObserver !== 'undefined'
+      ? new ResizeObserver(updateViewport)
+      : null;
+    resizeObserver?.observe(scrollEl);
+    window.addEventListener('resize', updateViewport);
+
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener('resize', updateViewport);
+    };
   }, [collapsed]);
 
   const [contextMenu, setContextMenu] = useState<ScopedContextMenu | null>(null);
@@ -237,6 +267,42 @@ export function FileTreePanel({
   const visibleRenameState = renameState?.agentId === workspaceAgentId ? renameState : null;
   const visibleDragSource = dragSource?.agentId === workspaceAgentId ? dragSource.entry : null;
   const visibleDropTargetPath = dropTargetPath?.agentId === workspaceAgentId ? dropTargetPath.path : null;
+  const flatRows = useMemo(() => flattenVisibleFileTree(entries, expandedPaths), [entries, expandedPaths]);
+  const rawStartIndex = Math.floor(treeScrollTop / FILE_TREE_ROW_HEIGHT) - FILE_TREE_OVERSCAN_ROWS;
+  const maxStartIndex = Math.max(0, flatRows.length - 1);
+  const visibleStartIndex = Math.min(maxStartIndex, Math.max(0, rawStartIndex));
+  const visibleCapacity = treeViewportHeight > 0
+    ? Math.ceil(treeViewportHeight / FILE_TREE_ROW_HEIGHT) + FILE_TREE_OVERSCAN_ROWS * 2
+    : 80;
+  const visibleEndIndex = Math.min(flatRows.length, visibleStartIndex + visibleCapacity);
+  const virtualRows = flatRows.slice(visibleStartIndex, visibleEndIndex);
+  const virtualTreeHeight = flatRows.length * FILE_TREE_ROW_HEIGHT;
+
+  useEffect(() => {
+    if (!selectedPath) return;
+    const scrollEl = treeScrollRef.current;
+    if (!scrollEl) return;
+
+    const selectedIndex = flatRows.findIndex((row) => row.entry.path === selectedPath);
+    if (selectedIndex < 0) return;
+
+    const viewportHeight = scrollEl.clientHeight || treeViewportHeight;
+    if (viewportHeight <= 0) return;
+
+    const rowTop = selectedIndex * FILE_TREE_ROW_HEIGHT;
+    const rowBottom = rowTop + FILE_TREE_ROW_HEIGHT;
+    const currentTop = scrollEl.scrollTop;
+    const currentBottom = currentTop + viewportHeight;
+
+    if (rowTop < currentTop) {
+      scrollEl.scrollTop = rowTop;
+      setTreeScrollTop(rowTop);
+    } else if (rowBottom > currentBottom) {
+      const nextTop = rowBottom - viewportHeight;
+      scrollEl.scrollTop = nextTop;
+      setTreeScrollTop(nextTop);
+    }
+  }, [flatRows, selectedPath, treeViewportHeight]);
 
   useEffect(() => {
     workspaceAgentIdRef.current = workspaceAgentId;
@@ -811,7 +877,13 @@ export function FileTreePanel({
         </div>
 
         {/* Tree content */}
-        <div className="flex-1 overflow-y-auto overflow-x-hidden py-1" role="tree" aria-label="File explorer">
+        <div
+          ref={treeScrollRef}
+          className="flex-1 overflow-y-auto overflow-x-hidden py-1"
+          role="tree"
+          aria-label="File explorer"
+          onScroll={(event) => setTreeScrollTop(event.currentTarget.scrollTop)}
+        >
           {loading ? (
             <div className="flex items-center gap-2 px-3 py-4 text-xs text-muted-foreground">
               <RefreshCw className="animate-spin" size={12} />
@@ -832,35 +904,46 @@ export function FileTreePanel({
               Empty workspace
             </div>
           ) : (
-            entries.map((entry) => (
-              <FileTreeNode
-                key={entry.path}
-                entry={entry}
-                depth={0}
-                expandedPaths={expandedPaths}
-                selectedPath={selectedPath}
-                loadingPaths={loadingPaths}
-                onToggleDir={toggleDirectory}
-                onOpenFile={onOpenFile}
-                onTouchLongPress={isCompactLayout ? undefined : openTouchContextMenu}
-                onSelect={selectFile}
-                onContextMenu={handleContextMenu}
-                dragSourcePath={visibleDragSource?.path || null}
-                dropTargetPath={visibleDropTargetPath}
-                onDragStart={handleDragStart}
-                onDragEnd={handleDragEnd}
-                onDragOverDirectory={handleDragOverDirectory}
-                onDragLeaveDirectory={handleDragLeaveDirectory}
-                onDropDirectory={handleDropDirectory}
-                renamingPath={visibleRenameState?.path || null}
-                renameValue={visibleRenameState?.value || ''}
-                onRenameChange={handleRenameChange}
-                onRenameCommit={() => { void commitRename(); }}
-                onRenameCancel={cancelRename}
-                compact={isCompactLayout}
-                onOpenActions={openCompactActionsMenu}
-              />
-            ))
+            <div className="relative" style={{ height: virtualTreeHeight }}>
+              {virtualRows.map((row) => (
+                <div
+                  key={row.entry.path}
+                  className="absolute left-0 right-0"
+                  style={{
+                    top: row.index * FILE_TREE_ROW_HEIGHT,
+                    height: FILE_TREE_ROW_HEIGHT,
+                  }}
+                >
+                  <FileTreeNode
+                    entry={row.entry}
+                    depth={row.depth}
+                    expandedPaths={expandedPaths}
+                    selectedPath={selectedPath}
+                    loadingPaths={loadingPaths}
+                    onToggleDir={toggleDirectory}
+                    onOpenFile={onOpenFile}
+                    onTouchLongPress={isCompactLayout ? undefined : openTouchContextMenu}
+                    onSelect={selectFile}
+                    onContextMenu={handleContextMenu}
+                    dragSourcePath={visibleDragSource?.path || null}
+                    dropTargetPath={visibleDropTargetPath}
+                    onDragStart={handleDragStart}
+                    onDragEnd={handleDragEnd}
+                    onDragOverDirectory={handleDragOverDirectory}
+                    onDragLeaveDirectory={handleDragLeaveDirectory}
+                    onDropDirectory={handleDropDirectory}
+                    renamingPath={visibleRenameState?.path || null}
+                    renameValue={visibleRenameState?.value || ''}
+                    onRenameChange={handleRenameChange}
+                    onRenameCommit={() => { void commitRename(); }}
+                    onRenameCancel={cancelRename}
+                    renderChildren={false}
+                    compact={isCompactLayout}
+                    onOpenActions={openCompactActionsMenu}
+                  />
+                </div>
+              ))}
+            </div>
           )}
         </div>
       </div>

--- a/src/features/file-browser/fileTreeRows.test.ts
+++ b/src/features/file-browser/fileTreeRows.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { flattenVisibleFileTree } from './fileTreeRows';
+import type { TreeEntry } from './types';
+
+const tree: TreeEntry[] = [
+  {
+    name: 'src',
+    path: 'src',
+    type: 'directory',
+    children: [
+      {
+        name: 'components',
+        path: 'src/components',
+        type: 'directory',
+        children: [
+          { name: 'Button.tsx', path: 'src/components/Button.tsx', type: 'file' },
+        ],
+      },
+      { name: 'main.ts', path: 'src/main.ts', type: 'file' },
+    ],
+  },
+  { name: 'README.md', path: 'README.md', type: 'file' },
+];
+
+describe('flattenVisibleFileTree', () => {
+  it('derives a depth-aware visible row list from expanded paths', () => {
+    const rows = flattenVisibleFileTree(tree, new Set(['src', 'src/components']));
+
+    expect(rows.map((row) => [row.entry.path, row.depth])).toEqual([
+      ['src', 0],
+      ['src/components', 1],
+      ['src/components/Button.tsx', 2],
+      ['src/main.ts', 1],
+      ['README.md', 0],
+    ]);
+  });
+
+  it('does not include collapsed descendants', () => {
+    const rows = flattenVisibleFileTree(tree, new Set(['src']));
+
+    expect(rows.map((row) => row.entry.path)).toEqual([
+      'src',
+      'src/components',
+      'src/main.ts',
+      'README.md',
+    ]);
+  });
+
+  it('caps generated rows for very large expanded trees', () => {
+    const rows = flattenVisibleFileTree(tree, new Set(['src', 'src/components']), 3);
+
+    expect(rows.map((row) => row.entry.path)).toEqual([
+      'src',
+      'src/components',
+      'src/components/Button.tsx',
+    ]);
+  });
+});

--- a/src/features/file-browser/fileTreeRows.ts
+++ b/src/features/file-browser/fileTreeRows.ts
@@ -1,0 +1,38 @@
+import type { TreeEntry } from './types';
+
+export const FILE_TREE_ROW_HEIGHT = 24;
+export const FILE_TREE_OVERSCAN_ROWS = 8;
+export const MAX_VISIBLE_FILE_TREE_ROWS = 10_000;
+
+export interface FileTreeRow {
+  entry: TreeEntry;
+  depth: number;
+  index: number;
+}
+
+export function flattenVisibleFileTree(
+  entries: TreeEntry[],
+  expandedPaths: Set<string>,
+  maxRows = MAX_VISIBLE_FILE_TREE_ROWS,
+): FileTreeRow[] {
+  const rows: FileTreeRow[] = [];
+  const stack = entries
+    .slice()
+    .reverse()
+    .map((entry) => ({ entry, depth: 0 }));
+
+  while (stack.length > 0 && rows.length < maxRows) {
+    const { entry, depth } = stack.pop()!;
+    rows.push({ entry, depth, index: rows.length });
+
+    if (entry.type !== 'directory' || !expandedPaths.has(entry.path) || !entry.children?.length) {
+      continue;
+    }
+
+    for (let index = entry.children.length - 1; index >= 0; index -= 1) {
+      stack.push({ entry: entry.children[index]!, depth: depth + 1 });
+    }
+  }
+
+  return rows;
+}

--- a/src/features/file-browser/hooks/useFileTree.test.ts
+++ b/src/features/file-browser/hooks/useFileTree.test.ts
@@ -420,6 +420,57 @@ describe('useFileTree', () => {
       expect(mockLocalStorage.getItem).toHaveBeenCalledWith(getWorkspaceStorageKey('file-tree-expanded', 'main'));
     });
 
+    it('bounds persisted expansion hydration for large restored trees', async () => {
+      const mockLocalStorage = vi.mocked(localStorage);
+      const expandedDirs = Array.from({ length: 70 }, (_, index) => `dir-${String(index).padStart(3, '0')}`);
+      mockLocalStorage.getItem.mockImplementation((key: string) => {
+        if (key === getWorkspaceStorageKey('file-tree-expanded', 'main')) return JSON.stringify(expandedDirs);
+        return null;
+      });
+
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockImplementation(async (input) => {
+        const url = getRequestUrl(input);
+        const requestedPath = url.searchParams.get('path');
+
+        if (!requestedPath) {
+          return {
+            ok: true,
+            json: async () => ({
+              ok: true,
+              entries: expandedDirs.map((dir) => ({
+                name: dir,
+                path: dir,
+                type: 'directory' as const,
+                children: null,
+              })),
+              workspaceInfo: { isCustomWorkspace: false, rootPath: '/workspace' },
+            }),
+          } as Response;
+        }
+
+        return {
+          ok: true,
+          json: async () => ({ ok: true, entries: [] }),
+        } as Response;
+      });
+
+      const { result } = renderHook(() => useFileTree('main'));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      const hydratedPaths = mockFetch.mock.calls
+        .map((call) => getRequestUrl(call[0]).searchParams.get('path'))
+        .filter(Boolean);
+
+      expect(hydratedPaths).toHaveLength(64);
+      expect(result.current.expandedPaths.size).toBe(64);
+      expect(result.current.expandedPaths.has('dir-063')).toBe(true);
+      expect(result.current.expandedPaths.has('dir-064')).toBe(false);
+    });
+
     it('includes showHidden in tree requests when enabled', async () => {
       const mockFetch = vi.mocked(fetch);
       mockFetch.mockResolvedValue({

--- a/src/features/file-browser/hooks/useFileTree.ts
+++ b/src/features/file-browser/hooks/useFileTree.ts
@@ -3,6 +3,8 @@ import { getWorkspaceStorageKey } from '@/features/workspace/workspaceScope';
 import type { TreeEntry } from '../types';
 
 const DEFAULT_AGENT_ID = 'main';
+const MAX_RESTORED_EXPANDED_PATHS = 64;
+const RESTORE_EXPANSION_CONCURRENCY = 4;
 
 function normalizeAgentId(agentId?: string): string {
   return agentId?.trim() || DEFAULT_AGENT_ID;
@@ -87,22 +89,64 @@ function clearEntryFromTree(entries: TreeEntry[], targetPath: string): TreeEntry
   });
 }
 
-function findEntry(entries: TreeEntry[], targetPath: string): TreeEntry | null {
-  for (const entry of entries) {
-    if (entry.path === targetPath) return entry;
-    if (entry.type === 'directory' && entry.children) {
-      const found = findEntry(entry.children, targetPath);
-      if (found) return found;
-    }
-  }
-  return null;
-}
-
 function buildTreeUrl(dirPath: string, agentId: string, showHiddenEntries: boolean): string {
   const params = new URLSearchParams({ depth: '1', agentId });
   if (showHiddenEntries) params.set('showHidden', 'true');
   if (dirPath) params.set('path', dirPath);
   return `/api/files/tree?${params.toString()}`;
+}
+
+function pathDepth(path: string): number {
+  return path.split('/').filter(Boolean).length;
+}
+
+function orderedExpansionPaths(paths: Set<string>): string[] {
+  return [...paths]
+    .map((path, index) => ({ path, index }))
+    .sort((a, b) => {
+      const depthDiff = pathDepth(a.path) - pathDepth(b.path);
+      return depthDiff || a.index - b.index;
+    })
+    .map((entry) => entry.path);
+}
+
+function limitRestoredExpandedPaths(paths: Set<string>): Set<string> {
+  if (paths.size <= MAX_RESTORED_EXPANDED_PATHS) return paths;
+  return new Set(orderedExpansionPaths(paths).slice(0, MAX_RESTORED_EXPANDED_PATHS));
+}
+
+function indexEntries(entries: TreeEntry[]): Map<string, TreeEntry> {
+  const index = new Map<string, TreeEntry>();
+  const stack = [...entries];
+
+  while (stack.length > 0) {
+    const entry = stack.pop()!;
+    index.set(entry.path, entry);
+    if (entry.type === 'directory' && entry.children) {
+      stack.push(...entry.children);
+    }
+  }
+
+  return index;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      results[currentIndex] = await mapper(items[currentIndex]!);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
 }
 
 /** Hook for managing file tree state with workspace info and persistence. */
@@ -116,6 +160,7 @@ export function useFileTree(agentId = DEFAULT_AGENT_ID, showHiddenEntries = fals
   const [selectedPath, setSelectedPathState] = useState<string | null>(() => loadSelectedPath(scopedAgentId));
   const [loadingPaths, setLoadingPaths] = useState<Set<string>>(new Set());
   const [workspaceInfo, setWorkspaceInfo] = useState<{ isCustomWorkspace: boolean; rootPath: string } | null>(null);
+  const entryIndexRef = useRef<Map<string, TreeEntry>>(new Map());
   const mountedRef = useRef(true);
   const agentIdRef = useRef(scopedAgentId);
   const stateOwnerAgentRef = useRef(scopedAgentId);
@@ -124,7 +169,9 @@ export function useFileTree(agentId = DEFAULT_AGENT_ID, showHiddenEntries = fals
 
   const ownsVisibleState = stateOwnerAgentRef.current === scopedAgentId;
   const visibleEntries = ownsVisibleState ? entries : [];
-  const visibleExpandedPaths = ownsVisibleState ? expandedPaths : loadExpandedPaths(scopedAgentId);
+  const visibleExpandedPaths = ownsVisibleState
+    ? expandedPaths
+    : limitRestoredExpandedPaths(loadExpandedPaths(scopedAgentId));
   const visibleSelectedPath = ownsVisibleState ? selectedPath : loadSelectedPath(scopedAgentId);
   const visibleLoadingPaths = ownsVisibleState ? loadingPaths : new Set<string>();
   const visibleWorkspaceInfo = ownsVisibleState ? workspaceInfo : null;
@@ -139,6 +186,7 @@ export function useFileTree(agentId = DEFAULT_AGENT_ID, showHiddenEntries = fals
 
   useEffect(() => {
     entriesRef.current = entries;
+    entryIndexRef.current = indexEntries(entries);
   }, [entries]);
 
   // Persist expanded paths
@@ -172,7 +220,12 @@ export function useFileTree(agentId = DEFAULT_AGENT_ID, showHiddenEntries = fals
             return next;
           });
 
-          setEntries((prev) => clearEntryFromTree(prev, dirPath));
+          setEntries((prev) => {
+            const next = clearEntryFromTree(prev, dirPath);
+            entriesRef.current = next;
+            entryIndexRef.current = indexEntries(next);
+            return next;
+          });
         }
         return null;
       }
@@ -193,12 +246,14 @@ export function useFileTree(agentId = DEFAULT_AGENT_ID, showHiddenEntries = fals
     if (agentIdRef.current !== requestAgentId) return;
 
     const requestVersion = ++requestVersionRef.current;
-    const persistedExpandedPaths = loadExpandedPaths(requestAgentId);
+    const persistedExpandedPaths = limitRestoredExpandedPaths(loadExpandedPaths(requestAgentId));
     const persistedSelectedPath = loadSelectedPath(requestAgentId);
 
     stateOwnerAgentRef.current = requestAgentId;
     setLoading(true);
     setError(null);
+    entriesRef.current = [];
+    entryIndexRef.current = new Map();
     setEntries([]);
     setLoadingPaths(new Set());
     setWorkspaceInfo(null);
@@ -212,11 +267,11 @@ export function useFileTree(agentId = DEFAULT_AGENT_ID, showHiddenEntries = fals
       let tree = children;
 
       if (persistedExpandedPaths.size > 0) {
-        const promises = [...persistedExpandedPaths].map(async (path) => {
+        const hydrationPaths = orderedExpansionPaths(persistedExpandedPaths);
+        const results = await mapWithConcurrency(hydrationPaths, RESTORE_EXPANSION_CONCURRENCY, async (path) => {
           const dirChildren = await fetchChildren(path, requestAgentId);
           return dirChildren ? { path, children: dirChildren } : null;
         });
-        const results = await Promise.all(promises);
         if (!mountedRef.current || requestVersionRef.current !== requestVersion || agentIdRef.current !== requestAgentId) return;
 
         for (const result of results) {
@@ -226,6 +281,8 @@ export function useFileTree(agentId = DEFAULT_AGENT_ID, showHiddenEntries = fals
         }
       }
 
+      entriesRef.current = tree;
+      entryIndexRef.current = indexEntries(tree);
       setEntries(tree);
     } else {
       setError('Failed to load file tree');
@@ -251,7 +308,7 @@ export function useFileTree(agentId = DEFAULT_AGENT_ID, showHiddenEntries = fals
 
     if (expandedPaths.has(dirPath)) return;
 
-    const entry = findEntry(entries, dirPath);
+    const entry = entryIndexRef.current.get(dirPath);
     if (entry?.children !== null && entry?.children !== undefined) return;
 
     const requestAgentId = agentIdRef.current;
@@ -266,9 +323,14 @@ export function useFileTree(agentId = DEFAULT_AGENT_ID, showHiddenEntries = fals
     });
 
     if (children) {
-      setEntries((prev) => mergeChildren(prev, dirPath, children));
+      setEntries((prev) => {
+        const next = mergeChildren(prev, dirPath, children);
+        entriesRef.current = next;
+        entryIndexRef.current = indexEntries(next);
+        return next;
+      });
     }
-  }, [entries, expandedPaths, fetchChildren]);
+  }, [expandedPaths, fetchChildren]);
 
   const selectFile = useCallback((filePath: string, targetAgentId = scopedAgentId) => {
     const requestAgentId = normalizeAgentId(targetAgentId);
@@ -292,18 +354,26 @@ export function useFileTree(agentId = DEFAULT_AGENT_ID, showHiddenEntries = fals
 
     if (!dirPath) {
       setEntries((prev) => {
-        return children.map((fresh) => {
+        const next = children.map((fresh) => {
           const existing = prev.find((entry) => entry.path === fresh.path);
           if (existing?.children && fresh.type === 'directory') {
             return { ...fresh, children: existing.children };
           }
           return fresh;
         });
+        entriesRef.current = next;
+        entryIndexRef.current = indexEntries(next);
+        return next;
       });
       return;
     }
 
-    setEntries((prev) => mergeChildren(prev, dirPath, children));
+    setEntries((prev) => {
+      const next = mergeChildren(prev, dirPath, children);
+      entriesRef.current = next;
+      entryIndexRef.current = indexEntries(next);
+      return next;
+    });
   }, [fetchChildren]);
 
   /**
@@ -321,7 +391,7 @@ export function useFileTree(agentId = DEFAULT_AGENT_ID, showHiddenEntries = fals
   }, [expandedPaths, refreshDirectory]);
 
   const ensureDirectoryLoaded = useCallback(async (dirPath: string, requestAgentId = agentIdRef.current) => {
-    const entry = findEntry(entriesRef.current, dirPath);
+    const entry = entryIndexRef.current.get(dirPath);
     if (entry?.type !== 'directory') return;
     if (entry.children !== null && entry.children !== undefined) return;
 
@@ -339,6 +409,7 @@ export function useFileTree(agentId = DEFAULT_AGENT_ID, showHiddenEntries = fals
       setEntries((prev) => {
         const next = mergeChildren(prev, dirPath, children);
         entriesRef.current = next;
+        entryIndexRef.current = indexEntries(next);
         return next;
       });
     }


### PR DESCRIPTION
## Summary
- add bounded local file-tree listing with limit/cursor pagination metadata, a 5k response budget, and bounded file stat concurrency
- bound restored expanded-directory hydration and use a path index for tree lookups in `useFileTree`
- flatten visible file-tree rows and virtualize the sidebar render path while preserving existing row interactions

## Validation
- npm exec vitest -- run server/routes/file-browser.test.ts src/features/file-browser/fileTreeRows.test.ts src/features/file-browser/hooks/useFileTree.test.ts src/features/file-browser/FileTreeNode.test.tsx src/features/file-browser/FileTreePanel.test.tsx
- npm run lint
- npm test -- --run
- npm run build
- git diff --check

Note: the production build still reports the existing bundle-splitting warnings from origin/next; that repair is isolated in PR #336.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pagination support to the file browsing API for improved directory navigation and performance.
  * Implemented virtual scrolling in the file tree panel to enhance responsiveness when working with large file lists.

* **Performance**
  * File tree rendering is now optimized to display only visible items, reducing memory usage and improving responsiveness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daggerhashimoto/openclaw-nerve/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->