### PR TITLE
fix: sync wake-word listener on refresh

### DIFF
--- a/src/features/voice/useVoiceInput.test.ts
+++ b/src/features/voice/useVoiceInput.test.ts
@@ -20,6 +20,7 @@ vi.mock('./wakeWordSupport', () => ({
 
 // Mock SpeechRecognition
 class MockSpeechRecognition {
+  static instances: MockSpeechRecognition[] = [];
   continuous = false;
   interimResults = false;
   lang = '';
@@ -27,6 +28,10 @@ class MockSpeechRecognition {
   onerror: ((event: { error: string }) => void) | null = null;
   onend: (() => void) | null = null;
   started = false;
+
+  constructor() {
+    MockSpeechRecognition.instances.push(this);
+  }
 
   start() {
     this.started = true;
@@ -99,6 +104,7 @@ describe('useVoiceInput', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    MockSpeechRecognition.instances = [];
     MockMediaRecorder.instances = [];
     mockRecognition = null;
 
@@ -117,6 +123,10 @@ describe('useVoiceInput', () => {
     // Mock getUserMedia
     (navigator as unknown as { mediaDevices: { getUserMedia: Mock } }).mediaDevices = {
       getUserMedia: vi.fn().mockResolvedValue(new MockMediaStream()),
+    };
+
+    (navigator as unknown as { permissions?: { query: Mock } }).permissions = {
+      query: vi.fn().mockResolvedValue({ state: 'granted' }),
     };
 
     // Mock fetch for voice phrases and transcription
@@ -157,6 +167,7 @@ describe('useVoiceInput', () => {
     globalThis.fetch = originalFetch;
     delete (window as unknown as { SpeechRecognition?: unknown }).SpeechRecognition;
     delete (window as unknown as { webkitSpeechRecognition?: unknown }).webkitSpeechRecognition;
+    delete (navigator as unknown as { permissions?: unknown }).permissions;
   });
 
   describe('Initial State', () => {
@@ -255,6 +266,64 @@ describe('useVoiceInput', () => {
       expect(result.current.voiceState).toBe('idle');
       expect(result.current.wakeWordEnabled).toBe(false);
       expect(audioFeedback.ensureAudioContext).not.toHaveBeenCalled();
+    });
+
+    it('auto-starts wake listening on load when persisted on and microphone is granted', async () => {
+      localStorage.setItem('nerve:wakeWordEnabled', 'true');
+      const onTranscription = vi.fn();
+
+      const { result } = renderHook(() => useVoiceInput(onTranscription));
+
+      await act(async () => {
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      expect(navigator.permissions?.query).toHaveBeenCalledWith({ name: 'microphone' });
+      expect(result.current.wakeWordEnabled).toBe(true);
+      expect(result.current.voiceState).toBe('listening');
+      expect(mockRecognition?.started).toBe(true);
+    });
+
+    it('clears persisted wake state when microphone permission is not granted', async () => {
+      localStorage.setItem('nerve:wakeWordEnabled', 'true');
+      (navigator.permissions?.query as Mock).mockResolvedValue({ state: 'prompt' });
+      const onTranscription = vi.fn();
+
+      const { result } = renderHook(() => useVoiceInput(onTranscription));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.wakeWordEnabled).toBe(false);
+      expect(result.current.voiceState).toBe('idle');
+      expect(localStorage.getItem('nerve:wakeWordEnabled')).toBe('false');
+      expect(MockSpeechRecognition.instances).toHaveLength(0);
+    });
+
+    it('does not create a stale wake listener after the persisted toggle is switched off during startup', async () => {
+      localStorage.setItem('nerve:wakeWordEnabled', 'true');
+      let resolvePermission!: (value: { state: PermissionState }) => void;
+      (navigator.permissions?.query as Mock).mockReturnValue(new Promise((resolve) => {
+        resolvePermission = resolve;
+      }));
+      const onTranscription = vi.fn();
+      const { result } = renderHook(() => useVoiceInput(onTranscription));
+
+      act(() => {
+        result.current.stopWakeWordListener();
+      });
+      resolvePermission({ state: 'granted' });
+
+      await act(async () => {
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      expect(result.current.wakeWordEnabled).toBe(false);
+      expect(result.current.voiceState).toBe('idle');
+      expect(MockSpeechRecognition.instances).toHaveLength(0);
     });
 
     it('still allows manual recording on mobile web', async () => {

--- a/src/features/voice/useVoiceInput.ts
+++ b/src/features/voice/useVoiceInput.ts
@@ -162,6 +162,7 @@ export function useVoiceInput(
 
   // Single persistent recognition instance
   const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const recognitionStartTokenRef = useRef(0);
   const wakeWordSupport = useMemo(() => getWakeWordSupport(), []);
   const wakeWordSupported = wakeWordSupport.supported;
   const [storedWakeWordEnabled, setStoredWakeWordEnabled] = useState(() => {
@@ -251,6 +252,7 @@ export function useVoiceInput(
   // Start or restart the single recognition instance
   const ensureRecognition = useCallback((mode: 'wake' | 'stop') => {
     modeRef.current = mode;
+    const startToken = ++recognitionStartTokenRef.current;
 
     // If we already have a running instance, abort it first
     if (recognitionRef.current) {
@@ -275,6 +277,7 @@ export function useVoiceInput(
     // Small delay to let the previous instance fully release
     trackedTimeout(() => {
       // Re-check state — might have changed during the delay
+      if (startToken !== recognitionStartTokenRef.current) return;
       if (mode === 'wake' && !wakeWordEnabledRef.current) return;
       if (mode === 'stop' && stateRef.current !== 'recording') return;
 
@@ -383,6 +386,7 @@ export function useVoiceInput(
     // Initialize AudioContext on user interaction
     ensureAudioContext();
     // Stop recognition intentionally — we'll restart in stop mode after recording starts
+    recognitionStartTokenRef.current += 1;
     intentionalStopRef.current = true;
     try { recognitionRef.current?.abort(); } catch { /* already stopped */ }
     recognitionRef.current = null;
@@ -418,6 +422,7 @@ export function useVoiceInput(
     setInterimTranscript('');
     resetBrowserTranscript();
     wakeTriggeredRef.current = false;
+    recognitionStartTokenRef.current += 1;
     intentionalStopRef.current = true;
     try { recognitionRef.current?.abort(); } catch { /* already stopped */ }
     recognitionRef.current = null;
@@ -459,6 +464,7 @@ export function useVoiceInput(
     if (!mr || mr.state !== 'recording') return;
     setInterimTranscript('');
     wakeTriggeredRef.current = false;
+    recognitionStartTokenRef.current += 1;
     intentionalStopRef.current = true;
     try {
       recognitionRef.current?.stop();
@@ -547,6 +553,7 @@ export function useVoiceInput(
 
   const stopWakeWordListener = useCallback(() => {
     wakeWordEnabledRef.current = false;
+    recognitionStartTokenRef.current += 1;
     intentionalStopRef.current = true;
     try { recognitionRef.current?.abort(); } catch { /* already stopped */ }
     recognitionRef.current = null;
@@ -574,18 +581,41 @@ export function useVoiceInput(
   const startWakeWordRef = useRef(startWakeWordListener);
   startWakeWordRef.current = startWakeWordListener;
   useEffect(() => {
-    if (!wakeWordSupported || !wakeWordEnabled || wakeWordEnabledRef.current) return;
+    if (!wakeWordSupported || !wakeWordEnabled) return;
+
+    const clearPersistedWakeWord = () => {
+      wakeWordEnabledRef.current = false;
+      recognitionStartTokenRef.current += 1;
+      setStoredWakeWordEnabled(false);
+      if (stateRef.current === 'listening') {
+        setVoiceState('idle');
+      }
+      try { localStorage.removeItem(WAKE_WORD_KEY); } catch { /* noop */ }
+    };
+
+    const autoStartWakeWord = () => {
+      if (!wakeWordEnabledRef.current || stateRef.current !== 'idle') return;
+      startWakeWordRef.current();
+    };
+
     // Only auto-start if mic permission was previously granted (avoid surprise prompts)
-    navigator.permissions?.query({ name: 'microphone' as PermissionName }).then((result) => {
+    const permissionQuery = navigator.permissions?.query?.({ name: 'microphone' as PermissionName });
+    if (!permissionQuery) {
+      // Permissions API not available — try starting anyway (user interaction may be required)
+      autoStartWakeWord();
+      return;
+    }
+
+    permissionQuery.then((result) => {
       if (result.state === 'granted') {
-        startWakeWordRef.current();
+        autoStartWakeWord();
       } else {
         // Permission not granted — clear persisted state so toggle shows off on supported environments
-        try { localStorage.removeItem(WAKE_WORD_KEY); } catch { /* noop */ }
+        clearPersistedWakeWord();
       }
     }).catch(() => {
-      // Permissions API not available — try starting anyway (user interaction required)
-      startWakeWordRef.current();
+      // Permissions API failed — try starting anyway (user interaction may be required)
+      autoStartWakeWord();
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount
   }, []);
@@ -647,6 +677,7 @@ export function useVoiceInput(
       for (const id of timers) clearTimeout(id);
       timers.clear();
       wakeWordEnabledRef.current = false;
+      recognitionStartTokenRef.current += 1;
       intentionalStopRef.current = true;
       try { recognitionRef.current?.abort(); } catch { /* already stopped */ }
       recognitionRef.current = null;


### PR DESCRIPTION
## Summary
- Auto-start the wake-word listener on page load when the persisted preference is enabled and microphone permission is already granted.
- Clear stale persisted wake-word state when permission is not granted so the settings toggle reflects reality.
- Add a recognition startup token to prevent delayed/stale SpeechRecognition instances after toggles, recording, transcription, or cleanup.

## Validation
- `npm test -- --run src/features/voice/useVoiceInput.test.ts` ✅ 62 passed
- `npm run lint -- src/features/voice/useVoiceInput.ts src/features/voice/useVoiceInput.test.ts` ✅
- `npm run build` ✅
- Manual smoke: restarted local Nerve on `127.0.0.1:3080`; user confirmed the wake-word state fix looks good ✅

## Notes
- This PR intentionally includes only `src/features/voice/useVoiceInput.ts` and `src/features/voice/useVoiceInput.test.ts`.
- The worktree had unrelated pre-existing `InputBar` changes; those were left unstaged/uncommitted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice input stability by preventing stale recognition instances from starting unexpectedly.
  * Enhanced microphone permission handling with better fallback support when the Permissions API is unavailable.
  * Fixed wake-word persistence to properly respect microphone permission states and prevent unnecessary listeners from being created.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daggerhashimoto/openclaw-nerve/pull/353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->