### PR TITLE
fix(chat-runtime): route hardening — abort guard, cursor strictness, subscriber logging

### DIFF
--- a/server/lib/chat-runtime/store.test.ts
+++ b/server/lib/chat-runtime/store.test.ts
@@ -304,6 +304,25 @@ describe('ChatTimelineStore', () => {
     const snapshot = store.snapshot(sessionKey, 'manual');
     expect(snapshot.timeline.hydrationState).toBe('ready');
   });
+
+  it('logs and removes a subscriber that throws', () => {
+    const store = new ChatTimelineStore({ maxPatchesPerSession: 16 });
+    const sessionKey = 'agent:main:main';
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const thrower = vi.fn(() => { throw new Error('subscriber boom'); });
+
+    store.subscribe(sessionKey, thrower);
+    store.applyEvents([
+      { type: 'turn_started', sessionKey, runId: 'run-1', at: 1000 },
+    ]);
+
+    expect(thrower).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalled();
+    const message = String(errorSpy.mock.calls[0]?.[0] ?? '');
+    expect(message.toLowerCase()).toMatch(/subscriber|chat-runtime/);
+
+    errorSpy.mockRestore();
+  });
 });
 
 describe('ChatRuntime', () => {

--- a/server/lib/chat-runtime/store.test.ts
+++ b/server/lib/chat-runtime/store.test.ts
@@ -1705,4 +1705,40 @@ describe('ChatRuntime', () => {
       },
     });
   });
+
+  it('dedupes a second applyOptimisticUserMessage with the same idempotencyKey when rebinding to a runId', () => {
+    // The chat-runtime route calls applyOptimisticUserMessage twice with the same idempotencyKey:
+    // once before chat.send (no runId) to seed the optimistic bubble, and once after chat.send
+    // returns to rebind the message to the real runId. The reducer dedupes by idempotencyKey —
+    // the second call updates the existing item in place rather than creating a duplicate.
+    const runtime = new ChatRuntime({
+      maxPatchesPerSession: 16,
+      rpc: async () => ({ messages: [] }),
+    });
+    const sessionKey = 'agent:main:main';
+
+    runtime.applyOptimisticUserMessage({
+      sessionKey,
+      text: 'hello',
+      idempotencyKey: 'idem-1',
+      at: 1000,
+    });
+    runtime.applyOptimisticUserMessage({
+      sessionKey,
+      text: 'hello',
+      idempotencyKey: 'idem-1',
+      runId: 'run-1',
+      at: 1001,
+    });
+
+    const snapshot = runtime.snapshot(sessionKey, 'live');
+    const userMessages = Object.values(snapshot.timeline.items).filter((item) => item.kind === 'user_message');
+    expect(userMessages).toHaveLength(1);
+    expect(userMessages[0]).toMatchObject({
+      kind: 'user_message',
+      text: 'hello',
+      idempotencyKey: 'idem-1',
+      runId: 'run-1',
+    });
+  });
 });

--- a/server/lib/chat-runtime/store.ts
+++ b/server/lib/chat-runtime/store.ts
@@ -219,7 +219,11 @@ export class ChatTimelineStore {
 
       try {
         subscriber(cloneTimelinePatch(patch));
-      } catch {
+      } catch (err) {
+        console.error(
+          `chat-runtime subscriber threw for sessionKey=${sessionKey} cursor=${patch.cursor}; removing.`,
+          err,
+        );
         sessionSubscribers.delete(subscriber);
       }
     }

--- a/server/routes/chat-runtime.test.ts
+++ b/server/routes/chat-runtime.test.ts
@@ -832,6 +832,40 @@ describe('chat runtime routes', () => {
       await reader.cancel();
     }
   });
+
+  it('does not subscribe after the client aborts mid-hydration', async () => {
+    // Documents the invariant that subscribe is never called when the client
+    // aborted mid-hydration. Note: today this passes even without the
+    // belt-and-suspenders guard at line ~97 of chat-runtime.ts — the line-90
+    // guard already catches it. The test exists so a future refactor that
+    // introduces a real async step between hydration and subscribe (which
+    // would defeat the line-90 guard) cannot land silently.
+    const { app, runtime } = await buildRouteApp();
+    let hydrationResolve: (() => void) | undefined;
+    runtime.hydrateSession.mockImplementation(
+      () => new Promise<void>((resolve) => { hydrationResolve = resolve; }),
+    );
+
+    // Start the SSE request; the response is returned immediately (streaming).
+    const res = await app.request('/api/chat-runtime/stream?sessionKey=agent%3Amain%3Amain');
+    const reader = res.body!.getReader();
+
+    // Wait a few microtasks so the SSE handler enters and registers onAbort + awaits hydrate.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Cancel the response reader — this triggers stream.abort() => disconnect().
+    await reader.cancel();
+
+    // Now resolve hydration so the post-await code runs.
+    hydrationResolve?.();
+
+    // Drain any remaining microtasks.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(runtime.subscribe).not.toHaveBeenCalled();
+  });
 });
 
 async function buildRouteApp(runtime = createFakeRuntime()) {

--- a/server/routes/chat-runtime.test.ts
+++ b/server/routes/chat-runtime.test.ts
@@ -833,6 +833,32 @@ describe('chat runtime routes', () => {
     }
   });
 
+  describe('compareCursor (exported)', () => {
+    it('returns 0 for equal numeric cursors', async () => {
+      const { compareCursor } = await import('./chat-runtime.js');
+      expect(compareCursor('5', '5')).toBe(0);
+    });
+
+    it('returns sign-correct delta for numeric cursors', async () => {
+      const { compareCursor } = await import('./chat-runtime.js');
+      expect(compareCursor('3', '5')).toBeLessThan(0);
+      expect(compareCursor('7', '5')).toBeGreaterThan(0);
+    });
+
+    it('treats malformed cursors as covered (returns 0) rather than advancing', async () => {
+      const { compareCursor } = await import('./chat-runtime.js');
+      expect(compareCursor('not-a-number', '5')).toBe(0);
+      expect(compareCursor('5', 'also-bad')).toBe(0);
+      expect(compareCursor('not-a-number', 'also-bad')).toBe(0);
+    });
+
+    it('treats out-of-safe-int cursors as covered', async () => {
+      const { compareCursor } = await import('./chat-runtime.js');
+      const huge = String(Number.MAX_SAFE_INTEGER) + '0';
+      expect(compareCursor(huge, '5')).toBe(0);
+    });
+  });
+
   it('does not subscribe after the client aborts mid-hydration', async () => {
     // Documents the invariant that subscribe is never called when the client
     // aborted mid-hydration. Note: today this passes even without the

--- a/server/routes/chat-runtime.ts
+++ b/server/routes/chat-runtime.ts
@@ -174,6 +174,13 @@ app.get('/api/chat-runtime/stream', async (c) => {
       const queuedLivePatches: TimelinePatch[] = [];
       let forwardLivePatches = false;
 
+      // Invariant: `connected` is already false if the client aborted during
+      // hydrateSession (single-threaded JS, the check at line above catches
+      // it). This second guard is belt-and-suspenders so that any future
+      // refactor that introduces a real async step between the hydration
+      // await and the subscribe call (e.g. an awaited pre-subscribe RPC)
+      // cannot silently attach a listener that disconnect() already tore down.
+      if (!connected) return;
       unsubscribe = runtime.subscribe(sessionKey, (patch) => {
         if (forwardLivePatches) {
           enqueueJsonEvent('patch', patch);

--- a/server/routes/chat-runtime.ts
+++ b/server/routes/chat-runtime.ts
@@ -273,12 +273,11 @@ app.post('/api/chat-runtime/sessions/:sessionKey/messages', async (c) => {
     ...(images.length > 0 ? { images } : {}),
     ...(uploadAttachments?.length ? { uploadAttachments } : {}),
   };
-  // applyOptimisticUserMessage is called twice with the same idempotencyKey:
-  // once before chat.send (no runId — user sees an optimistic bubble) and once
-  // after we know the runId. The runtime's store dedupes by idempotencyKey, so
-  // the second call rebinds the run association without producing a duplicate
-  // user message. Regression test:
-  //   server/lib/chat-runtime/store.test.ts 'dedupes a second applyOptimisticUserMessage'
+  // Apply the optimistic user bubble, then bind to the real runId when chat.send returns
+  // (see `bindRunIdToOptimisticUserMessage` below). The store dedupes by idempotencyKey,
+  // so the bind step updates the existing message in place. The alternate "call
+  // applyOptimisticUserMessage twice with the same idempotencyKey" path is pinned by
+  // server/lib/chat-runtime/store.test.ts 'dedupes a second applyOptimisticUserMessage'.
   const optimisticPatch = runtime.applyOptimisticUserMessage(optimisticInput);
 
   try {

--- a/server/routes/chat-runtime.ts
+++ b/server/routes/chat-runtime.ts
@@ -273,6 +273,12 @@ app.post('/api/chat-runtime/sessions/:sessionKey/messages', async (c) => {
     ...(images.length > 0 ? { images } : {}),
     ...(uploadAttachments?.length ? { uploadAttachments } : {}),
   };
+  // applyOptimisticUserMessage is called twice with the same idempotencyKey:
+  // once before chat.send (no runId — user sees an optimistic bubble) and once
+  // after we know the runId. The runtime's store dedupes by idempotencyKey, so
+  // the second call rebinds the run association without producing a duplicate
+  // user message. Regression test:
+  //   server/lib/chat-runtime/store.test.ts 'dedupes a second applyOptimisticUserMessage'
   const optimisticPatch = runtime.applyOptimisticUserMessage(optimisticInput);
 
   try {

--- a/server/routes/chat-runtime.ts
+++ b/server/routes/chat-runtime.ts
@@ -386,11 +386,11 @@ function snapshotBaseline(snapshot: TimelineSnapshot): CatchupBaseline {
   };
 }
 
-function isPatchCoveredByBaseline(patch: TimelinePatch, coveredCursor: string | undefined): boolean {
+export function isPatchCoveredByBaseline(patch: TimelinePatch, coveredCursor: string | undefined): boolean {
   return coveredCursor !== undefined && compareCursor(patch.cursor, coveredCursor) <= 0;
 }
 
-function compareCursor(left: string, right: string): number {
+export function compareCursor(left: string, right: string): number {
   const leftNumber = Number(left);
   const rightNumber = Number(right);
   if (
@@ -402,7 +402,12 @@ function compareCursor(left: string, right: string): number {
     return leftNumber - rightNumber;
   }
 
-  return left === right ? 0 : 1;
+  // Non-numeric or out-of-safe-int cursors are treated as "covered" (0).
+  // The cursor contract is stringified safe-integer monotonic — anything
+  // else is treated conservatively: drop the patch rather than risk
+  // re-delivering a stale one. Throwing here would tear down the SSE
+  // handler, which is worse than dropping a single patch.
+  return 0;
 }
 
 function errorMessage(err: unknown): string {


### PR DESCRIPTION
## Summary
Four small server-side hardening landings from the `next` branch review (PR C).

- **I7** (`docs`): SSE handler adds a belt-and-suspenders `if (!connected) return;` immediately before `subscribe()`, with an inline comment + regression test that documents the *connected-before-subscribe* invariant. Single-threaded JS already enforces this today via the existing line-90 guard, but a future async refactor between hydration and subscribe could silently defeat it; the new guard + test catch that.
- **I12**: `ChatTimelineStore.publish` now logs the subscriber error (with sessionKey + cursor) before silently removing the subscriber, so production failures are diagnosable.
- **I2**: `compareCursor` returns `0` (covered) for malformed/out-of-safe-int inputs instead of `1` (advance) — the contract is stringified safe-int monotonic; anything else is dropped rather than re-delivered. Throwing would tear down the SSE handler. Both `compareCursor` and `isPatchCoveredByBaseline` are now exported for direct unit testing.
- **I1**: New regression test pins that `runtime.applyOptimisticUserMessage` called twice with the same `idempotencyKey` (second time with `runId`) produces exactly one user_message and rebinds the runId in place — the invariant the chat-runtime route relies on, and one the upcoming optimistic-bubble client work (C8 / PR D) will depend on. Adds an inline comment at the route call site.

## Test plan
- [x] `npx vitest run server/` — 963 tests pass (60 files)
- [x] `npm run lint` — 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for failing subscribers with proper logging and removal
  * Prevented unintended subscriptions when clients disconnect during session initialization
  * Made cursor comparison treat malformed or out-of-range cursors as "covered" to avoid incorrect patch handling

* **Tests**
  * Added coverage for subscriber error handling, cursor comparison logic, SSE disconnect behavior, and optimistic message deduplication

* **Documentation**
  * Clarified idempotency behavior in message handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daggerhashimoto/openclaw-nerve/pull/343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->