### PR TITLE
fix: restore audio feedback and TTS playback

### DIFF
--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -206,7 +206,16 @@ export function ChatProvider({ children }: { children: ReactNode }) {
           playCompletionPing();
         }
       } else if (wasRuntimeGeneratingRef.current) {
-        playCompletionPing();
+        const latestFinalMessageWithTTS = [...messages]
+          .reverse()
+          .find((message) => isRuntimeFinalAssistantMessage(message) && Boolean(message.ttsText));
+        if (latestFinalMessageWithTTS) {
+          handleFinalTTS(chatMessageDataFromRuntimeMessage(latestFinalMessageWithTTS), true, {
+            completionPing: false,
+          });
+        } else {
+          playCompletionPing();
+        }
       }
     }
     wasRuntimeGeneratingRef.current = runtimeIsGenerating;
@@ -375,6 +384,10 @@ function finalMessageDataFromRuntimeMessages(
       ?? singleTimestampFallbackCandidate(candidates, activeRequest.sentAt);
   if (!finalMessage) return null;
 
+  return chatMessageDataFromRuntimeMessage(finalMessage);
+}
+
+function chatMessageDataFromRuntimeMessage(finalMessage: ChatMsg): FinalMessageData {
   const message: ChatMessage = {
     role: 'assistant',
     content: finalMessage.rawText,

--- a/src/contexts/ChatContext.tts.test.tsx
+++ b/src/contexts/ChatContext.tts.test.tsx
@@ -130,6 +130,34 @@ describe('ChatContext runtime TTS playback', () => {
     expect(speakMock).toHaveBeenCalledTimes(1);
   });
 
+  it('speaks a completed TTS marker when generation ends without a tracked active request', async () => {
+    const { ChatProvider, setRuntimeState, speakMock, playPingMock } = await setup({
+      soundEnabled: true,
+    });
+
+    const { rerender } = render(<ChatProvider><div /></ChatProvider>);
+
+    setRuntimeState({ isGenerating: true });
+    rerender(<ChatProvider><div /></ChatProvider>);
+
+    setRuntimeState({
+      isGenerating: false,
+      messages: [{
+        msgId: 'assistant:main:run-1:answer',
+        role: 'assistant',
+        html: '<p>Untracked reply.</p>',
+        rawText: 'Untracked reply.',
+        timestamp: new Date(Date.now() + 1000),
+        ttsText: 'Untracked spoken reply.',
+      }],
+    });
+    rerender(<ChatProvider><div /></ChatProvider>);
+
+    await waitFor(() => expect(speakMock).toHaveBeenCalledWith('Untracked spoken reply.'));
+    expect(speakMock).toHaveBeenCalledTimes(1);
+    expect(playPingMock).not.toHaveBeenCalled();
+  });
+
   it('retains pending TTS requests when generation stops before the final message projects', async () => {
     const { ChatProvider, useChat, setRuntimeState, speakMock } = await setup();
 

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -110,7 +110,7 @@ function resolveInitialFont(): FontName {
 }
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
-  const [soundEnabled, setSoundEnabled] = useState(localStorage.getItem('oc-sound') === 'true');
+  const [soundEnabled, setSoundEnabled] = useState(() => localStorage.getItem('oc-sound') !== 'false');
   const [ttsProvider, setTtsProvider] = useState<TTSProvider>(() => migrateTTSProvider(localStorage.getItem('oc-tts-provider') || 'edge'));
   const [ttsModel, setTtsModelState] = useState(() => localStorage.getItem('oc-tts-model') || '');
   const [sttProvider, setSttProviderState] = useState<STTProvider>(() => {
@@ -164,7 +164,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     const saved = localStorage.getItem(KANBAN_VISIBILITY_STORAGE_KEY);
     return saved !== 'false';
   });
-  const { speak } = useTTS(soundEnabled, ttsProvider, ttsModel || undefined);
+  const { speak } = useTTS(ttsProvider, ttsModel || undefined);
   const wakeWordToggleRef = useRef<(() => void) | null>(null);
 
   // Apply theme on mount and when it changes

--- a/src/features/command-palette/commands.test.ts
+++ b/src/features/command-palette/commands.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createCommands } from './commands';
+import type { CommandActions } from './commands';
+
+function makeActions(): CommandActions {
+  return {
+    onNewSession: vi.fn(),
+    onResetSession: vi.fn(),
+    onToggleSound: vi.fn(),
+    onSettings: vi.fn(),
+    onSearch: vi.fn(),
+    onAbort: vi.fn(),
+    onSetTheme: vi.fn(),
+    onSetFont: vi.fn(),
+    onTtsProviderChange: vi.fn(),
+    onToggleWakeWord: vi.fn(),
+    onToggleEvents: vi.fn(),
+    onToggleLog: vi.fn(),
+    onToggleTelemetry: vi.fn(),
+    onOpenSettings: vi.fn(),
+    onRefreshSessions: vi.fn(),
+    onRefreshMemory: vi.fn(),
+  };
+}
+
+describe('createCommands', () => {
+  it('includes a command for disabling TTS', () => {
+    const actions = makeActions();
+    const command = createCommands(actions).find((candidate) => candidate.id === 'tts-off');
+
+    expect(command).toMatchObject({ label: 'TTS: Off', category: 'voice' });
+    command?.action();
+    expect(actions.onTtsProviderChange).toHaveBeenCalledWith('off');
+  });
+});

--- a/src/features/command-palette/commands.ts
+++ b/src/features/command-palette/commands.ts
@@ -184,6 +184,13 @@ export function createCommands(actions: CommandActions): Command[] {
       keywords: ['tts', 'voice', 'speech', 'xiaomi', 'mimo'],
     },
     {
+      id: 'tts-off',
+      label: 'TTS: Off',
+      action: () => actions.onTtsProviderChange('off' as TTSProvider),
+      category: 'voice',
+      keywords: ['tts', 'voice', 'speech', 'off', 'disable'],
+    },
+    {
       id: 'toggle-wake-word',
       label: 'Toggle Wake Word',
       action: actions.onToggleWakeWord,

--- a/src/features/settings/AudioSettings.component.test.tsx
+++ b/src/features/settings/AudioSettings.component.test.tsx
@@ -173,9 +173,19 @@ describe('AudioSettings', () => {
   });
 
   describe('Xiaomi Mimo output settings', () => {
-    it('renders a Xiaomi Mimo provider button', async () => {
+    it('renders provider buttons including Off', async () => {
       render(<AudioSettings {...baseProps} section="output" ttsProvider="xiaomi" ttsModel="" />);
       expect(await screen.findByRole('button', { name: 'Xiaomi Mimo' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Off' })).toBeInTheDocument();
+    });
+
+    it('does not render provider-specific settings when TTS is off', async () => {
+      render(<AudioSettings {...baseProps} section="output" ttsProvider="off" ttsModel="" />);
+
+      expect(await screen.findByRole('button', { name: 'Off' })).toHaveAttribute('data-active', 'true');
+      expect(screen.queryByLabelText('TTS Model')).not.toBeInTheDocument();
+      expect(screen.queryByText(/OpenAI Voice/i)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Xiaomi Voice')).not.toBeInTheDocument();
     });
 
     it('shows the Xiaomi API key prompt when Xiaomi is selected and the key is missing', async () => {

--- a/src/features/settings/AudioSettings.tsx
+++ b/src/features/settings/AudioSettings.tsx
@@ -413,7 +413,7 @@ function ApiKeyInput({
 }
 
 /** Available models per provider. */
-const PROVIDER_MODELS: Record<TTSProvider, { value: string; label: string }[]> = {
+const PROVIDER_MODELS: Record<Exclude<TTSProvider, 'off'>, { value: string; label: string }[]> = {
   openai: [
     { value: '', label: 'gpt-4o-mini-tts (default)' },
     { value: 'tts-1', label: 'tts-1' },
@@ -449,7 +449,7 @@ export function AudioSettings({
   agentName = 'Agent',
   section = 'all',
 }: AudioSettingsProps) {
-  const models = PROVIDER_MODELS[ttsProvider] || [];
+  const models = ttsProvider === 'off' ? [] : PROVIDER_MODELS[ttsProvider] || [];
   const showInput = section === 'all' || section === 'input';
   const showOutput = section === 'all' || section === 'output';
   const wakeWordSupport = useMemo(() => getWakeWordSupport(), []);
@@ -723,12 +723,12 @@ export function AudioSettings({
       {showOutput && (
         <div className="space-y-2">
           <span className="cockpit-field-label">TTS Provider</span>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             <button
               type="button"
               onClick={() => onTtsProviderChange('openai')}
               data-active={ttsProvider === 'openai'}
-              className="shell-chip min-h-11 flex-1 justify-center rounded-2xl px-3 py-2 text-sm font-medium"
+              className="shell-chip min-h-11 min-w-[7.5rem] flex-1 justify-center rounded-2xl px-3 py-2 text-sm font-medium"
             >
               OpenAI
             </button>
@@ -736,7 +736,7 @@ export function AudioSettings({
               type="button"
               onClick={() => onTtsProviderChange('replicate')}
               data-active={ttsProvider === 'replicate'}
-              className="shell-chip min-h-11 flex-1 justify-center rounded-2xl px-3 py-2 text-sm font-medium"
+              className="shell-chip min-h-11 min-w-[7.5rem] flex-1 justify-center rounded-2xl px-3 py-2 text-sm font-medium"
             >
               Replicate
             </button>
@@ -744,7 +744,7 @@ export function AudioSettings({
               type="button"
               onClick={() => onTtsProviderChange('edge')}
               data-active={ttsProvider === 'edge'}
-              className="shell-chip min-h-11 flex-1 justify-center rounded-2xl px-3 py-2 text-sm font-medium"
+              className="shell-chip min-h-11 min-w-[7.5rem] flex-1 justify-center rounded-2xl px-3 py-2 text-sm font-medium"
             >
               Edge (Free)
             </button>
@@ -752,9 +752,17 @@ export function AudioSettings({
               type="button"
               onClick={() => onTtsProviderChange('xiaomi')}
               data-active={ttsProvider === 'xiaomi'}
-              className="shell-chip min-h-11 flex-1 justify-center rounded-2xl px-3 py-2 text-sm font-medium"
+              className="shell-chip min-h-11 min-w-[7.5rem] flex-1 justify-center rounded-2xl px-3 py-2 text-sm font-medium"
             >
               Xiaomi Mimo
+            </button>
+            <button
+              type="button"
+              onClick={() => onTtsProviderChange('off')}
+              data-active={ttsProvider === 'off'}
+              className="shell-chip min-h-11 min-w-[7.5rem] flex-1 justify-center rounded-2xl px-3 py-2 text-sm font-medium"
+            >
+              Off
             </button>
           </div>
           <p className="cockpit-field-hint px-1">Choose the voice engine first, then tune the model and speaking style below.</p>

--- a/src/features/tts/useTTS.test.ts
+++ b/src/features/tts/useTTS.test.ts
@@ -52,6 +52,12 @@ describe('extractTTSMarkers', () => {
     expect(result.ttsText).toBe('say "hello!"');
   });
 
+  it('should handle marker text containing closing brackets', () => {
+    const result = extractTTSMarkers('Visible. [tts: say [brackets] out loud.]');
+    expect(result.cleaned).toBe('Visible.');
+    expect(result.ttsText).toBe(' say [brackets] out loud.');
+  });
+
   it('should not match incomplete brackets', () => {
     const result = extractTTSMarkers('[tts:unclosed text');
     expect(result.cleaned).toBe('[tts:unclosed text');
@@ -84,6 +90,10 @@ describe('migrateTTSProvider', () => {
 
   it('should keep "xiaomi" as-is', () => {
     expect(migrateTTSProvider('xiaomi')).toBe('xiaomi');
+  });
+
+  it('should keep "off" as-is', () => {
+    expect(migrateTTSProvider('off')).toBe('off');
   });
 
   it('should default unknown values to "openai"', () => {

--- a/src/features/tts/useTTS.ts
+++ b/src/features/tts/useTTS.ts
@@ -14,7 +14,7 @@ if (typeof document !== 'undefined') {
   events.forEach(e => document.addEventListener(e, handler, { capture: true, once: false }));
 }
 
-export type TTSProvider = 'openai' | 'replicate' | 'edge' | 'xiaomi';
+export type TTSProvider = 'openai' | 'replicate' | 'edge' | 'xiaomi' | 'off';
 
 /** @deprecated Use 'replicate' instead. Kept for migration. */
 export type LegacyTTSProvider = 'qwen';
@@ -22,11 +22,11 @@ export type LegacyTTSProvider = 'qwen';
 /** Migrate legacy provider names to current ones. */
 export function migrateTTSProvider(provider: string): TTSProvider {
   if (provider === 'qwen') return 'replicate';
-  if (provider === 'openai' || provider === 'replicate' || provider === 'edge' || provider === 'xiaomi') return provider;
+  if (provider === 'openai' || provider === 'replicate' || provider === 'edge' || provider === 'xiaomi' || provider === 'off') return provider;
   return 'openai';
 }
 
-async function fetchTTS(text: string, provider: TTSProvider = 'openai', model?: string): Promise<Blob> {
+async function fetchTTS(text: string, provider: Exclude<TTSProvider, 'off'> = 'openai', model?: string): Promise<Blob> {
   const body: Record<string, string> = { text, provider };
   if (model) body.model = model;
   const resp = await fetch('/api/tts', {
@@ -49,7 +49,7 @@ async function fetchTTS(text: string, provider: TTSProvider = 'openai', model?: 
  * Audio is fetched from `/api/tts` and played via an `HTMLAudioElement`.
  * Successive calls cancel the previous utterance automatically.
  */
-export function useTTS(enabled: boolean, provider: TTSProvider = 'openai', model?: string) {
+export function useTTS(provider: TTSProvider = 'openai', model?: string) {
   const currentAudio = useRef<{ audio: HTMLAudioElement; url: string } | null>(null);
   const generationRef = useRef(0);
 
@@ -69,7 +69,7 @@ export function useTTS(enabled: boolean, provider: TTSProvider = 'openai', model
   }, [cleanupAudio]);
 
   const speak = useCallback(async (text: string) => {
-    if (!enabled || !text) return;
+    if (provider === 'off' || !text) return;
     cleanupAudio();
     const gen = ++generationRef.current;
     try {
@@ -99,17 +99,57 @@ export function useTTS(enabled: boolean, provider: TTSProvider = 'openai', model
     } catch (err: unknown) {
       console.error('[TTS] play failed:', err instanceof Error ? err.message : String(err));
     }
-  }, [enabled, provider, model, cleanupAudio]);
+  }, [provider, model, cleanupAudio]);
 
   return { speak };
 }
 
-/** Strip [tts:...] markers from text, returning cleaned text and the first TTS text found */
+/** Strip [tts:...] markers from text, returning cleaned text and the first TTS text found. */
 export function extractTTSMarkers(text: string): { cleaned: string; ttsText: string | null } {
   let ttsText: string | null = null;
-  const cleaned = text.replace(/\[tts:([^\]]+)\]/g, (_, t) => {
-    if (ttsText === null) ttsText = t;
-    return '';
-  });
+  let cleaned = '';
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const markerStart = text.indexOf('[tts:', cursor);
+    if (markerStart === -1) {
+      cleaned += text.slice(cursor);
+      break;
+    }
+
+    const contentStart = markerStart + '[tts:'.length;
+    const markerEnd = findTTSMarkerEnd(text, contentStart);
+    if (markerEnd === -1) {
+      cleaned += text.slice(cursor);
+      break;
+    }
+
+    cleaned += text.slice(cursor, markerStart);
+    if (ttsText === null) ttsText = text.slice(contentStart, markerEnd);
+    cursor = markerEnd + 1;
+  }
+
   return { cleaned: cleaned.trim(), ttsText };
+}
+
+function findTTSMarkerEnd(text: string, contentStart: number): number {
+  let nestedBracketDepth = 0;
+
+  for (let index = contentStart; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === '[') {
+      nestedBracketDepth += 1;
+      continue;
+    }
+    if (char !== ']') continue;
+
+    if (nestedBracketDepth > 0) {
+      nestedBracketDepth -= 1;
+      continue;
+    }
+
+    return index;
+  }
+
+  return -1;
 }

--- a/src/features/voice/audio-feedback.ts
+++ b/src/features/voice/audio-feedback.ts
@@ -1,22 +1,47 @@
-// Audio feedback using pre-recorded MP3 files served from /sounds/
+// Audio feedback using pre-recorded MP3/OGG files served from /sounds/
 // Files are preloaded into AudioBuffers for instant, glitch-free playback.
 
 let audioCtx: AudioContext | null = null;
 const bufferCache = new Map<string, AudioBuffer>();
 const loadingCache = new Map<string, Promise<AudioBuffer | null>>();
 
+type AudioContextConstructor = new () => AudioContext;
+type WindowWithWebkitAudioContext = Window & {
+  webkitAudioContext?: AudioContextConstructor;
+};
+
+function getAudioContextConstructor(): AudioContextConstructor | undefined {
+  if (typeof window === 'undefined') return undefined;
+  return window.AudioContext ?? (window as WindowWithWebkitAudioContext).webkitAudioContext;
+}
+
+function getAudioContext(): AudioContext | null {
+  if (audioCtx) return audioCtx;
+
+  const AudioContextCtor = getAudioContextConstructor();
+  if (!AudioContextCtor) return null;
+
+  audioCtx = new AudioContextCtor();
+  return audioCtx;
+}
+
 /** Preload an audio file into an AudioBuffer. */
 function preloadSound(path: string): Promise<AudioBuffer | null> {
+  const cached = bufferCache.get(path);
+  if (cached) return Promise.resolve(cached);
+
   const existing = loadingCache.get(path);
   if (existing) return existing;
 
   const promise = (async () => {
     try {
+      const ctx = getAudioContext();
+      if (!ctx) return null;
+
       const resp = await fetch(path);
       if (!resp.ok) return null;
       const arrayBuffer = await resp.arrayBuffer();
-      if (!audioCtx) audioCtx = new AudioContext();
-      const buffer = await audioCtx.decodeAudioData(arrayBuffer);
+      const buffer = await ctx.decodeAudioData(arrayBuffer);
       bufferCache.set(path, buffer);
       return buffer;
     } catch {
@@ -25,6 +50,9 @@ function preloadSound(path: string): Promise<AudioBuffer | null> {
   })();
 
   loadingCache.set(path, promise);
+  void promise.finally(() => {
+    loadingCache.delete(path);
+  });
   return promise;
 }
 
@@ -35,21 +63,25 @@ if (typeof window !== 'undefined') {
 }
 
 function playSound(path: string, playbackRate = 1): void {
+  void playSoundAsync(path, playbackRate);
+}
+
+async function playSoundAsync(path: string, playbackRate = 1): Promise<void> {
   try {
-    if (!audioCtx) audioCtx = new AudioContext();
-    if (audioCtx.state === 'suspended') audioCtx.resume();
+    const ctx = getAudioContext();
+    if (!ctx) return;
 
-    const buffer = bufferCache.get(path);
-    if (!buffer) {
-      // Not yet loaded — trigger preload for next time, skip this play
-      preloadSound(path);
-      return;
-    }
+    if (ctx.state === 'suspended') await ctx.resume();
 
-    const source = audioCtx.createBufferSource();
+    const buffer = bufferCache.get(path) ?? await preloadSound(path);
+    if (!buffer) return;
+
+    if (ctx.state === 'suspended') await ctx.resume();
+
+    const source = ctx.createBufferSource();
     source.buffer = buffer;
     source.playbackRate.value = playbackRate;
-    source.connect(audioCtx.destination);
+    source.connect(ctx.destination);
     source.start(0);
   } catch {
     // AudioContext not available, silently skip
@@ -59,10 +91,12 @@ function playSound(path: string, playbackRate = 1): void {
 /** Initialize or resume the AudioContext (call on user interaction to unlock). */
 export function ensureAudioContext(): void {
   try {
-    if (!audioCtx) audioCtx = new AudioContext();
-    if (audioCtx.state === 'suspended') audioCtx.resume();
+    const ctx = getAudioContext();
+    if (!ctx) return;
+
+    if (ctx.state === 'suspended') void ctx.resume();
     // Re-trigger preloads if they failed before context existed
-    SOUND_PATHS.forEach(p => { if (!bufferCache.has(p)) preloadSound(p); });
+    SOUND_PATHS.forEach(p => { if (!bufferCache.has(p)) void preloadSound(p); });
   } catch {
     // AudioContext not available
   }

--- a/src/features/voice/useVoiceInput.test.ts
+++ b/src/features/voice/useVoiceInput.test.ts
@@ -20,6 +20,7 @@ vi.mock('./wakeWordSupport', () => ({
 
 // Mock SpeechRecognition
 class MockSpeechRecognition {
+  static instances: MockSpeechRecognition[] = [];
   continuous = false;
   interimResults = false;
   lang = '';
@@ -27,6 +28,10 @@ class MockSpeechRecognition {
   onerror: ((event: { error: string }) => void) | null = null;
   onend: (() => void) | null = null;
   started = false;
+
+  constructor() {
+    MockSpeechRecognition.instances.push(this);
+  }
 
   start() {
     this.started = true;
@@ -99,6 +104,7 @@ describe('useVoiceInput', () => {
 
   beforeEach(() => {
     vi.useFakeTimers();
+    MockSpeechRecognition.instances = [];
     MockMediaRecorder.instances = [];
     mockRecognition = null;
 
@@ -117,6 +123,10 @@ describe('useVoiceInput', () => {
     // Mock getUserMedia
     (navigator as unknown as { mediaDevices: { getUserMedia: Mock } }).mediaDevices = {
       getUserMedia: vi.fn().mockResolvedValue(new MockMediaStream()),
+    };
+
+    (navigator as unknown as { permissions?: { query: Mock } }).permissions = {
+      query: vi.fn().mockResolvedValue({ state: 'granted' }),
     };
 
     // Mock fetch for voice phrases and transcription
@@ -157,6 +167,7 @@ describe('useVoiceInput', () => {
     globalThis.fetch = originalFetch;
     delete (window as unknown as { SpeechRecognition?: unknown }).SpeechRecognition;
     delete (window as unknown as { webkitSpeechRecognition?: unknown }).webkitSpeechRecognition;
+    delete (navigator as unknown as { permissions?: unknown }).permissions;
   });
 
   describe('Initial State', () => {
@@ -255,6 +266,64 @@ describe('useVoiceInput', () => {
       expect(result.current.voiceState).toBe('idle');
       expect(result.current.wakeWordEnabled).toBe(false);
       expect(audioFeedback.ensureAudioContext).not.toHaveBeenCalled();
+    });
+
+    it('auto-starts wake listening on load when persisted on and microphone is granted', async () => {
+      localStorage.setItem('nerve:wakeWordEnabled', 'true');
+      const onTranscription = vi.fn();
+
+      const { result } = renderHook(() => useVoiceInput(onTranscription));
+
+      await act(async () => {
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      expect(navigator.permissions?.query).toHaveBeenCalledWith({ name: 'microphone' });
+      expect(result.current.wakeWordEnabled).toBe(true);
+      expect(result.current.voiceState).toBe('listening');
+      expect(mockRecognition?.started).toBe(true);
+    });
+
+    it('clears persisted wake state when microphone permission is not granted', async () => {
+      localStorage.setItem('nerve:wakeWordEnabled', 'true');
+      (navigator.permissions?.query as Mock).mockResolvedValue({ state: 'prompt' });
+      const onTranscription = vi.fn();
+
+      const { result } = renderHook(() => useVoiceInput(onTranscription));
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(result.current.wakeWordEnabled).toBe(false);
+      expect(result.current.voiceState).toBe('idle');
+      expect(localStorage.getItem('nerve:wakeWordEnabled')).toBe('false');
+      expect(MockSpeechRecognition.instances).toHaveLength(0);
+    });
+
+    it('does not create a stale wake listener after the persisted toggle is switched off during startup', async () => {
+      localStorage.setItem('nerve:wakeWordEnabled', 'true');
+      let resolvePermission!: (value: { state: PermissionState }) => void;
+      (navigator.permissions?.query as Mock).mockReturnValue(new Promise((resolve) => {
+        resolvePermission = resolve;
+      }));
+      const onTranscription = vi.fn();
+      const { result } = renderHook(() => useVoiceInput(onTranscription));
+
+      act(() => {
+        result.current.stopWakeWordListener();
+      });
+      resolvePermission({ state: 'granted' });
+
+      await act(async () => {
+        await Promise.resolve();
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      expect(result.current.wakeWordEnabled).toBe(false);
+      expect(result.current.voiceState).toBe('idle');
+      expect(MockSpeechRecognition.instances).toHaveLength(0);
     });
 
     it('still allows manual recording on mobile web', async () => {

--- a/src/features/voice/useVoiceInput.ts
+++ b/src/features/voice/useVoiceInput.ts
@@ -162,6 +162,7 @@ export function useVoiceInput(
 
   // Single persistent recognition instance
   const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const recognitionStartTokenRef = useRef(0);
   const wakeWordSupport = useMemo(() => getWakeWordSupport(), []);
   const wakeWordSupported = wakeWordSupport.supported;
   const [storedWakeWordEnabled, setStoredWakeWordEnabled] = useState(() => {
@@ -251,6 +252,7 @@ export function useVoiceInput(
   // Start or restart the single recognition instance
   const ensureRecognition = useCallback((mode: 'wake' | 'stop') => {
     modeRef.current = mode;
+    const startToken = ++recognitionStartTokenRef.current;
 
     // If we already have a running instance, abort it first
     if (recognitionRef.current) {
@@ -275,6 +277,7 @@ export function useVoiceInput(
     // Small delay to let the previous instance fully release
     trackedTimeout(() => {
       // Re-check state — might have changed during the delay
+      if (startToken !== recognitionStartTokenRef.current) return;
       if (mode === 'wake' && !wakeWordEnabledRef.current) return;
       if (mode === 'stop' && stateRef.current !== 'recording') return;
 
@@ -383,6 +386,7 @@ export function useVoiceInput(
     // Initialize AudioContext on user interaction
     ensureAudioContext();
     // Stop recognition intentionally — we'll restart in stop mode after recording starts
+    recognitionStartTokenRef.current += 1;
     intentionalStopRef.current = true;
     try { recognitionRef.current?.abort(); } catch { /* already stopped */ }
     recognitionRef.current = null;
@@ -418,6 +422,7 @@ export function useVoiceInput(
     setInterimTranscript('');
     resetBrowserTranscript();
     wakeTriggeredRef.current = false;
+    recognitionStartTokenRef.current += 1;
     intentionalStopRef.current = true;
     try { recognitionRef.current?.abort(); } catch { /* already stopped */ }
     recognitionRef.current = null;
@@ -459,6 +464,7 @@ export function useVoiceInput(
     if (!mr || mr.state !== 'recording') return;
     setInterimTranscript('');
     wakeTriggeredRef.current = false;
+    recognitionStartTokenRef.current += 1;
     intentionalStopRef.current = true;
     try {
       recognitionRef.current?.stop();
@@ -547,6 +553,7 @@ export function useVoiceInput(
 
   const stopWakeWordListener = useCallback(() => {
     wakeWordEnabledRef.current = false;
+    recognitionStartTokenRef.current += 1;
     intentionalStopRef.current = true;
     try { recognitionRef.current?.abort(); } catch { /* already stopped */ }
     recognitionRef.current = null;
@@ -574,18 +581,41 @@ export function useVoiceInput(
   const startWakeWordRef = useRef(startWakeWordListener);
   startWakeWordRef.current = startWakeWordListener;
   useEffect(() => {
-    if (!wakeWordSupported || !wakeWordEnabled || wakeWordEnabledRef.current) return;
+    if (!wakeWordSupported || !wakeWordEnabled) return;
+
+    const clearPersistedWakeWord = () => {
+      wakeWordEnabledRef.current = false;
+      recognitionStartTokenRef.current += 1;
+      setStoredWakeWordEnabled(false);
+      if (stateRef.current === 'listening') {
+        setVoiceState('idle');
+      }
+      try { localStorage.removeItem(WAKE_WORD_KEY); } catch { /* noop */ }
+    };
+
+    const autoStartWakeWord = () => {
+      if (!wakeWordEnabledRef.current || stateRef.current !== 'idle') return;
+      startWakeWordRef.current();
+    };
+
     // Only auto-start if mic permission was previously granted (avoid surprise prompts)
-    navigator.permissions?.query({ name: 'microphone' as PermissionName }).then((result) => {
+    const permissionQuery = navigator.permissions?.query?.({ name: 'microphone' as PermissionName });
+    if (!permissionQuery) {
+      // Permissions API not available — try starting anyway (user interaction may be required)
+      autoStartWakeWord();
+      return;
+    }
+
+    permissionQuery.then((result) => {
       if (result.state === 'granted') {
-        startWakeWordRef.current();
+        autoStartWakeWord();
       } else {
         // Permission not granted — clear persisted state so toggle shows off on supported environments
-        try { localStorage.removeItem(WAKE_WORD_KEY); } catch { /* noop */ }
+        clearPersistedWakeWord();
       }
     }).catch(() => {
-      // Permissions API not available — try starting anyway (user interaction required)
-      startWakeWordRef.current();
+      // Permissions API failed — try starting anyway (user interaction may be required)
+      autoStartWakeWord();
     });
   // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount
   }, []);
@@ -647,6 +677,7 @@ export function useVoiceInput(
       for (const id of timers) clearTimeout(id);
       timers.clear();
       wakeWordEnabledRef.current = false;
+      recognitionStartTokenRef.current += 1;
       intentionalStopRef.current = true;
       try { recognitionRef.current?.abort(); } catch { /* already stopped */ }
       recognitionRef.current = null;


### PR DESCRIPTION
## Summary
- Default sound effects to enabled on fresh installs while preserving explicit mute (`oc-sound=false`).
- Decouple `[tts:...]` voice playback from the sound-effects toggle and add an explicit TTS provider `Off` option.
- Make completion pings wait for decoded audio buffers instead of silently dropping first playback, with webkit AudioContext fallback.
- Harden TTS marker extraction for bracketed spoken text and expose `TTS: Off` in the command palette.

## Test Plan
- [x] npm test -- --run src/features/tts/useTTS.test.ts src/features/voice/audio-feedback.test.ts src/contexts/ChatContext.tts.test.tsx src/features/settings/AudioSettings.component.test.tsx src/features/command-palette/commands.test.ts
- [x] npm run lint -- src/features/voice/audio-feedback.ts src/features/tts/useTTS.ts src/features/tts/useTTS.test.ts src/contexts/SettingsContext.tsx src/features/settings/AudioSettings.tsx src/features/settings/AudioSettings.component.test.tsx src/features/command-palette/commands.ts src/features/command-palette/commands.test.ts
- [x] npm run build
- [x] Manual: restarted local Nerve on this branch and verified a voice reply played via trailing [tts:...] marker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to disable text-to-speech with an explicit "Off" option in settings
  * Voice input wake-word settings now persist between sessions and auto-start when microphone permission is granted
  * TTS provider selection redesigned as a grid layout with clearer options
  * New command palette entry to quickly disable text-to-speech
  * Enhanced audio playback with improved context and buffer management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daggerhashimoto/openclaw-nerve/pull/354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->