### PR TITLE
fix(chat-runtime): reducer correctness — tool groups & hydration ready

### DIFF
--- a/server/lib/chat-runtime/reducer.test.ts
+++ b/server/lib/chat-runtime/reducer.test.ts
@@ -1056,7 +1056,7 @@ describe('chat runtime reducer', () => {
 
     expect(group0).toMatchObject({
       kind: 'tool_group',
-      status: 'failed',
+      status: 'running',
       source: 'history',
       closed: true,
       childItemIds: [tool1Id],
@@ -1089,9 +1089,8 @@ describe('chat runtime reducer', () => {
       .map((item) => item.id);
     orderedIds = timelineItemsInOrder(timeline).map((item) => item.id);
 
-    expect(group0).toMatchObject({ status: 'failed', source: 'history', closed: true, childItemIds: [tool1Id] });
-    expect(group1).toMatchObject({ source: 'history', closed: true, childItemIds: [tool2Id] });
-    expect(group1).not.toMatchObject({ status: 'running' });
+    expect(group0).toMatchObject({ status: 'running', source: 'history', closed: true, childItemIds: [tool1Id] });
+    expect(group1).toMatchObject({ status: 'running', source: 'history', closed: true, childItemIds: [tool2Id] });
     expect(orderedIds.indexOf(group1Id)).toBeLessThan(orderedIds.indexOf(assistantId));
     expect(orderedTopLevelIds).toEqual([group0Id, thinkingId, group1Id, assistantId]);
   });
@@ -1318,5 +1317,34 @@ describe('chat runtime reducer', () => {
       source: 'history',
       durationMs: 2500,
     });
+  });
+
+  it('keeps tool group status running when closed with no terminal or failed children', () => {
+    let timeline = createEmptyTimeline('agent:main:main');
+    timeline = reduceRuntimeEvent(timeline, { type: 'turn_started', sessionKey: 'agent:main:main', runId: 'run-1', at: 1000 });
+    timeline = reduceRuntimeEvent(timeline, { type: 'tool_started', sessionKey: 'agent:main:main', runId: 'run-1', toolCallId: 'call-1', name: 'bash', args: {}, at: 1001 });
+    // No tool_finished/failed. Then start an assistant delta which currently force-closes the group.
+    timeline = reduceRuntimeEvent(timeline, { type: 'assistant_delta', sessionKey: 'agent:main:main', runId: 'run-1', text: 'mid-stream text', at: 1002 });
+
+    const groups = Object.values(timeline.items).filter((item) => item.kind === 'tool_group');
+    expect(groups).toHaveLength(1);
+    expect(groups[0].status).toBe('running');
+  });
+
+  it('finalizes a running tool child when its own completion event arrives after an assistant delta', () => {
+    let timeline = createEmptyTimeline('agent:main:main');
+    // 1. Start a turn.
+    timeline = reduceRuntimeEvent(timeline, { type: 'turn_started', sessionKey: 'agent:main:main', runId: 'run-1', at: 1000 });
+    // 2. Start a tool call.
+    timeline = reduceRuntimeEvent(timeline, { type: 'tool_started', sessionKey: 'agent:main:main', runId: 'run-1', toolCallId: 'call-1', name: 'bash', args: { command: 'ls' }, at: 1001 });
+    // 3. An assistant delta arrives before the tool finishes (the output boundary crossing).
+    timeline = reduceRuntimeEvent(timeline, { type: 'assistant_delta', sessionKey: 'agent:main:main', runId: 'run-1', text: 'here is the result', at: 1002 });
+    // 4. The tool completion event finally arrives.
+    timeline = reduceRuntimeEvent(timeline, { type: 'tool_finished', sessionKey: 'agent:main:main', runId: 'run-1', toolCallId: 'call-1', result: 'file.txt', at: 1003 });
+
+    // 5. The tool call item must be complete, not stuck at 'running'.
+    const toolCalls = Object.values(timeline.items).filter((item) => item.kind === 'tool_call');
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0].status).toBe('complete');
   });
 });

--- a/server/lib/chat-runtime/reducer.ts
+++ b/server/lib/chat-runtime/reducer.ts
@@ -511,7 +511,7 @@ function closedToolGroupStatus(
   if (childStatuses.some((status) => status === 'failed' || status === 'aborted')) return 'failed';
   if (areToolGroupChildrenTerminal(timeline, childItemIds)) return 'complete';
   if (existingStatus && existingStatus !== 'running') return existingStatus;
-  return 'failed';
+  return 'running';
 }
 
 function closeOpenToolGroupsForOutputBoundary(timeline: SessionTimeline, turn: TimelineTurn, at: number): void {
@@ -519,7 +519,6 @@ function closeOpenToolGroupsForOutputBoundary(timeline: SessionTimeline, turn: T
     if (group.closed) continue;
 
     const childItemIds = [...group.childItemIds];
-    terminalizeToolGroupChildren(timeline, childItemIds, at, 'failed');
     timeline.items[group.id] = {
       ...group,
       childItemIds,

--- a/server/lib/chat-runtime/store.test.ts
+++ b/server/lib/chat-runtime/store.test.ts
@@ -291,6 +291,19 @@ describe('ChatTimelineStore', () => {
 
     expect(store.replayAfter('agent:main:main', first.cursor)).toEqual({ kind: 'snapshot_required' });
   });
+
+  it('marks timeline ready after replaceEvents even without a history_snapshot event', () => {
+    const store = new ChatTimelineStore({ maxPatchesPerSession: 16 });
+    const sessionKey = 'agent:main:main';
+
+    store.replaceEvents(sessionKey, [
+      { type: 'turn_started', sessionKey, runId: 'run-1', at: 1000 },
+      { type: 'turn_finalized', sessionKey, runId: 'run-1', at: 1001 },
+    ]);
+
+    const snapshot = store.snapshot(sessionKey, 'manual');
+    expect(snapshot.timeline.hydrationState).toBe('ready');
+  });
 });
 
 describe('ChatRuntime', () => {

--- a/server/lib/chat-runtime/store.ts
+++ b/server/lib/chat-runtime/store.ts
@@ -121,6 +121,10 @@ export class ChatTimelineStore {
     const version = current.version + 1;
     next = {
       ...next,
+      // Replace always represents a hydration / reset boundary, so the timeline
+      // is by definition ready after the replay completes — regardless of
+      // whether the input contained an explicit history_snapshot event.
+      hydrationState: options.mode === 'replace' ? 'ready' : next.hydrationState,
       version,
       cursor: String(version),
       updatedAt: Math.max(next.updatedAt, createdAt),


### PR DESCRIPTION
## Summary
Two small, surgical reducer/store fixes from the `next` branch review (PR A).

- **C6 + I4** (`reducer.ts`): `closeOpenToolGroupsForOutputBoundary` no longer marks running tool children as `'failed'` when an assistant text/thinking block opens mid-stream. Real OpenClaw streaming order is `tool_started → assistant_delta → tool_finished`; running children now stay `running` and the group is closed without fabricating a failure signal. The companion change in `closedToolGroupStatus` flips the default branch from `'failed'` to `'running'` (necessary so the new behavior is observable). Two pre-existing assertions in "uses thinking as a tool group boundary…" that encoded the bug were updated from `'failed'` to `'running'`.
- **I3** (`store.ts`): `applySessionEvents` in `'replace'` mode forces `hydrationState='ready'` regardless of whether the input contains a `history_snapshot` event. Callers passing only synthetic events (e.g. `turn_finalized` from active history sync) no longer leave the timeline stuck `'cold'`.

Each fix lands with a TDD red→green test in the existing reducer/store test files.

## Test plan
- [x] `npx vitest run server/lib/chat-runtime` — 144 tests pass (6 files)
- [x] `npm run lint` — 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined tool execution state tracking during complex chat interactions for more accurate status handling
  * Enhanced chat session initialization to properly restore state even when full history snapshots aren't available

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daggerhashimoto/openclaw-nerve/pull/342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->