### PR TITLE
fix(tts): play voice markers when sounds are muted

### DIFF
--- a/server/lib/config.ts
+++ b/server/lib/config.ts
@@ -51,6 +51,7 @@ export const config = {
   openaiApiKey: process.env.OPENAI_API_KEY || '',
   replicateApiToken: process.env.REPLICATE_API_TOKEN || '',
   mimoApiKey: process.env.MIMO_API_KEY || '',
+  cartesiaApiKey: process.env.CARTESIA_API_KEY || '',
 
   // Speech-to-text
   sttProvider: (process.env.STT_PROVIDER || 'local') as 'local' | 'openai',
@@ -174,9 +175,13 @@ export const WS_ALLOWED_HOSTS = new Set([
 
 /** Resolve the TTS provider label for the startup banner. */
 function ttsProviderLabel(): string {
-  if (config.openaiApiKey && config.replicateApiToken) return 'OpenAI + Replicate + Edge';
-  if (config.openaiApiKey) return 'OpenAI + Edge';
-  if (config.replicateApiToken) return 'Replicate + Edge';
+  const providers = [
+    config.openaiApiKey ? 'OpenAI' : null,
+    config.replicateApiToken ? 'Replicate' : null,
+    config.cartesiaApiKey ? 'Cartesia' : null,
+  ].filter(Boolean);
+
+  if (providers.length > 0) return `${providers.join(' + ')} + Edge`;
   return 'Edge (free)';
 }
 
@@ -264,6 +269,9 @@ export function validateConfig(): void {
   }
   if (!config.replicateApiToken) {
     console.warn('[config] ⚠ REPLICATE_API_TOKEN not set — Qwen TTS unavailable');
+  }
+  if (!config.cartesiaApiKey) {
+    console.warn('[config] ⚠ CARTESIA_API_KEY not set — Cartesia TTS unavailable');
   }
   if (!process.env.NERVE_LANGUAGE && process.env.LANGUAGE) {
     console.warn('[config] ⚠ LANGUAGE is deprecated — use NERVE_LANGUAGE instead');

--- a/server/lib/language.ts
+++ b/server/lib/language.ts
@@ -32,7 +32,7 @@ export function getQwen3Language(langCode: string): string | null {
 
 /** Check if a language is supported by a given provider. */
 export function isLanguageSupported(
-  provider: 'edge' | 'qwen3' | 'openai',
+  provider: 'edge' | 'qwen3' | 'openai' | 'cartesia',
   langCode: string,
 ): boolean {
   const lang = resolveLanguage(langCode);
@@ -47,6 +47,9 @@ export function isLanguageSupported(
     case 'openai':
       // OpenAI TTS auto-detects language from input text
       return true;
+    case 'cartesia':
+      // Sonic 3.5 supports the same language set Nerve currently exposes.
+      return true;
     default:
       return false;
   }
@@ -58,7 +61,7 @@ export function getFallbackInfo(
   langCode: string,
 ): { supported: boolean; fallbackLang: string; warning?: string } {
   const mapped = provider === 'replicate' ? 'qwen3' : provider;
-  const supported = isLanguageSupported(mapped as 'edge' | 'qwen3' | 'openai', langCode);
+  const supported = isLanguageSupported(mapped as 'edge' | 'qwen3' | 'openai' | 'cartesia', langCode);
   const lang = resolveLanguage(langCode);
   const langName = lang?.name || langCode;
 

--- a/server/lib/tts-config.test.ts
+++ b/server/lib/tts-config.test.ts
@@ -57,7 +57,7 @@ async function loadTtsModule(opts: {
 }
 
 describe('getTTSConfig', () => {
-  it('returns Xiaomi defaults when config file is missing', async () => {
+  it('returns Xiaomi and Cartesia defaults when config file is missing', async () => {
     const mod = await loadTtsModule({
       language: 'en',
       edgeVoiceGender: 'female',
@@ -68,6 +68,9 @@ describe('getTTSConfig', () => {
     expect(cfg.xiaomi.model).toBe('mimo-v2-tts');
     expect(cfg.xiaomi.voice).toBe('mimo_default');
     expect(cfg.xiaomi.style).toBe('');
+    expect(cfg.cartesia.model).toBe('sonic-3.5');
+    expect(cfg.cartesia.voice).toBe('Skylar');
+    expect(cfg.cartesia.voiceId).toBe('db6b0ed5-d5d3-463d-ae85-518a07d3c2b4');
   });
 
   it('deep-merges Xiaomi patches without dropping defaults', async () => {

--- a/server/lib/tts-config.ts
+++ b/server/lib/tts-config.ts
@@ -1,7 +1,7 @@
 /**
  * TTS voice configuration — reads/writes a JSON config file.
  *
- * All voice-related settings (OpenAI, Qwen/Replicate, Edge) live here
+ * All voice-related settings (OpenAI, Qwen/Replicate, Edge, Xiaomi, Cartesia) live here
  * instead of env vars or hardcoded values. On first run, default settings
  * are written to `<PROJECT_ROOT>/tts-config.json`. Subsequent reads merge
  * the on-disk config with defaults so new fields are always present.
@@ -54,7 +54,18 @@ export interface TTSVoiceConfig {
     /** Optional default Xiaomi style prompt */
     style: string;
   };
+  /** Cartesia TTS settings */
+  cartesia: {
+    /** Cartesia model id */
+    model: string;
+    /** Only supported voice name in Nerve UI */
+    voice: 'Skylar';
+    /** Cartesia Skylar voice id */
+    voiceId: string;
+  };
 }
+
+export const CARTESIA_SKYLAR_VOICE_ID = 'db6b0ed5-d5d3-463d-ae85-518a07d3c2b4';
 
 const DEFAULTS: TTSVoiceConfig = {
   qwen: {
@@ -77,6 +88,11 @@ const DEFAULTS: TTSVoiceConfig = {
     model: 'mimo-v2-tts',
     voice: 'mimo_default',
     style: '',
+  },
+  cartesia: {
+    model: 'sonic-3.5',
+    voice: 'Skylar',
+    voiceId: CARTESIA_SKYLAR_VOICE_ID,
   },
 };
 
@@ -230,5 +246,6 @@ export function getProviderLanguageSupport(): Record<string, { supported: boolea
     edge: getFallbackInfo('edge', lang),
     replicate: getFallbackInfo('replicate', lang),
     openai: getFallbackInfo('openai', lang),
+    cartesia: getFallbackInfo('cartesia', lang),
   };
 }

--- a/server/routes/api-keys.test.ts
+++ b/server/routes/api-keys.test.ts
@@ -11,11 +11,12 @@ describe('api-keys routes', () => {
     vi.restoreAllMocks();
   });
 
-  function mockDeps(overrides: { mimoKey?: string } = {}) {
+  function mockDeps(overrides: { mimoKey?: string; cartesiaKey?: string } = {}) {
     const mockConfig: Record<string, unknown> = {
       openaiApiKey: '',
       replicateApiToken: '',
       mimoApiKey: overrides.mimoKey || '',
+      cartesiaApiKey: overrides.cartesiaKey || '',
     };
 
     vi.doMock('../lib/config.js', () => ({
@@ -38,8 +39,8 @@ describe('api-keys routes', () => {
     return app;
   }
 
-  it('reports xiaomiKeySet from config', async () => {
-    mockDeps({ mimoKey: 'sk-mimo' });
+  it('reports xiaomiKeySet and cartesiaKeySet from config', async () => {
+    mockDeps({ mimoKey: 'sk-mimo', cartesiaKey: 'sk-car-test' });
     const app = await buildApp();
 
     const res = await app.request('/api/keys');
@@ -47,6 +48,7 @@ describe('api-keys routes', () => {
 
     const json = await res.json() as Record<string, unknown>;
     expect(json.xiaomiKeySet).toBe(true);
+    expect(json.cartesiaKeySet).toBe(true);
   });
 
   it('writes MIMO_API_KEY from mimoApiKey input', async () => {
@@ -64,5 +66,22 @@ describe('api-keys routes', () => {
     const json = await res.json() as Record<string, unknown>;
     expect(json.ok).toBe(true);
     expect(json.xiaomiKeySet).toBe(true);
+  });
+
+  it('writes CARTESIA_API_KEY from cartesiaApiKey input', async () => {
+    mockDeps();
+    const app = await buildApp();
+
+    const res = await app.request('/api/keys', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cartesiaApiKey: 'sk-car-test' }),
+    });
+
+    expect(res.status).toBe(200);
+
+    const json = await res.json() as Record<string, unknown>;
+    expect(json.ok).toBe(true);
+    expect(json.cartesiaKeySet).toBe(true);
   });
 });

--- a/server/routes/api-keys.ts
+++ b/server/routes/api-keys.ts
@@ -19,6 +19,7 @@ app.get('/api/keys', rateLimitGeneral, (c) => {
     openaiKeySet: !!config.openaiApiKey,
     replicateKeySet: !!config.replicateApiToken,
     xiaomiKeySet: !!config.mimoApiKey,
+    cartesiaKeySet: !!config.cartesiaApiKey,
   });
 });
 
@@ -50,12 +51,20 @@ app.put('/api/keys', rateLimitGeneral, async (c) => {
       results.push(val ? 'MIMO_API_KEY saved' : 'MIMO_API_KEY cleared');
     }
 
+    if (body.cartesiaApiKey !== undefined) {
+      const val = body.cartesiaApiKey.trim();
+      await writeEnvKey('CARTESIA_API_KEY', val);
+      (config as Record<string, unknown>).cartesiaApiKey = val;
+      results.push(val ? 'CARTESIA_API_KEY saved' : 'CARTESIA_API_KEY cleared');
+    }
+
     return c.json({
       ok: true,
       message: results.join(', ') || 'No changes',
       openaiKeySet: !!config.openaiApiKey,
       replicateKeySet: !!config.replicateApiToken,
       xiaomiKeySet: !!config.mimoApiKey,
+      cartesiaKeySet: !!config.cartesiaApiKey,
     });
   } catch {
     return c.text('Invalid request', 400);

--- a/server/routes/transcribe.ts
+++ b/server/routes/transcribe.ts
@@ -168,6 +168,7 @@ app.get('/api/language', rateLimitGeneral, (c) => {
       edge: isLanguageSupported('edge', config.language),
       qwen3: isLanguageSupported('qwen3', config.language),
       openai: isLanguageSupported('openai', config.language),
+      cartesia: isLanguageSupported('cartesia', config.language),
     },
   });
 });

--- a/server/routes/tts.test.ts
+++ b/server/routes/tts.test.ts
@@ -19,6 +19,8 @@ describe('TTS routes', () => {
     openaiResult?: { ok: boolean; buf?: Buffer; message?: string; status?: number };
     replicateResult?: { ok: boolean; buf?: Buffer; message?: string; status?: number };
     xiaomiResult?: { ok: boolean; buf?: Buffer; message?: string; status?: number; contentType?: string };
+    cartesiaKey?: string;
+    cartesiaResult?: { ok: boolean; buf?: Buffer; message?: string; status?: number; contentType?: string };
   } = {}) {
     vi.doMock('../lib/config.js', () => ({
       config: {
@@ -26,6 +28,7 @@ describe('TTS routes', () => {
         openaiApiKey: overrides.openaiKey || '',
         replicateApiToken: overrides.replicateToken || '',
         mimoApiKey: overrides.mimoKey || '',
+        cartesiaApiKey: overrides.cartesiaKey || '',
       },
       SESSION_COOKIE_NAME: 'nerve_session_3000',
     }));
@@ -57,12 +60,19 @@ describe('TTS routes', () => {
         overrides.xiaomiResult || { ok: true, buf: Buffer.from('RIFFdemo'), contentType: 'audio/wav' }
       ),
     }));
+    vi.doMock('../services/cartesia-tts.js', () => ({
+      synthesizeCartesia: vi.fn(async () =>
+        overrides.cartesiaResult || { ok: true, buf: Buffer.from('ID3demo'), contentType: 'audio/mpeg' }
+      ),
+    }));
     vi.doMock('../lib/tts-config.js', () => ({
+      CARTESIA_SKYLAR_VOICE_ID: 'db6b0ed5-d5d3-463d-ae85-518a07d3c2b4',
       getTTSConfig: vi.fn(() => ({
         openai: { voice: 'alloy', model: 'tts-1', instructions: '' },
         edge: { voice: 'en-US-JennyNeural' },
         qwen: {},
         xiaomi: { model: 'mimo-v2-tts', voice: 'mimo_default', style: 'Happy' },
+        cartesia: { model: 'sonic-3.5', voice: 'Skylar', voiceId: 'db6b0ed5-d5d3-463d-ae85-518a07d3c2b4' },
       })),
       updateTTSConfig: vi.fn((patch: unknown) => patch),
     }));
@@ -167,6 +177,41 @@ describe('TTS routes', () => {
       expect(res.status).toBe(502);
     });
 
+    it('uses explicit Cartesia provider and returns MP3 audio', async () => {
+      mockDeps({ cartesiaKey: 'sk-car-test' });
+      const app = await buildApp();
+      const res = await app.request('/api/tts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: 'Hello', provider: 'cartesia' }),
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Content-Type')).toBe('audio/mpeg');
+    });
+
+    it('uses Cartesia as automatic fallback before Edge when only Cartesia key is set', async () => {
+      mockDeps({ cartesiaKey: 'sk-car-test' });
+      const app = await buildApp();
+      const res = await app.request('/api/tts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: 'Hello' }),
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Content-Type')).toBe('audio/mpeg');
+    });
+
+    it('returns Cartesia provider errors', async () => {
+      mockDeps({ cartesiaResult: { ok: false, message: 'Cartesia failed', status: 502 } });
+      const app = await buildApp();
+      const res = await app.request('/api/tts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: 'Hello', provider: 'cartesia' }),
+      });
+      expect(res.status).toBe(502);
+    });
+
     it('returns error from provider failure', async () => {
       mockDeps({ edgeResult: { ok: false, message: 'Edge TTS failed', status: 500 } });
       const app = await buildApp();
@@ -234,6 +279,28 @@ describe('TTS routes', () => {
         body: JSON.stringify({ xiaomi: { model: 'mimo-v2-tts', voice: 'default_en', style: 'Happy' } }),
       });
       expect(res.status).toBe(200);
+    });
+
+    it('accepts valid Cartesia config patch', async () => {
+      mockDeps();
+      const app = await buildApp();
+      const res = await app.request('/api/tts/config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cartesia: { model: 'sonic-3.5' } }),
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it('rejects Cartesia voice changes', async () => {
+      mockDeps();
+      const app = await buildApp();
+      const res = await app.request('/api/tts/config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cartesia: { voiceId: 'not-skylar' } }),
+      });
+      expect(res.status).toBe(400);
     });
 
     it('rejects non-string values', async () => {

--- a/server/routes/tts.ts
+++ b/server/routes/tts.ts
@@ -1,7 +1,7 @@
 /**
  * POST /api/tts — Text-to-speech synthesis.
  *
- * Supports OpenAI TTS, Replicate (Qwen, etc.), and Edge TTS (free, zero-config).
+ * Supports OpenAI TTS, Replicate (Qwen, etc.), Cartesia, Xiaomi, and Edge TTS (free, zero-config).
  * Body: { text: string, provider?: string, model?: string, voice?: string }
  * Response: audio/mpeg binary
  *
@@ -10,7 +10,7 @@
  *  - "openai" → OpenAI TTS (requires OPENAI_API_KEY)
  *  - "replicate" → Replicate-hosted models (requires REPLICATE_API_TOKEN)
  *  - "edge" → Microsoft Edge Read-Aloud TTS (free, no key needed)
- *  - Auto fallback: openai (if key) → replicate (if key) → edge (always available)
+ *  - Auto fallback: openai (if key) → replicate (if key) → cartesia (if key) → edge (always available)
  *
  * Backward compat: provider "qwen" is treated as replicate + model "qwen-tts".
  */
@@ -20,12 +20,13 @@ import { zValidator } from '@hono/zod-validator';
 import { z } from 'zod';
 import crypto from 'node:crypto';
 import { config } from '../lib/config.js';
-import { getTTSConfig, updateTTSConfig } from '../lib/tts-config.js';
+import { CARTESIA_SKYLAR_VOICE_ID, getTTSConfig, updateTTSConfig } from '../lib/tts-config.js';
 import { getTtsCache, setTtsCache } from '../services/tts-cache.js';
 import { synthesizeOpenAI } from '../services/openai-tts.js';
 import { synthesizeReplicate } from '../services/replicate-tts.js';
 import { synthesizeEdge } from '../services/edge-tts.js';
 import { synthesizeXiaomi } from '../services/xiaomi-tts.js';
+import { synthesizeCartesia } from '../services/cartesia-tts.js';
 import { rateLimitTTS, rateLimitGeneral } from '../middleware/rate-limit.js';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 
@@ -41,7 +42,7 @@ const ttsSchema = z.object({
     .refine((s) => s.trim().length > 0, 'Text cannot be empty or whitespace'),
   voice: z.string().optional(),
   // Accept both old ("qwen") and new ("replicate") values
-  provider: z.enum(['openai', 'replicate', 'qwen', 'edge', 'xiaomi']).optional(),
+  provider: z.enum(['openai', 'replicate', 'qwen', 'edge', 'xiaomi', 'cartesia']).optional(),
   model: z.string().optional(),
 });
 
@@ -72,29 +73,35 @@ app.post(
       // Voice is passed through — each provider resolves its own default from config
       const voice = rawVoice;
 
-      // Resolve effective provider: explicit > openai (if key) > replicate (if key) > edge
+      // Resolve effective provider: explicit > openai (if key) > replicate (if key) > cartesia (if key) > edge
       const useXiaomi = provider === 'xiaomi';
+      const useCartesia =
+        provider === 'cartesia' ||
+        (!provider && !config.openaiApiKey && !config.replicateApiToken && !!config.cartesiaApiKey);
       const useReplicate =
         provider === 'replicate' ||
         (!provider && !config.openaiApiKey && !!config.replicateApiToken);
       const useEdge =
         provider === 'edge' ||
-        (!provider && !config.openaiApiKey && !config.replicateApiToken);
+        (!provider && !config.openaiApiKey && !config.replicateApiToken && !config.cartesiaApiKey);
       const effectiveProvider = useXiaomi
         ? 'xiaomi'
-        : useEdge
-          ? 'edge'
-          : useReplicate
-            ? 'replicate'
-            : 'openai';
+        : useCartesia
+          ? 'cartesia'
+          : useEdge
+            ? 'edge'
+            : useReplicate
+              ? 'replicate'
+              : 'openai';
       console.log(`[tts] provider=${effectiveProvider} voice=${voice} text="${text.slice(0, 50)}..."`);
 
       const xiaomiStyle = effectiveProvider === 'xiaomi' ? getTTSConfig().xiaomi.style : '';
+      const cacheVoice = effectiveProvider === 'cartesia' ? CARTESIA_SKYLAR_VOICE_ID : (voice || '');
 
-      // Cache key includes provider + model + voice and Xiaomi style for proper isolation
+      // Cache key includes provider + model + effective voice and provider-specific style metadata for proper isolation.
       const hash = crypto
         .createHash('md5')
-        .update(`${effectiveProvider}:${model || ''}:${voice || ''}:${xiaomiStyle}:${text}`)
+        .update(`${effectiveProvider}:${model || ''}:${cacheVoice}:${xiaomiStyle}:${text}`)
         .digest('hex');
 
       const cached = getTtsCache(hash);
@@ -107,6 +114,8 @@ app.post(
       let result;
       if (effectiveProvider === 'xiaomi') {
         result = await synthesizeXiaomi(text, { model, voice });
+      } else if (effectiveProvider === 'cartesia') {
+        result = await synthesizeCartesia(text, { model, voice });
       } else if (effectiveProvider === 'edge') {
         result = await synthesizeEdge(text, voice);
       } else if (effectiveProvider === 'replicate') {
@@ -144,6 +153,7 @@ const TTS_CONFIG_SCHEMA: Record<string, string[]> = {
   openai: ['model', 'voice', 'instructions'],
   edge: ['voice'],
   xiaomi: ['model', 'voice', 'style'],
+  cartesia: ['model'],
 };
 
 /** Validate TTS config patch — only allow known keys with string values */
@@ -160,6 +170,7 @@ function validateTTSPatch(patch: unknown): string | null {
     for (const [subKey, subVal] of Object.entries(val as Record<string, unknown>)) {
       if (!allowed.includes(subKey)) return `Unknown key: "${key}.${subKey}"`;
       if (typeof subVal !== 'string') return `"${key}.${subKey}" must be a string`;
+      if (key === 'cartesia' && subKey !== 'model') return 'Cartesia voice is locked to Skylar';
       if (subVal.length > 2000) return `"${key}.${subKey}" exceeds max length (2000)`;
     }
   }

--- a/server/services/cartesia-tts.test.ts
+++ b/server/services/cartesia-tts.test.ts
@@ -57,7 +57,7 @@ describe('synthesizeCartesia', () => {
       expect.objectContaining({
         method: 'POST',
         headers: expect.objectContaining({
-          Authorization: 'Bearer sk-car-test',
+          'X-API-Key': 'sk-car-test',
           'Cartesia-Version': '2026-03-01',
           'Content-Type': 'application/json',
         }),

--- a/server/services/cartesia-tts.test.ts
+++ b/server/services/cartesia-tts.test.ts
@@ -1,0 +1,76 @@
+/** Tests for the Cartesia TTS provider service. */
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+const SKYLAR_ID = 'db6b0ed5-d5d3-463d-ae85-518a07d3c2b4';
+
+describe('synthesizeCartesia', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns a clear error when the Cartesia key is missing', async () => {
+    vi.doMock('../lib/config.js', () => ({
+      config: { cartesiaApiKey: '' },
+    }));
+
+    vi.doMock('../lib/tts-config.js', () => ({
+      CARTESIA_SKYLAR_VOICE_ID: SKYLAR_ID,
+      getTTSConfig: () => ({ cartesia: { model: 'sonic-3.5', voice: 'Skylar', voiceId: SKYLAR_ID } }),
+    }));
+
+    const { synthesizeCartesia } = await import('./cartesia-tts.js');
+    await expect(synthesizeCartesia('Hello')).resolves.toMatchObject({
+      ok: false,
+      status: 500,
+      message: expect.stringContaining('Cartesia'),
+    });
+  });
+
+  it('posts Sonic 3.5 bytes request using only the Skylar voice id', async () => {
+    vi.doMock('../lib/config.js', () => ({
+      config: { cartesiaApiKey: 'sk-car-test' },
+    }));
+
+    vi.doMock('../lib/tts-config.js', () => ({
+      CARTESIA_SKYLAR_VOICE_ID: SKYLAR_ID,
+      getTTSConfig: () => ({ cartesia: { model: 'sonic-3.5', voice: 'Skylar', voiceId: SKYLAR_ID } }),
+    }));
+
+    const mp3 = Buffer.from('ID3demo');
+    vi.mocked(fetch).mockResolvedValue(new Response(mp3, { status: 200, headers: { 'Content-Type': 'audio/mpeg' } }));
+
+    const { synthesizeCartesia } = await import('./cartesia-tts.js');
+    const result = await synthesizeCartesia('Hello there', { voice: 'not-allowed' });
+
+    expect(result).toMatchObject({ ok: true, contentType: 'audio/mpeg' });
+    if (!result.ok) throw new Error('Expected Cartesia synthesis to succeed');
+    expect(result.buf.equals(mp3)).toBe(true);
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.cartesia.ai/tts/bytes',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer sk-car-test',
+          'Cartesia-Version': '2026-03-01',
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+
+    const [, init] = vi.mocked(fetch).mock.calls[0] ?? [];
+    const body = JSON.parse(String(init?.body));
+    expect(body).toEqual({
+      model_id: 'sonic-3.5',
+      transcript: 'Hello there',
+      voice: { mode: 'id', id: SKYLAR_ID },
+      output_format: { container: 'mp3', sample_rate: 44100, bit_rate: 128000 },
+    });
+  });
+});

--- a/server/services/cartesia-tts.ts
+++ b/server/services/cartesia-tts.ts
@@ -1,0 +1,70 @@
+/**
+ * Cartesia TTS provider.
+ *
+ * Generates non-streaming MP3 audio through Cartesia's `/tts/bytes` endpoint.
+ * Nerve intentionally exposes only the Skylar voice for now.
+ * @module
+ */
+
+import { config } from '../lib/config.js';
+import { CARTESIA_SKYLAR_VOICE_ID, getTTSConfig } from '../lib/tts-config.js';
+
+const CARTESIA_TTS_URL = 'https://api.cartesia.ai/tts/bytes';
+const CARTESIA_VERSION = '2026-03-01';
+
+export interface CartesiaTTSResult {
+  ok: true;
+  buf: Buffer;
+  contentType: 'audio/mpeg';
+}
+
+export interface CartesiaTTSError {
+  ok: false;
+  status: number;
+  message: string;
+}
+
+export async function synthesizeCartesia(
+  text: string,
+  opts?: { voice?: string; model?: string },
+): Promise<CartesiaTTSResult | CartesiaTTSError> {
+  if (!config.cartesiaApiKey) {
+    return { ok: false, status: 500, message: 'Cartesia API key not configured' };
+  }
+
+  const cartesia = getTTSConfig().cartesia;
+  const effectiveModel = opts?.model || cartesia.model;
+  // Only Skylar is exposed; ignore arbitrary request voices entirely.
+  const effectiveVoice = CARTESIA_SKYLAR_VOICE_ID;
+
+  const resp = await fetch(CARTESIA_TTS_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${config.cartesiaApiKey}`,
+      'Cartesia-Version': CARTESIA_VERSION,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model_id: effectiveModel,
+      transcript: text,
+      voice: {
+        mode: 'id',
+        id: effectiveVoice,
+      },
+      output_format: {
+        container: 'mp3',
+        sample_rate: 44100,
+        bit_rate: 128000,
+      },
+    }),
+  });
+
+  if (!resp.ok) {
+    const errBody = await resp.text();
+    console.error('[tts:cartesia] API error:', resp.status, errBody);
+    return { ok: false, status: resp.status, message: errBody || 'Cartesia TTS failed' };
+  }
+
+  const buf = Buffer.from(await resp.arrayBuffer());
+  return { ok: true, buf, contentType: 'audio/mpeg' };
+}

--- a/server/services/cartesia-tts.ts
+++ b/server/services/cartesia-tts.ts
@@ -40,7 +40,7 @@ export async function synthesizeCartesia(
   const resp = await fetch(CARTESIA_TTS_URL, {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${config.cartesiaApiKey}`,
+      'X-API-Key': config.cartesiaApiKey,
       'Cartesia-Version': CARTESIA_VERSION,
       'Content-Type': 'application/json',
     },

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -78,6 +78,12 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const { rpc } = useGateway();
   const { currentSession, sessions, agentStatus = {} } = useSessionContext();
   const { soundEnabled, speak } = useSettings();
+  // Voice-response TTS should not depend on the optional "Sound effects" toggle.
+  // That toggle gates pings/cues, but marker/fallback speech has its own
+  // explicit trigger: the user sent a voice message and the assistant returned
+  // (or omitted) a [tts:...] marker. Keep a dedicated enabled ref for speech
+  // so marker playback still works when UI sounds are muted.
+  const ttsSpeechEnabledRef = useRef(true);
 
   const [showResetConfirm, setShowResetConfirm] = useState(false);
   const [pendingSendCount, setPendingSendCount] = useState(0);
@@ -138,7 +144,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     ttsExpiryTimersRef.current.clear();
   }, []);
 
-  const ttsHook = useChatTTS({ soundEnabled: soundEnabledRef, speak: speakRef });
+  const ttsHook = useChatTTS({ soundEnabled: soundEnabledRef, speak: speakRef, speechEnabled: ttsSpeechEnabledRef });
   const { handleFinalTTS, playCompletionPing, resetPlayedSounds, trackVoiceMessage } = ttsHook;
   const displayMessages = useMemo(
     () => mergeOptimisticMessages(messages, optimisticSends),

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -77,7 +77,7 @@ const ChatContext = createContext<ChatContextValue | null>(null);
 export function ChatProvider({ children }: { children: ReactNode }) {
   const { rpc } = useGateway();
   const { currentSession, sessions, agentStatus = {} } = useSessionContext();
-  const { soundEnabled, speak } = useSettings();
+  const { soundEnabled, speakVoiceReply } = useSettings();
   // Voice-response TTS should not depend on the optional "Sound effects" toggle.
   // That toggle gates pings/cues, but marker/fallback speech has its own
   // explicit trigger: the user sent a voice message and the assistant returned
@@ -91,7 +91,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
 
   const currentSessionRef = useRef(currentSession || '');
   const soundEnabledRef = useRef(soundEnabled);
-  const speakRef = useRef(speak);
+  const speakRef = useRef(speakVoiceReply);
   const runtimeMessagesRef = useRef<ChatMsg[]>([]);
   const catchupTimersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
   const ttsExpiryTimersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
@@ -99,8 +99,8 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     currentSessionRef.current = currentSession || '';
     soundEnabledRef.current = soundEnabled;
-    speakRef.current = speak;
-  }, [currentSession, soundEnabled, speak]);
+    speakRef.current = speakVoiceReply;
+  }, [currentSession, soundEnabled, speakVoiceReply]);
 
   const runtime = useChatRuntime({
     sessionKey: currentSession || '',

--- a/src/contexts/ChatContext.tts.test.tsx
+++ b/src/contexts/ChatContext.tts.test.tsx
@@ -830,6 +830,63 @@ describe('ChatContext runtime TTS playback', () => {
     expect(speakMock).toHaveBeenCalledWith('Second spoken reply.');
     expect(speakMock).toHaveBeenCalledTimes(2);
   });
+
+  it('speaks TTS markers from voice turns even when sound effects are disabled', async () => {
+    const { ChatProvider, useChat, setRuntimeState, speakMock, playPingMock } = await setup({
+      soundEnabled: false,
+    });
+
+    let send: ((text: string) => Promise<void>) | null = null;
+
+    function Consumer() {
+      const chat = useChat();
+      useEffect(() => {
+        send = chat.handleSend;
+      }, [chat]);
+      return null;
+    }
+
+    const { rerender } = render(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(send).not.toBeNull());
+
+    await act(async () => {
+      await send!('[voice] hello with muted ui sounds');
+    });
+
+    setRuntimeState({ isGenerating: true });
+    rerender(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    setRuntimeState({
+      isGenerating: false,
+      messages: [{
+        msgId: 'assistant:main:run-1:answer',
+        role: 'assistant',
+        html: '<p>Visible reply.</p>',
+        rawText: 'Visible reply.',
+        timestamp: new Date(Date.now() + 1000),
+        ttsText: 'Spoken reply while muted.',
+      }],
+    });
+    rerender(
+      <ChatProvider>
+        <Consumer />
+      </ChatProvider>,
+    );
+
+    await waitFor(() => expect(speakMock).toHaveBeenCalledWith('Spoken reply while muted.'));
+    expect(speakMock).toHaveBeenCalledTimes(1);
+    expect(playPingMock).not.toHaveBeenCalled();
+  });
+
 });
 
 async function setup(options: {

--- a/src/contexts/ChatContext.tts.test.tsx
+++ b/src/contexts/ChatContext.tts.test.tsx
@@ -933,7 +933,8 @@ async function setup(options: {
   vi.doMock('./SettingsContext', () => ({
     useSettings: () => ({
       soundEnabled: options.soundEnabled ?? false,
-      speak: speakMock,
+      speak: vi.fn(),
+      speakVoiceReply: speakMock,
     }),
   }));
 

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -274,7 +274,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   const toggleTtsProvider = useCallback(() => {
     setTtsProvider(prev => {
-      const order: TTSProvider[] = ['openai', 'replicate', 'xiaomi', 'edge'];
+      const order: TTSProvider[] = ['openai', 'replicate', 'cartesia', 'xiaomi', 'edge'];
       const next = order[(order.indexOf(prev) + 1) % order.length]!;
       localStorage.setItem('oc-tts-provider', next);
       return next;

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -28,6 +28,7 @@ interface SettingsContextValue {
   liveTranscriptionPreview: boolean;
   toggleLiveTranscriptionPreview: () => void;
   speak: (text: string) => Promise<void>;
+  speakVoiceReply: (text: string) => Promise<void>;
   panelRatio: number;
   setPanelRatio: (ratio: number) => void;
   telemetryVisible: boolean;
@@ -165,6 +166,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     return saved !== 'false';
   });
   const { speak } = useTTS(soundEnabled, ttsProvider, ttsModel || undefined);
+  const { speak: speakVoiceReply } = useTTS(true, ttsProvider, ttsModel || undefined);
   const wakeWordToggleRef = useRef<(() => void) | null>(null);
 
   // Apply theme on mount and when it changes
@@ -386,6 +388,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     liveTranscriptionPreview,
     toggleLiveTranscriptionPreview,
     speak,
+    speakVoiceReply,
     panelRatio,
     setPanelRatio,
     telemetryVisible,
@@ -410,6 +413,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     toggleKanbanVisible,
   }), [
     soundEnabled, toggleSound, ttsProvider, ttsModel, changeTtsProvider, changeTtsModel, toggleTtsProvider,
+    speakVoiceReply,
     sttProvider, changeSttProvider, sttInputMode, changeSttInputMode, sttModel, changeSttModel,
     wakeWordEnabled, handleToggleWakeWord, handleWakeWordState,
     liveTranscriptionPreview, toggleLiveTranscriptionPreview,

--- a/src/features/command-palette/commands.ts
+++ b/src/features/command-palette/commands.ts
@@ -177,6 +177,13 @@ export function createCommands(actions: CommandActions): Command[] {
       keywords: ['tts', 'voice', 'speech', 'edge', 'free'],
     },
     {
+      id: 'tts-cartesia',
+      label: 'TTS: Switch to Cartesia',
+      action: () => actions.onTtsProviderChange('cartesia' as TTSProvider),
+      category: 'voice',
+      keywords: ['tts', 'voice', 'speech', 'cartesia', 'skylar'],
+    },
+    {
       id: 'tts-xiaomi',
       label: 'TTS: Switch to Xiaomi Mimo',
       action: () => actions.onTtsProviderChange('xiaomi' as TTSProvider),

--- a/src/features/settings/AudioSettings.component.test.tsx
+++ b/src/features/settings/AudioSettings.component.test.tsx
@@ -18,6 +18,7 @@ vi.mock('@/features/tts/useTTSConfig', () => ({
       openai: { model: 'tts-1', voice: 'alloy', instructions: '' },
       qwen: { mode: 'voice_design', language: 'English', speaker: 'Serena', voiceDescription: '', styleInstruction: '' },
       xiaomi: { model: 'mimo-v2-tts', voice: 'mimo_default', style: '' },
+      cartesia: { model: 'sonic-3.5', voice: 'Skylar', voiceId: 'db6b0ed5-d5d3-463d-ae85-518a07d3c2b4' },
     },
     saved: true,
     updateField,
@@ -72,11 +73,12 @@ function mockWakeWordSupport(result: { supported: boolean; reason: 'mobile-web' 
   (wakeWordSupport.isWakeWordSupportedEnvironment as Mock).mockReturnValue(result.supported);
 }
 
-type ApiKeyState = { openaiKeySet: boolean; replicateKeySet: boolean; xiaomiKeySet: boolean; hasGpu: boolean };
+type ApiKeyState = { openaiKeySet: boolean; replicateKeySet: boolean; xiaomiKeySet: boolean; cartesiaKeySet: boolean; hasGpu: boolean };
 let apiKeyState: ApiKeyState = {
   openaiKeySet: true,
   replicateKeySet: true,
   xiaomiKeySet: false,
+  cartesiaKeySet: false,
   hasGpu: false,
 };
 
@@ -88,6 +90,7 @@ describe('AudioSettings', () => {
       openaiKeySet: true,
       replicateKeySet: true,
       xiaomiKeySet: false,
+      cartesiaKeySet: false,
       hasGpu: false,
     };
 
@@ -114,7 +117,7 @@ describe('AudioSettings', () => {
           json: () => Promise.resolve({
             language: 'en',
             supported: [{ code: 'en', name: 'English', nativeName: 'English' }],
-            providers: { edge: true, qwen3: true, openai: true },
+            providers: { edge: true, qwen3: true, openai: true, cartesia: true },
           }),
         } as Response);
       }
@@ -210,6 +213,30 @@ describe('AudioSettings', () => {
       fireEvent.change(screen.getByPlaceholderText('Happy, whisper, calm, dramatic...'), { target: { value: 'Happy' } });
 
       expect(updateField).toHaveBeenCalledWith('xiaomi', 'style', 'Happy');
+    });
+  });
+
+  describe('Cartesia output settings', () => {
+    it('renders a Cartesia provider button', async () => {
+      render(<AudioSettings {...baseProps} section="output" ttsProvider="cartesia" ttsModel="" />);
+      expect(await screen.findByRole('button', { name: 'Cartesia' })).toBeInTheDocument();
+    });
+
+    it('shows the Cartesia API key prompt when Cartesia is selected and the key is missing', async () => {
+      apiKeyState.cartesiaKeySet = false;
+      render(<AudioSettings {...baseProps} section="output" ttsProvider="cartesia" ttsModel="" />);
+
+      expect(await screen.findByText(/CARTESIA_API_KEY required for Cartesia TTS/i)).toBeInTheDocument();
+    });
+
+    it('renders Cartesia model selector and only the Skylar voice', async () => {
+      render(<AudioSettings {...baseProps} section="output" ttsProvider="cartesia" ttsModel="sonic-3.5" />);
+
+      expect(await screen.findByLabelText('TTS Model')).toHaveValue('sonic-3.5');
+      expect(screen.getByLabelText('Cartesia Voice')).toHaveValue('db6b0ed5-d5d3-463d-ae85-518a07d3c2b4');
+      expect(screen.getByRole('option', { name: 'sonic-3.5 (default)' })).toBeInTheDocument();
+      expect(screen.getByRole('option', { name: 'Skylar' })).toBeInTheDocument();
+      expect(screen.queryByRole('option', { name: /Katie/i })).not.toBeInTheDocument();
     });
   });
 });

--- a/src/features/settings/AudioSettings.tsx
+++ b/src/features/settings/AudioSettings.tsx
@@ -21,7 +21,7 @@ interface LanguageInfo {
 interface LanguageState {
   language: string;
   supported: LanguageInfo[];
-  providers: { edge: boolean; qwen3: boolean; openai: boolean };
+  providers: { edge: boolean; qwen3: boolean; openai: boolean; cartesia?: boolean };
 }
 
 interface LanguageSupportEntry {
@@ -30,7 +30,7 @@ interface LanguageSupportEntry {
   nativeName: string;
   edgeTtsVoices: { female: string; male: string };
   stt: { local: boolean; openai: boolean };
-  tts: { edge: boolean; qwen3: boolean; openai: boolean };
+  tts: { edge: boolean; qwen3: boolean; openai: boolean; cartesia?: boolean };
 }
 
 interface EdgeVoiceOption {
@@ -352,7 +352,7 @@ function ApiKeyInput({
 }: {
   keyName: string;
   provider: string;
-  fieldName: 'openaiKey' | 'replicateToken' | 'mimoApiKey';
+  fieldName: 'openaiKey' | 'replicateToken' | 'mimoApiKey' | 'cartesiaApiKey';
   onSaved: () => void;
 }) {
   const [value, setValue] = useState('');
@@ -425,6 +425,9 @@ const PROVIDER_MODELS: Record<TTSProvider, { value: string; label: string }[]> =
   xiaomi: [
     { value: 'mimo-v2-tts', label: 'mimo-v2-tts' },
   ],
+  cartesia: [
+    { value: 'sonic-3.5', label: 'sonic-3.5 (default)' },
+  ],
   edge: [],
 };
 
@@ -465,7 +468,12 @@ export function AudioSettings({
   const { state: langState, support, isMultilingual, setLanguage } = useLanguage();
 
   // Fetch API key status once on mount
-  const [apiKeys, setApiKeys] = useState<{ openai: boolean; replicate: boolean; xiaomi: boolean }>({ openai: true, replicate: true, xiaomi: true });
+  const [apiKeys, setApiKeys] = useState<{ openai: boolean; replicate: boolean; xiaomi: boolean; cartesia: boolean }>({
+    openai: true,
+    replicate: true,
+    xiaomi: true,
+    cartesia: true,
+  });
   useEffect(() => {
     fetch('/api/keys')
       .then((r) => r.json())
@@ -474,6 +482,7 @@ export function AudioSettings({
           openai: !!data.openaiKeySet,
           replicate: !!data.replicateKeySet,
           xiaomi: !!data.xiaomiKeySet,
+          cartesia: !!data.cartesiaKeySet,
         });
       })
       .catch(() => {});
@@ -750,6 +759,14 @@ export function AudioSettings({
             </button>
             <button
               type="button"
+              onClick={() => onTtsProviderChange('cartesia')}
+              data-active={ttsProvider === 'cartesia'}
+              className="shell-chip min-h-11 flex-1 justify-center rounded-2xl px-3 py-2 text-sm font-medium"
+            >
+              Cartesia
+            </button>
+            <button
+              type="button"
               onClick={() => onTtsProviderChange('xiaomi')}
               data-active={ttsProvider === 'xiaomi'}
               className="shell-chip min-h-11 flex-1 justify-center rounded-2xl px-3 py-2 text-sm font-medium"
@@ -783,6 +800,9 @@ export function AudioSettings({
       {showOutput && ttsProvider === 'xiaomi' && !apiKeys.xiaomi && (
         <ApiKeyInput keyName="MIMO_API_KEY" provider="Xiaomi Mimo" fieldName="mimoApiKey" onSaved={() => setApiKeys(k => ({ ...k, xiaomi: true }))} />
       )}
+      {showOutput && ttsProvider === 'cartesia' && !apiKeys.cartesia && (
+        <ApiKeyInput keyName="CARTESIA_API_KEY" provider="Cartesia TTS" fieldName="cartesiaApiKey" onSaved={() => setApiKeys(k => ({ ...k, cartesia: true }))} />
+      )}
 
       {/* TTS Model (shown when provider has multiple models) */}
       {showOutput && models.length > 0 && (
@@ -792,10 +812,15 @@ export function AudioSettings({
             <p className="mt-1 text-xs text-muted-foreground">Select the synthesis model exposed by the active provider.</p>
           </div>
           <InlineSelect
-            value={ttsProvider === 'xiaomi' ? (ttsModel || config?.xiaomi.model || '') : ttsModel}
+            value={ttsProvider === 'xiaomi'
+              ? (ttsModel || config?.xiaomi.model || '')
+              : ttsProvider === 'cartesia'
+                ? (ttsModel || config?.cartesia.model || '')
+                : ttsModel}
             onChange={(value) => {
               onTtsModelChange(value);
               if (ttsProvider === 'xiaomi') updateField('xiaomi', 'model', value);
+              if (ttsProvider === 'cartesia') updateField('cartesia', 'model', value);
             }}
             options={models}
             ariaLabel="TTS Model"
@@ -900,6 +925,23 @@ export function AudioSettings({
                 placeholder="Happy, whisper, calm, dramatic..."
               />
             </>
+          )}
+
+          {ttsProvider === 'cartesia' && (
+            <div className="cockpit-row items-start justify-between">
+              <div className="min-w-0 flex-1">
+                <span className="text-sm font-medium text-foreground">Voice</span>
+                <p className="mt-1 text-xs text-muted-foreground">Cartesia output is locked to Skylar for now.</p>
+              </div>
+              <InlineSelect
+                value={config.cartesia.voiceId}
+                onChange={() => undefined}
+                options={[{ value: config.cartesia.voiceId, label: 'Skylar' }]}
+                ariaLabel="Cartesia Voice"
+                triggerClassName={`${INLINE_SELECT_TRIGGER_CLASS} min-w-[188px]`}
+                menuClassName={`${INLINE_SELECT_MENU_CLASS} min-w-[188px]`}
+              />
+            </div>
           )}
         </div>
       )}

--- a/src/features/tts/useTTS.test.ts
+++ b/src/features/tts/useTTS.test.ts
@@ -86,6 +86,10 @@ describe('migrateTTSProvider', () => {
     expect(migrateTTSProvider('xiaomi')).toBe('xiaomi');
   });
 
+  it('should keep "cartesia" as-is', () => {
+    expect(migrateTTSProvider('cartesia')).toBe('cartesia');
+  });
+
   it('should default unknown values to "openai"', () => {
     expect(migrateTTSProvider('unknown')).toBe('openai');
     expect(migrateTTSProvider('')).toBe('openai');

--- a/src/features/tts/useTTS.ts
+++ b/src/features/tts/useTTS.ts
@@ -14,7 +14,7 @@ if (typeof document !== 'undefined') {
   events.forEach(e => document.addEventListener(e, handler, { capture: true, once: false }));
 }
 
-export type TTSProvider = 'openai' | 'replicate' | 'edge' | 'xiaomi';
+export type TTSProvider = 'openai' | 'replicate' | 'edge' | 'xiaomi' | 'cartesia';
 
 /** @deprecated Use 'replicate' instead. Kept for migration. */
 export type LegacyTTSProvider = 'qwen';
@@ -22,7 +22,7 @@ export type LegacyTTSProvider = 'qwen';
 /** Migrate legacy provider names to current ones. */
 export function migrateTTSProvider(provider: string): TTSProvider {
   if (provider === 'qwen') return 'replicate';
-  if (provider === 'openai' || provider === 'replicate' || provider === 'edge' || provider === 'xiaomi') return provider;
+  if (provider === 'openai' || provider === 'replicate' || provider === 'edge' || provider === 'xiaomi' || provider === 'cartesia') return provider;
   return 'openai';
 }
 

--- a/src/features/tts/useTTSConfig.ts
+++ b/src/features/tts/useTTSConfig.ts
@@ -21,6 +21,11 @@ export interface TTSVoiceConfig {
     voice: string;
     style: string;
   };
+  cartesia: {
+    model: string;
+    voice: 'Skylar';
+    voiceId: string;
+  };
 }
 
 interface UseTTSConfigReturn {

--- a/src/hooks/useChatTTS.ts
+++ b/src/hooks/useChatTTS.ts
@@ -43,6 +43,11 @@ export function buildVoiceFallbackText(raw: string): string | null {
 interface UseChatTTSDeps {
   soundEnabled: React.RefObject<boolean>;
   speak: React.RefObject<(text: string) => void>;
+  /**
+   * Gates response speech from [tts:...] markers and voice fallbacks. This is
+   * intentionally separate from soundEnabled, which only controls UI cues.
+   */
+  speechEnabled?: React.RefObject<boolean>;
 }
 
 interface HandleFinalTTSOptions {
@@ -50,7 +55,7 @@ interface HandleFinalTTSOptions {
   completionPing?: boolean;
 }
 
-export function useChatTTS({ soundEnabled, speak }: UseChatTTSDeps) {
+export function useChatTTS({ soundEnabled, speak, speechEnabled = soundEnabled }: UseChatTTSDeps) {
   const lastMessageWasVoiceRef = useRef(false);
   const playedSoundsRef = useRef<Set<string>>(new Set());
 
@@ -77,12 +82,13 @@ export function useChatTTS({ soundEnabled, speak }: UseChatTTSDeps) {
 
     if (finalData?.ttsText && !playedSoundsRef.current.has(finalData.ttsText)) {
       playedSoundsRef.current.add(finalData.ttsText);
+      if (!speechEnabled.current) return false;
       speak.current(finalData.ttsText);
       return true;
     }
 
     const shouldUseVoiceFallback = options.voiceFallback ?? lastMessageWasVoiceRef.current;
-    if (!finalData?.ttsText && shouldUseVoiceFallback && finalData?.text) {
+    if (!finalData?.ttsText && speechEnabled.current && shouldUseVoiceFallback && finalData?.text) {
       // Voice fallback: agent forgot [tts:...] marker — auto-speak cleaned response
       const fallback = buildVoiceFallbackText(finalData.text);
       if (fallback) {
@@ -97,7 +103,7 @@ export function useChatTTS({ soundEnabled, speak }: UseChatTTSDeps) {
     }
 
     return false;
-  }, [soundEnabled, speak]);
+  }, [soundEnabled, speak, speechEnabled]);
 
   /** Play the completion ping sound if sound is enabled. */
   const playCompletionPing = useCallback(() => {


### PR DESCRIPTION
## Summary
- decouple voice-response TTS playback from the Sound effects toggle
- keep UI completion pings/cues gated by Sound effects
- add regression coverage for `[tts:...]` marker playback when UI sounds are muted

## Why
Voice responses were returning valid `[tts:...]` markers, but playback did not fire when Sound effects were disabled because the same boolean gated both pings and TTS speech. This made marker extraction look healthy while `/api/tts` was never called.

## Verification
- `npm test -- --run src/contexts/ChatContext.tts.test.tsx src/features/tts/useTTS.test.ts src/features/chat/runtime/projection.test.ts` — 42 tests passed
- `npm run build` — passed
- Manual probe: `POST /api/tts` returned valid `audio/mpeg`
- Manual UI test: post-fix voice marker playback worked after rebuild/restart
