### PR TITLE
fix(whisper): cgroup-aware threads + Vulkan ICD manifest fallback

### DIFF
--- a/server/services/whisper-local.ts
+++ b/server/services/whisper-local.ts
@@ -80,10 +80,24 @@ async function getContext(): Promise<WhisperContext> {
   const useGpu = process.platform !== 'linux' || hasVulkanBackend();
   const backend = process.platform === 'linux' && useGpu ? 'vulkan' : undefined;
 
-  contextInitializing = initWhisper({
-    filePath: modelPath(),
-    useGpu, // Metal on macOS; Vulkan on Linux when present; CPU fallback elsewhere
-  }, backend).then((ctx) => {
+  // initWhisper throws synchronously inside the promise if the requested
+  // backend can't initialize (e.g., the ICD manifest probe matched a stale
+  // JSON whose driver library isn't loadable). Fall back to CPU once if the
+  // Vulkan path fails — the probes are heuristics, not load-time guarantees.
+  const initWithFallback = async (): Promise<WhisperContext> => {
+    try {
+      return await initWhisper({ filePath: modelPath(), useGpu }, backend);
+    } catch (err) {
+      if (backend !== 'vulkan') throw err;
+      console.warn(
+        `[whisper-local] Vulkan init failed, retrying on CPU: ${(err as Error).message}`,
+      );
+      vulkanBackendAvailable = false; // poison the cache so future inits skip the probe
+      return initWhisper({ filePath: modelPath(), useGpu: false });
+    }
+  };
+
+  contextInitializing = initWithFallback().then((ctx) => {
     whisperContext = ctx;
     contextInitializing = null;
     console.log(`[whisper-local] Model loaded: ${activeModel}`);

--- a/server/services/whisper-local.ts
+++ b/server/services/whisper-local.ts
@@ -93,6 +93,7 @@ async function getContext(): Promise<WhisperContext> {
         `[whisper-local] Vulkan init failed, retrying on CPU: ${(err as Error).message}`,
       );
       vulkanBackendAvailable = false; // poison the cache so future inits skip the probe
+      gpuDetected = null; // force detectGpu() to recompute so getSystemInfo() reports the post-fallback state
       return initWhisper({ filePath: modelPath(), useGpu: false });
     }
   };

--- a/server/services/whisper-local.ts
+++ b/server/services/whisper-local.ts
@@ -307,13 +307,20 @@ const VULKAN_ICD_DIRS = [
  * Honors `VK_DRIVER_FILES` / `VK_ICD_FILENAMES` overrides as the loader does.
  */
 function hasVulkanIcdManifest(): boolean {
-  const explicit = (process.env.VK_DRIVER_FILES ?? process.env.VK_ICD_FILENAMES)?.trim();
-  if (explicit) {
-    return explicit.split(':').some(p => {
-      if (!p) return false;
-      try { accessSync(p); return true; } catch { return false; }
-    });
-  }
+  const checkPath = (p: string): boolean => {
+    if (!p) return false;
+    try { accessSync(p); return true; } catch { return false; }
+  };
+  const checkList = (raw: string | undefined): boolean =>
+    raw ? raw.split(':').some(checkPath) : false;
+
+  // VK_DRIVER_FILES / legacy VK_ICD_FILENAMES *replace* the loader's default search.
+  const replace = (process.env.VK_DRIVER_FILES ?? process.env.VK_ICD_FILENAMES)?.trim();
+  if (replace) return checkList(replace);
+
+  // VK_ADD_DRIVER_FILES is *additive* on top of the default search.
+  if (checkList(process.env.VK_ADD_DRIVER_FILES?.trim())) return true;
+
   return VULKAN_ICD_DIRS.some(dir => {
     try {
       return readdirSync(dir).some(f => f.endsWith('.json'));

--- a/server/services/whisper-local.ts
+++ b/server/services/whisper-local.ts
@@ -8,7 +8,7 @@
 
 import { execFileSync, execSync } from 'node:child_process';
 import { writeFileSync, unlinkSync, accessSync, mkdirSync, createWriteStream, readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, delimiter as pathDelimiter } from 'node:path';
 import { tmpdir, cpus, availableParallelism } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { initWhisper } from '@fugood/whisper.node';
@@ -312,7 +312,9 @@ function hasVulkanIcdManifest(): boolean {
     try { accessSync(p); return true; } catch { return false; }
   };
   const checkList = (raw: string | undefined): boolean =>
-    raw ? raw.split(':').some(checkPath) : false;
+    // Loader splits these env vars on the OS path-list delimiter (`:` POSIX, `;` Win).
+    // Hardcoding `:` would mangle Windows entries like `C:\drivers\nvidia.json`.
+    raw ? raw.split(pathDelimiter).some(checkPath) : false;
 
   // VK_DRIVER_FILES / legacy VK_ICD_FILENAMES *replace* the loader's default search.
   const replace = (process.env.VK_DRIVER_FILES ?? process.env.VK_ICD_FILENAMES)?.trim();

--- a/server/services/whisper-local.ts
+++ b/server/services/whisper-local.ts
@@ -7,9 +7,9 @@
  */
 
 import { execFileSync, execSync } from 'node:child_process';
-import { writeFileSync, unlinkSync, accessSync, mkdirSync, createWriteStream } from 'node:fs';
+import { writeFileSync, unlinkSync, accessSync, mkdirSync, createWriteStream, readdirSync } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir, cpus } from 'node:os';
+import { tmpdir, cpus, availableParallelism } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { initWhisper } from '@fugood/whisper.node';
 import type { WhisperContext, TranscribeOptions } from '@fugood/whisper.node';
@@ -279,15 +279,49 @@ export async function setWhisperModel(model: string): Promise<{ ok: boolean; mes
 let gpuDetected: boolean | null = null;
 let vulkanBackendAvailable: boolean | null = null;
 
-/** Probe for a Vulkan ICD/runtime specifically — the stricter check needed before passing 'vulkan' to initWhisper. */
+/** Standard Vulkan loader ICD manifest directories per the Vulkan-Loader spec. */
+const VULKAN_ICD_DIRS = [
+  '/usr/share/vulkan/icd.d',
+  '/usr/local/share/vulkan/icd.d',
+  '/etc/vulkan/icd.d',
+];
+
+/**
+ * Detect a Vulkan ICD via manifest enumeration — covers slim containers that ship
+ * libvulkan + ICD JSONs but omit the `vulkan-tools` (`vulkaninfo`) CLI package.
+ * Honors `VK_DRIVER_FILES` / `VK_ICD_FILENAMES` overrides as the loader does.
+ */
+function hasVulkanIcdManifest(): boolean {
+  const explicit = (process.env.VK_DRIVER_FILES ?? process.env.VK_ICD_FILENAMES)?.trim();
+  if (explicit) {
+    return explicit.split(':').some(p => {
+      if (!p) return false;
+      try { accessSync(p); return true; } catch { return false; }
+    });
+  }
+  return VULKAN_ICD_DIRS.some(dir => {
+    try {
+      return readdirSync(dir).some(f => f.endsWith('.json'));
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
+ * Probe for a Vulkan ICD/runtime — the stricter check needed before passing 'vulkan'
+ * to initWhisper. Prefers `vulkaninfo --summary` (most authoritative), then falls
+ * back to ICD manifest enumeration so slim Linux containers with the runtime but
+ * no CLI tools still light up the GPU path.
+ */
 function hasVulkanBackend(): boolean {
   if (vulkanBackendAvailable !== null) return vulkanBackendAvailable;
   try {
     execSync('vulkaninfo --summary', { stdio: 'pipe', timeout: 3000 });
     vulkanBackendAvailable = true;
-  } catch {
-    vulkanBackendAvailable = false;
-  }
+    return vulkanBackendAvailable;
+  } catch { /* fall through */ }
+  vulkanBackendAvailable = hasVulkanIcdManifest();
   return vulkanBackendAvailable;
 }
 
@@ -416,7 +450,10 @@ export async function transcribeLocal(
     const transcribeOpts: TranscribeOptions = {
       temperature: 0.0,
       language: whisperLang,
-      maxThreads: cpus().length,
+      // availableParallelism honors cgroup CPU quota on Linux (libuv reads
+      // cgroup v1/v2 CFS limits + sched_getaffinity); cpus().length over-allocates
+      // worker threads inside containers with a CPU quota smaller than the host.
+      maxThreads: availableParallelism(),
     };
     const { promise } = ctx.transcribeFile(wavTmp, transcribeOpts);
 


### PR DESCRIPTION
## Summary

Two small fixes to `server/services/whisper-local.ts`, both filed today by CodeRabbit during the #319 review:

### Closes #346 — cgroup-aware thread count

Swap `cpus().length` for `os.availableParallelism()` when computing the transcription `maxThreads`. libuv's implementation (Node 22+) reads cgroup v1/v2 CFS quotas and `sched_getaffinity`, so worker thread allocation now scales to the container's actual CPU budget instead of the host's logical-core count.

### Closes #347 — Vulkan ICD manifest probe fallback

Add a manifest-enumeration fallback to `hasVulkanBackend()`. The previous code disabled the Vulkan backend whenever `vulkaninfo --summary` failed, which silently skipped GPU transcription on slim container images that ship the Vulkan runtime (`libvulkan.so.1` + ICD JSONs) without the `vulkan-tools` (`vulkaninfo`) package.

The new flow:
1. **Primary:** `vulkaninfo --summary` (most authoritative — also reports loader/instance health)
2. **Fallback:** enumerate ICD manifests at the standard loader search paths and honor `VK_DRIVER_FILES` / `VK_ICD_FILENAMES` overrides, matching how the Vulkan loader itself locates ICDs

Standard search paths:
- `/usr/share/vulkan/icd.d`
- `/usr/local/share/vulkan/icd.d`
- `/etc/vulkan/icd.d`

## Verification

- \`npm run build:server\` — clean
- No new test file added; \`whisper-local.ts\` has no test harness yet, and both changes are runtime-detection paths whose behavior depends on the host's filesystem layout (hard to mock cleanly for a single helper)

## Out of scope

Neither change touches the macOS/Windows code paths. \`cpus().length\` still feeds \`getSystemInfo().cpuCount\` (host info, distinct from "what we can use").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU detection by checking standard Vulkan manifest locations and honoring environment overrides.
  * Prefer system tooling for Vulkan availability checks, with a manifest-based fallback when tools are unavailable.
  * If GPU backend initialization fails, retry once on CPU and mark the GPU backend unavailable to avoid repeated probes.
  * Adjusted transcription threading to respect container/cgroup CPU quotas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daggerhashimoto/openclaw-nerve/pull/348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->