### PR TITLE
fix(chat-runtime): keep windowed totalMessages in sync with projected output (#344)

### DIFF
--- a/src/features/chat/operations/index.ts
+++ b/src/features/chat/operations/index.ts
@@ -6,7 +6,7 @@ export {
   splitToolCallMessage,
   groupToolMessages,
   tagIntermediateMessages,
-  userTextProjects,
+  countUserChatMsgs,
 } from './loadHistory';
 export { buildUserMessage, sendChatMessage, sendChatRuntimeMessage } from './sendMessage';
 export type { ChatRuntimeSendAck, ChatSendAck, ChatSendStatus } from './sendMessage';

--- a/src/features/chat/operations/index.ts
+++ b/src/features/chat/operations/index.ts
@@ -6,6 +6,7 @@ export {
   splitToolCallMessage,
   groupToolMessages,
   tagIntermediateMessages,
+  userTextProjects,
 } from './loadHistory';
 export { buildUserMessage, sendChatMessage, sendChatRuntimeMessage } from './sendMessage';
 export type { ChatRuntimeSendAck, ChatSendAck, ChatSendStatus } from './sendMessage';

--- a/src/features/chat/operations/loadHistory.ts
+++ b/src/features/chat/operations/loadHistory.ts
@@ -228,19 +228,30 @@ const TTS_SYSTEM_HINT_RE = /\s*\[system: User sent a voice message\.[\s\S]*$/;
  */
 const WEBCHAT_ENVELOPE_RE = /Conversation info \(untrusted metadata\):[\s\S]*?"sender":\s*"[^"]*"\s*\}\s*\n?(?:```\s*\n?)?(?:\n?\[[\w, ]+ \d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})? [^\]]*\]\s*)?/g;
 
+const WEBCHAT_ENVELOPE_PREFIX = 'Conversation info (untrusted metadata):';
+
 /**
- * Returns true if a user message body would survive all gateway/voice/envelope
- * stripping done by {@link splitToolCallMessage} as a non-empty bubble. Mirrors
- * the in-function strip pipeline so callers can predict projection output
- * without running the full split. Used by the chat-runtime windowed projection
- * to keep totalMessages in sync with rendered ChatMsgs.
+ * Returns the number of user-bubble ChatMsgs that {@link splitToolCallMessage}
+ * would emit for a user message body. Mirrors the in-function strip pipeline
+ * plus the system-event splitting behavior so chat-runtime's windowed
+ * projection can keep totalMessages in sync with rendered ChatMsgs without
+ * running the full split for every off-window item.
+ *
+ * Returns 0 when the body collapses to empty after TTS hint, webchat envelope,
+ * and [voice] prefix stripping. Returns 1 in the common non-empty case.
+ * Returns the segment count when the body contains a SYSTEM_EVENT_LINE that
+ * splitToolCallMessage will fan out into separate bubbles, in which case the
+ * full splitter is invoked so the count reflects the actual segment shape.
  */
-export function userTextProjects(text: string): boolean {
-  const stripped = text
-    .replace(TTS_SYSTEM_HINT_RE, '')
-    .replace(WEBCHAT_ENVELOPE_RE, '')
-    .replace(/^\[voice\]\s*/, '');
-  return stripped.trim().length > 0;
+export function countUserChatMsgs(text: string): number {
+  let stripped = text.replace(TTS_SYSTEM_HINT_RE, '');
+  if (stripped.includes(WEBCHAT_ENVELOPE_PREFIX)) {
+    stripped = stripped.replace(WEBCHAT_ENVELOPE_RE, '');
+  }
+  stripped = stripped.replace(/^\[voice\]\s*/, '');
+  if (!stripped.trim()) return 0;
+  if (!SYSTEM_EVENT_LINE.test(stripped)) return 1;
+  return splitToolCallMessage({ role: 'user', content: text }).length;
 }
 
 /** Strip ANSI escape sequences (e.g. \x1b[33m) from terminal output. */

--- a/src/features/chat/operations/loadHistory.ts
+++ b/src/features/chat/operations/loadHistory.ts
@@ -228,6 +228,21 @@ const TTS_SYSTEM_HINT_RE = /\s*\[system: User sent a voice message\.[\s\S]*$/;
  */
 const WEBCHAT_ENVELOPE_RE = /Conversation info \(untrusted metadata\):[\s\S]*?"sender":\s*"[^"]*"\s*\}\s*\n?(?:```\s*\n?)?(?:\n?\[[\w, ]+ \d{4}-\d{2}-\d{2} \d{2}:\d{2}(?::\d{2})? [^\]]*\]\s*)?/g;
 
+/**
+ * Returns true if a user message body would survive all gateway/voice/envelope
+ * stripping done by {@link splitToolCallMessage} as a non-empty bubble. Mirrors
+ * the in-function strip pipeline so callers can predict projection output
+ * without running the full split. Used by the chat-runtime windowed projection
+ * to keep totalMessages in sync with rendered ChatMsgs.
+ */
+export function userTextProjects(text: string): boolean {
+  const stripped = text
+    .replace(TTS_SYSTEM_HINT_RE, '')
+    .replace(WEBCHAT_ENVELOPE_RE, '')
+    .replace(/^\[voice\]\s*/, '');
+  return stripped.trim().length > 0;
+}
+
 /** Strip ANSI escape sequences (e.g. \x1b[33m) from terminal output. */
 // eslint-disable-next-line no-control-regex
 const stripAnsi = (s: string) => s.replace(/\x1b\[\d*(?:;\d+)*m/g, '');

--- a/src/features/chat/runtime/projection.test.ts
+++ b/src/features/chat/runtime/projection.test.ts
@@ -587,11 +587,13 @@ describe('chat runtime projection', () => {
 
       const windowed = projectTimeline(timeline, { visibleCount: 50 });
       const linear = projectTimeline(timeline);
+      const zeroVisible = projectTimeline(timeline, { visibleCount: 0 });
 
       expect(windowed.totalMessages).toBe(windowed.messages.length);
       expect(windowed.totalMessages).toBe(linear.messages.length);
       expect(windowed.messages.map((m) => m.role)).toEqual(linear.messages.map((m) => m.role));
       expect(windowed.messages.map((m) => m.msgId)).toEqual(linear.messages.map((m) => m.msgId));
+      expect(zeroVisible.totalMessages).toBe(linear.messages.length);
       const toolGroups = windowed.messages.filter((m) => m.toolGroup);
       expect(toolGroups).toHaveLength(1);
       expect(toolGroups[0].toolGroup).toHaveLength(3);

--- a/src/features/chat/runtime/projection.test.ts
+++ b/src/features/chat/runtime/projection.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { renderMarkdown } from '@/utils/helpers';
-import { projectTimeline } from './projection';
+import { projectItemCount, projectTimeline } from './projection';
 import type {
   AssistantTimelineItem,
   SessionTimeline,
+  SystemTimelineItem,
   ThinkingTimelineItem,
   TimelineItem,
   TimelineTurn,
   ToolCallTimelineItem,
   ToolGroupTimelineItem,
+  ToolResultTimelineItem,
   UserTimelineItem,
 } from './types';
 
@@ -364,6 +366,148 @@ describe('chat runtime projection', () => {
     expect(projection.messages[1].toolGroup).toHaveLength(2);
     expect(projection.processingStage).toBe('streaming');
   });
+
+  describe('totalMessages consistency (#344)', () => {
+    it('excludes voice-only-no-media user items from totalMessages', () => {
+      const turn = makeTurn('session-1', 'run-1', 0, 'finalized');
+      const timeline = makeTimeline('session-1', [turn], {
+        'user-voice-empty': userItem(turn, 'user-voice-empty', '[voice] ', 0),
+        'assistant-1': assistantItem(turn, 'assistant-1', 'reply', 1, false),
+      });
+
+      const projection = projectTimeline(timeline, { visibleCount: 50 });
+
+      expect(projection.totalMessages).toBe(projection.messages.length);
+      expect(projection.totalMessages).toBe(1);
+      expect(projection.messages.map((message) => message.msgId)).toEqual(['assistant-1']);
+    });
+
+    it('keeps totalMessages and messages.length in sync for voice-only with attachments', () => {
+      const turn = makeTurn('session-1', 'run-1', 0, 'finalized');
+      const userWithMedia: UserTimelineItem = {
+        ...userItem(turn, 'user-voice-media', '[voice] ', 0),
+        uploadAttachments: [
+          {
+            id: 'att-1',
+            origin: 'upload',
+            mode: 'inline',
+            name: 'note.txt',
+            mimeType: 'text/plain',
+            sizeBytes: 12,
+            policy: { forwardToSubagents: false },
+          },
+        ],
+      };
+      const timeline = makeTimeline('session-1', [turn], {
+        'user-voice-media': userWithMedia,
+        'assistant-1': assistantItem(turn, 'assistant-1', 'got it', 1, false),
+      });
+
+      const projection = projectTimeline(timeline, { visibleCount: 50 });
+
+      expect(projection.totalMessages).toBe(projection.messages.length);
+      expect(projection.totalMessages).toBe(2);
+    });
+
+    it.each<{ name: string; build: () => { item: TimelineItem; expected: 0 | 1 } }>([
+      {
+        name: 'finalized assistant with text',
+        build: () => {
+          const t = makeTurn('session', 'run', 0, 'finalized');
+          return { item: assistantItem(t, 'a-text', 'hello', 0, false), expected: 1 };
+        },
+      },
+      {
+        name: 'streaming assistant with empty text',
+        build: () => {
+          const t = makeTurn('session', 'run', 0, 'running');
+          return { item: assistantItem(t, 'a-stream', '', 0, true), expected: 1 };
+        },
+      },
+      {
+        name: 'finalized assistant with empty text',
+        build: () => {
+          const t = makeTurn('session', 'run', 0, 'finalized');
+          return { item: assistantItem(t, 'a-empty', '', 0, false), expected: 0 };
+        },
+      },
+      {
+        name: 'thinking with text',
+        build: () => {
+          const t = makeTurn('session', 'run', 0, 'finalized');
+          return { item: thinkingItem(t, 'think', 'pondering', 0, 'complete'), expected: 1 };
+        },
+      },
+      {
+        name: 'thinking with empty text',
+        build: () => {
+          const t = makeTurn('session', 'run', 0, 'finalized');
+          return { item: thinkingItem(t, 'think-empty', '', 0, 'complete'), expected: 0 };
+        },
+      },
+      {
+        name: 'user with plain text',
+        build: () => {
+          const t = makeTurn('session', 'run', 0, 'finalized');
+          return { item: userItem(t, 'u-plain', 'hi there', 0), expected: 1 };
+        },
+      },
+      {
+        name: 'user voice-only with no media',
+        build: () => {
+          const t = makeTurn('session', 'run', 0, 'finalized');
+          return { item: userItem(t, 'u-voice-empty', '[voice] ', 0), expected: 0 };
+        },
+      },
+      {
+        name: 'user voice-only with media',
+        build: () => {
+          const t = makeTurn('session', 'run', 0, 'finalized');
+          const item: UserTimelineItem = {
+            ...userItem(t, 'u-voice-media', '[voice] ', 0),
+            uploadAttachments: [
+          {
+            id: 'att-1',
+            origin: 'upload',
+            mode: 'inline',
+            name: 'note.txt',
+            mimeType: 'text/plain',
+            sizeBytes: 12,
+            policy: { forwardToSubagents: false },
+          },
+        ],
+          };
+          return { item, expected: 1 };
+        },
+      },
+      {
+        name: 'system event',
+        build: () => {
+          const t = makeTurn('session', 'run', 0, 'finalized');
+          return { item: systemItem(t, 'sys-1', 'system note', 0, 'info'), expected: 1 };
+        },
+      },
+      {
+        name: 'tool_result',
+        build: () => {
+          const t = makeTurn('session', 'run', 0, 'finalized');
+          return { item: toolResultItem(t, 'tr-1', 'ok', 0), expected: 1 };
+        },
+      },
+    ])(
+      'projectItemCount matches projected output length for $name',
+      ({ build }) => {
+        const { item, expected } = build();
+        expect(projectItemCount(item)).toBe(expected);
+
+        const turn = makeTurn(item.sessionKey, item.runId, 0, 'finalized');
+        const timeline = makeTimeline(item.sessionKey, [turn], { [item.id]: item });
+        const projection = projectTimeline(timeline, { visibleCount: 50 });
+        expect(projection.messages.length).toBe(expected);
+        expect(projection.totalMessages).toBe(expected);
+      },
+    );
+  });
 });
 
 function makeTimeline(
@@ -508,6 +652,50 @@ function assistantItem(
     updatedAt: 1_775_000_000_000 + block,
     status: isStreaming ? 'running' : 'complete',
     source: isStreaming ? 'live' : 'history',
+  };
+}
+
+function systemItem(
+  turn: TimelineTurn,
+  id: string,
+  text: string,
+  block: number,
+  severity: SystemTimelineItem['severity'],
+): SystemTimelineItem {
+  return {
+    id,
+    sessionKey: turn.sessionKey,
+    turnId: turn.id,
+    runId: turn.runId,
+    kind: 'system_event',
+    text,
+    severity,
+    orderKey: { turn: turn.orderBase.turn, block, sub: 0 },
+    createdAt: 1_775_000_000_000 + block,
+    updatedAt: 1_775_000_000_000 + block,
+    status: 'complete',
+    source: 'system',
+  };
+}
+
+function toolResultItem(
+  turn: TimelineTurn,
+  id: string,
+  text: string,
+  block: number,
+): ToolResultTimelineItem {
+  return {
+    id,
+    sessionKey: turn.sessionKey,
+    turnId: turn.id,
+    runId: turn.runId,
+    kind: 'tool_result',
+    text,
+    orderKey: { turn: turn.orderBase.turn, block, sub: 0 },
+    createdAt: 1_775_000_000_000 + block,
+    updatedAt: 1_775_000_000_000 + block,
+    status: 'complete',
+    source: 'history',
   };
 }
 

--- a/src/features/chat/runtime/projection.test.ts
+++ b/src/features/chat/runtime/projection.test.ts
@@ -572,6 +572,30 @@ describe('chat runtime projection', () => {
       expect(projectItemCount(tool)).toBe(0);
       expect(projectItemCount(group)).toBe(0);
     });
+
+    it('keeps tool-run grouping intact across zero-projection items in the windowed branch', () => {
+      const turn = makeTurn('session-1', 'run-1', 0, 'finalized');
+      const timeline = makeTimeline('session-1', [turn], {
+        'user-1': userItem(turn, 'user-1', 'do stuff', 0),
+        'tool-1': toolItem(turn, 'tool-1', 'read', { path: '/tmp/a' }, 10, 'complete'),
+        'thinking-empty': thinkingItem(turn, 'thinking-empty', '', 11, 'complete'),
+        'tool-2': toolItem(turn, 'tool-2', 'exec', { command: 'pwd' }, 12, 'complete'),
+        'assistant-empty': assistantItem(turn, 'assistant-empty', '', 13, false),
+        'tool-3': toolItem(turn, 'tool-3', 'read', { path: '/tmp/b' }, 14, 'complete'),
+        'assistant-final': assistantItem(turn, 'assistant-final', 'done', 100, false),
+      });
+
+      const windowed = projectTimeline(timeline, { visibleCount: 50 });
+      const linear = projectTimeline(timeline);
+
+      expect(windowed.totalMessages).toBe(windowed.messages.length);
+      expect(windowed.totalMessages).toBe(linear.messages.length);
+      expect(windowed.messages.map((m) => m.role)).toEqual(linear.messages.map((m) => m.role));
+      expect(windowed.messages.map((m) => m.msgId)).toEqual(linear.messages.map((m) => m.msgId));
+      const toolGroups = windowed.messages.filter((m) => m.toolGroup);
+      expect(toolGroups).toHaveLength(1);
+      expect(toolGroups[0].toolGroup).toHaveLength(3);
+    });
   });
 });
 

--- a/src/features/chat/runtime/projection.test.ts
+++ b/src/features/chat/runtime/projection.test.ts
@@ -368,6 +368,21 @@ describe('chat runtime projection', () => {
   });
 
   describe('totalMessages consistency (#344)', () => {
+    const ATTACH_NOTE: UserTimelineItem['uploadAttachments'] = [
+      {
+        id: 'att-1',
+        origin: 'upload',
+        mode: 'inline',
+        name: 'note.txt',
+        mimeType: 'text/plain',
+        sizeBytes: 12,
+        policy: { forwardToSubagents: false },
+      },
+    ];
+    const IMG_PNG: UserTimelineItem['images'] = [
+      { mimeType: 'image/png', content: 'b64', name: 'snap.png' },
+    ];
+
     it('excludes voice-only-no-media user items from totalMessages', () => {
       const turn = makeTurn('session-1', 'run-1', 0, 'finalized');
       const timeline = makeTimeline('session-1', [turn], {
@@ -382,21 +397,62 @@ describe('chat runtime projection', () => {
       expect(projection.messages.map((message) => message.msgId)).toEqual(['assistant-1']);
     });
 
+    it('excludes user items that collapse to empty after webchat envelope stripping', () => {
+      const envelopeOnly = [
+        'Conversation info (untrusted metadata):',
+        '```json',
+        '{"message_id":"abc","sender":"someone"}',
+        '```',
+        '[Wed 2026-05-22 10:30 UTC]',
+      ].join('\n');
+      const turn = makeTurn('session-1', 'run-1', 0, 'finalized');
+      const timeline = makeTimeline('session-1', [turn], {
+        'user-envelope-only': userItem(turn, 'user-envelope-only', envelopeOnly, 0),
+        'assistant-1': assistantItem(turn, 'assistant-1', 'ok', 1, false),
+      });
+
+      const projection = projectTimeline(timeline, { visibleCount: 50 });
+
+      expect(projection.totalMessages).toBe(projection.messages.length);
+      expect(projection.totalMessages).toBe(1);
+    });
+
+    it('excludes user items that collapse to empty after TTS hint stripping', () => {
+      const ttsHintOnly = '[system: User sent a voice message. Always include a [tts:...] marker.]';
+      const turn = makeTurn('session-1', 'run-1', 0, 'finalized');
+      const timeline = makeTimeline('session-1', [turn], {
+        'user-tts-only': userItem(turn, 'user-tts-only', ttsHintOnly, 0),
+        'assistant-1': assistantItem(turn, 'assistant-1', 'ok', 1, false),
+      });
+
+      const projection = projectTimeline(timeline, { visibleCount: 50 });
+
+      expect(projection.totalMessages).toBe(projection.messages.length);
+      expect(projection.totalMessages).toBe(1);
+    });
+
+    it('counts user messages that fan out into multiple system-event segments', () => {
+      const userWithEvent = [
+        'System: [2026-05-22 10:30 UTC] sub-agent task completed',
+        '',
+        'please review the output',
+      ].join('\n');
+      const turn = makeTurn('session-1', 'run-1', 0, 'finalized');
+      const timeline = makeTimeline('session-1', [turn], {
+        'user-with-event': userItem(turn, 'user-with-event', userWithEvent, 0),
+      });
+
+      const projection = projectTimeline(timeline, { visibleCount: 50 });
+
+      expect(projection.totalMessages).toBe(projection.messages.length);
+      expect(projection.totalMessages).toBeGreaterThan(1);
+    });
+
     it('keeps totalMessages and messages.length in sync for voice-only with attachments', () => {
       const turn = makeTurn('session-1', 'run-1', 0, 'finalized');
       const userWithMedia: UserTimelineItem = {
         ...userItem(turn, 'user-voice-media', '[voice] ', 0),
-        uploadAttachments: [
-          {
-            id: 'att-1',
-            origin: 'upload',
-            mode: 'inline',
-            name: 'note.txt',
-            mimeType: 'text/plain',
-            sizeBytes: 12,
-            policy: { forwardToSubagents: false },
-          },
-        ],
+        uploadAttachments: ATTACH_NOTE,
       };
       const timeline = makeTimeline('session-1', [turn], {
         'user-voice-media': userWithMedia,
@@ -409,90 +465,90 @@ describe('chat runtime projection', () => {
       expect(projection.totalMessages).toBe(2);
     });
 
-    it.each<{ name: string; build: () => { item: TimelineItem; expected: 0 | 1 } }>([
+    const finalizedTurn = (): TimelineTurn => makeTurn('session', 'run', 0, 'finalized');
+    const runningTurn = (): TimelineTurn => makeTurn('session', 'run', 0, 'running');
+
+    const assistantSegmentItem = (
+      turn: TimelineTurn,
+      id: string,
+      text: string,
+      block: number,
+      isStreaming: boolean,
+    ): AssistantTimelineItem => ({
+      ...assistantItem(turn, id, text, block, isStreaming),
+      kind: 'assistant_segment',
+    });
+
+    it.each<{ name: string; build: () => { item: TimelineItem; expected: number } }>([
       {
-        name: 'finalized assistant with text',
-        build: () => {
-          const t = makeTurn('session', 'run', 0, 'finalized');
-          return { item: assistantItem(t, 'a-text', 'hello', 0, false), expected: 1 };
-        },
+        name: 'finalized assistant_message with text',
+        build: () => ({ item: assistantItem(finalizedTurn(), 'a-text', 'hello', 0, false), expected: 1 }),
       },
       {
-        name: 'streaming assistant with empty text',
-        build: () => {
-          const t = makeTurn('session', 'run', 0, 'running');
-          return { item: assistantItem(t, 'a-stream', '', 0, true), expected: 1 };
-        },
+        name: 'streaming assistant_message with empty text',
+        build: () => ({ item: assistantItem(runningTurn(), 'a-stream', '', 0, true), expected: 1 }),
       },
       {
-        name: 'finalized assistant with empty text',
-        build: () => {
-          const t = makeTurn('session', 'run', 0, 'finalized');
-          return { item: assistantItem(t, 'a-empty', '', 0, false), expected: 0 };
-        },
+        name: 'finalized assistant_message with empty text',
+        build: () => ({ item: assistantItem(finalizedTurn(), 'a-empty', '', 0, false), expected: 0 }),
+      },
+      {
+        name: 'finalized assistant_segment with text',
+        build: () => ({ item: assistantSegmentItem(finalizedTurn(), 'seg-text', 'partial', 0, false), expected: 1 }),
+      },
+      {
+        name: 'finalized assistant_segment with empty text',
+        build: () => ({ item: assistantSegmentItem(finalizedTurn(), 'seg-empty', '', 0, false), expected: 0 }),
       },
       {
         name: 'thinking with text',
-        build: () => {
-          const t = makeTurn('session', 'run', 0, 'finalized');
-          return { item: thinkingItem(t, 'think', 'pondering', 0, 'complete'), expected: 1 };
-        },
+        build: () => ({ item: thinkingItem(finalizedTurn(), 'think', 'pondering', 0, 'complete'), expected: 1 }),
       },
       {
         name: 'thinking with empty text',
-        build: () => {
-          const t = makeTurn('session', 'run', 0, 'finalized');
-          return { item: thinkingItem(t, 'think-empty', '', 0, 'complete'), expected: 0 };
-        },
+        build: () => ({ item: thinkingItem(finalizedTurn(), 'think-empty', '', 0, 'complete'), expected: 0 }),
       },
       {
         name: 'user with plain text',
-        build: () => {
-          const t = makeTurn('session', 'run', 0, 'finalized');
-          return { item: userItem(t, 'u-plain', 'hi there', 0), expected: 1 };
-        },
+        build: () => ({ item: userItem(finalizedTurn(), 'u-plain', 'hi there', 0), expected: 1 }),
       },
       {
         name: 'user voice-only with no media',
-        build: () => {
-          const t = makeTurn('session', 'run', 0, 'finalized');
-          return { item: userItem(t, 'u-voice-empty', '[voice] ', 0), expected: 0 };
-        },
+        build: () => ({ item: userItem(finalizedTurn(), 'u-voice-empty', '[voice] ', 0), expected: 0 }),
       },
       {
-        name: 'user voice-only with media',
-        build: () => {
-          const t = makeTurn('session', 'run', 0, 'finalized');
-          const item: UserTimelineItem = {
-            ...userItem(t, 'u-voice-media', '[voice] ', 0),
-            uploadAttachments: [
-          {
-            id: 'att-1',
-            origin: 'upload',
-            mode: 'inline',
-            name: 'note.txt',
-            mimeType: 'text/plain',
-            sizeBytes: 12,
-            policy: { forwardToSubagents: false },
-          },
-        ],
-          };
-          return { item, expected: 1 };
-        },
+        name: 'user voice-only with uploadAttachments',
+        build: () => ({
+          item: { ...userItem(finalizedTurn(), 'u-voice-att', '[voice] ', 0), uploadAttachments: ATTACH_NOTE },
+          expected: 1,
+        }),
+      },
+      {
+        name: 'user voice-only with images only',
+        build: () => ({
+          item: { ...userItem(finalizedTurn(), 'u-voice-img', '[voice] ', 0), images: IMG_PNG },
+          expected: 1,
+        }),
+      },
+      {
+        name: 'user with TTS hint only',
+        build: () => ({
+          item: userItem(
+            finalizedTurn(),
+            'u-tts-only',
+            '[system: User sent a voice message. Always include a [tts:...] marker.]',
+            0,
+          ),
+          expected: 0,
+        }),
       },
       {
         name: 'system event',
-        build: () => {
-          const t = makeTurn('session', 'run', 0, 'finalized');
-          return { item: systemItem(t, 'sys-1', 'system note', 0, 'info'), expected: 1 };
-        },
+        build: () => ({ item: systemItem(finalizedTurn(), 'sys-1', 'system note', 0, 'info'), expected: 1 }),
       },
       {
         name: 'tool_result',
-        build: () => {
-          const t = makeTurn('session', 'run', 0, 'finalized');
-          return { item: toolResultItem(t, 'tr-1', 'ok', 0), expected: 1 };
-        },
+        build: () => ({ item: toolResultItem(finalizedTurn(), 'tr-1', 'ok', 0), expected: 1 }),
       },
     ])(
       'projectItemCount matches projected output length for $name',
@@ -507,6 +563,15 @@ describe('chat runtime projection', () => {
         expect(projection.totalMessages).toBe(expected);
       },
     );
+
+    it('returns 0 from projectItemCount for tool_call and tool_group (handled by the tool-grouping branch)', () => {
+      const turn = makeTurn('session', 'run', 0, 'finalized');
+      const tool = toolItem(turn, 'tc-1', 'read', { path: '/tmp/a' }, 0, 'complete');
+      const group = toolGroupItem(turn, 'tg-1', ['tc-1'], 0);
+
+      expect(projectItemCount(tool)).toBe(0);
+      expect(projectItemCount(group)).toBe(0);
+    });
   });
 });
 

--- a/src/features/chat/runtime/projection.ts
+++ b/src/features/chat/runtime/projection.ts
@@ -1,5 +1,5 @@
 import type { ChatMessage } from '@/types';
-import { splitToolCallMessage, userTextProjects } from '@/features/chat/operations';
+import { splitToolCallMessage, countUserChatMsgs } from '@/features/chat/operations';
 import type { ChatMsg, ToolGroupEntry } from '@/features/chat/types';
 import { extractTTSMarkers } from '@/features/tts/useTTS';
 import { describeToolUse, renderMarkdown, renderToolResults } from '@/utils/helpers';
@@ -133,8 +133,8 @@ function projectMessages(
     const messageCount = projectItemCount(item);
     totalMessages += messageCount;
     if (messageCount > 0 && visibleMessages.length < visibleCount) {
+      const remaining = visibleCount - visibleMessages.length;
       const projected = projectItem(item, options);
-      const remaining = Math.min(visibleCount - visibleMessages.length, projected.length);
       visibleMessages.unshift(...projected.slice(-remaining));
     }
     index--;
@@ -374,7 +374,8 @@ export function projectItemCount(item: TimelineItem): number {
     case 'thinking':
       return item.text.trim() ? 1 : 0;
     case 'user_message': {
-      if (userTextProjects(item.text)) return 1;
+      const textCount = countUserChatMsgs(item.text);
+      if (textCount > 0) return textCount;
       if (item.images?.length || item.uploadAttachments?.length) return 1;
       return 0;
     }

--- a/src/features/chat/runtime/projection.ts
+++ b/src/features/chat/runtime/projection.ts
@@ -359,8 +359,11 @@ function countProjectedMessages(orderedItems: TimelineItem[]): number {
       inToolRun = true;
       continue;
     }
-    inToolRun = false;
-    count += projectItemCount(item);
+    const itemCount = projectItemCount(item);
+    if (itemCount > 0) {
+      inToolRun = false;
+    }
+    count += itemCount;
   }
 
   return count;

--- a/src/features/chat/runtime/projection.ts
+++ b/src/features/chat/runtime/projection.ts
@@ -1,5 +1,5 @@
 import type { ChatMessage } from '@/types';
-import { splitToolCallMessage } from '@/features/chat/operations';
+import { splitToolCallMessage, userTextProjects } from '@/features/chat/operations';
 import type { ChatMsg, ToolGroupEntry } from '@/features/chat/types';
 import { extractTTSMarkers } from '@/features/tts/useTTS';
 import { describeToolUse, renderMarkdown, renderToolResults } from '@/utils/helpers';
@@ -130,11 +130,11 @@ function projectMessages(
       continue;
     }
 
-    const messageCount = countProjectedItemMessages(item);
+    const messageCount = projectItemCount(item);
     totalMessages += messageCount;
     if (messageCount > 0 && visibleMessages.length < visibleCount) {
-      const remaining = visibleCount - visibleMessages.length;
       const projected = projectItem(item, options);
+      const remaining = Math.min(visibleCount - visibleMessages.length, projected.length);
       visibleMessages.unshift(...projected.slice(-remaining));
     }
     index--;
@@ -357,13 +357,13 @@ function countProjectedMessages(orderedItems: TimelineItem[]): number {
       continue;
     }
     inToolRun = false;
-    count += countProjectedItemMessages(item);
+    count += projectItemCount(item);
   }
 
   return count;
 }
 
-function countProjectedItemMessages(item: TimelineItem): number {
+export function projectItemCount(item: TimelineItem): number {
   switch (item.kind) {
     case 'tool_group':
     case 'tool_call':
@@ -373,8 +373,11 @@ function countProjectedItemMessages(item: TimelineItem): number {
       return item.text.trim() || item.isStreaming ? 1 : 0;
     case 'thinking':
       return item.text.trim() ? 1 : 0;
-    case 'user_message':
-      return item.text.trim() || item.images?.length || item.uploadAttachments?.length ? 1 : 0;
+    case 'user_message': {
+      if (userTextProjects(item.text)) return 1;
+      if (item.images?.length || item.uploadAttachments?.length) return 1;
+      return 0;
+    }
     case 'tool_result':
     case 'system_event':
       return 1;

--- a/src/features/chat/runtime/projection.ts
+++ b/src/features/chat/runtime/projection.ts
@@ -117,7 +117,10 @@ function projectMessages(
       for (; nextIndex >= 0; nextIndex--) {
         const candidate = orderedItems[nextIndex];
         if (candidate.kind === 'tool_group') continue;
-        if (candidate.kind !== 'tool_call') break;
+        if (candidate.kind !== 'tool_call') {
+          if (projectItemCount(candidate) === 0) continue;
+          break;
+        }
         toolItems.unshift(candidate);
       }
 


### PR DESCRIPTION
## Summary

Closes #344.

The windowed projection in `src/features/chat/runtime/projection.ts` (introduced by #335) advanced `totalMessages` via `countProjectedItemMessages`, a per-kind constant table, while it built the visible window via `projectItem`, which runs the full strip/split pipeline. The two were hand-coupled per kind, so changes to one path could drift from the other without anything failing. The drift was already visible for two real shapes:

- Voice-only-no-media user messages (`[voice] ` with no transcript and no media) - `countProjectedItemMessages` returned 1 because `item.text.trim()` was non-empty, but `projectUserItem` returned 0 ChatMsgs after `splitToolCallMessage` stripped the voice prefix. Result: `hasMore` stuck `true` after the visible window was full.
- User messages whose body starts with a `System: [timestamp] ...` line - `splitToolCallMessage` fans these out into multiple bubbles via `splitSystemEvents`, but `countProjectedItemMessages` still returned 1. Result: under-count; "load more" could disappear early.

This PR makes the two paths share a single source of truth.

## Changes

- `src/features/chat/operations/loadHistory.ts`
  - New exported `countUserChatMsgs(text: string): number`. Returns the number of user ChatMsgs that `splitToolCallMessage` would emit for the body. Mirrors the in-function strip pipeline (TTS hint, webchat envelope, `[voice]` prefix) and defers to `splitToolCallMessage` for the `SYSTEM_EVENT_LINE` fan-out path so segment count is exact.
  - Webchat envelope strip is gated on a literal-prefix `indexOf` check (`'Conversation info (untrusted metadata):'`) so the regex never runs on off-window items that don't carry the envelope. Avoids a quadratic-backtracking shape on adversarial input.
- `src/features/chat/runtime/projection.ts`
  - Renamed `countProjectedItemMessages` to `projectItemCount` and exported it.
  - User-message branch routes through `countUserChatMsgs`, then falls back to media presence (images / uploadAttachments) the same way `projectUserItem` does.
  - The unwindowed early-return helper `countProjectedMessages` calls `projectItemCount` so both branches use the same predicate.
- `src/features/chat/operations/index.ts` - re-export `countUserChatMsgs` through the operations barrel.
- `src/features/chat/runtime/projection.test.ts`
  - New `totalMessages consistency (#344)` describe block.
  - Regression tests for: voice-only-no-media, webchat-envelope-only, TTS-hint-only, system-event-line fan-out, voice-only-with-attachments.
  - Parametric contract suite asserting `projectItemCount(item) === projectTimeline(...).messages.length === projectTimeline(...).totalMessages` across the 14 representative item shapes processed by the standard branch (assistant_message x3, assistant_segment x2, thinking x2, user_message x6, system_event, tool_result).
  - Explicit zero-count test for `tool_call` and `tool_group` (handled by the consecutive-tool-grouping branch, not by `projectItemCount`).

## Verification

- `npx vitest run src/features/chat/runtime/projection.test.ts` - 36/36 pass
- `npx vitest run src/features/chat/` - 279/279 pass across 18 files (no regressions in adjacent chat code)
- `npx tsc --noEmit` clean
- `npm run lint` clean
- Vite dev server boots cleanly against the new bundle; behavioral verification of the count fix is data-dependent (requires real session data with voice-only-no-media or system-event-line user messages) and is covered by the unit suite

## Out of scope

- Refactoring `splitToolCallMessage` or moving the strip regexes - the new helper colocates with them in `loadHistory.ts` and treats them as the existing source of truth
- Multi-ChatMsg projection from array-content assistant messages - not reachable from the projection.ts call sites today (content is always a string)

## Review notes

ce-code-review on this branch dispatched 8 reviewers in parallel. Findings applied as `fix(review): apply autofix feedback`:

1. ce-correctness-reviewer CR-1: `countProjectedItemMessages` undercount for user messages with a leading `SYSTEM_EVENT_LINE` - replaced the boolean predicate with `countUserChatMsgs` which detects the system-event-line case and defers to `splitToolCallMessage` for the segment count.
2. ce-performance-reviewer PERF-001: `WEBCHAT_ENVELOPE_RE` carries a `[\s\S]*?` cross-line wildcard that can quadratic-backtrack on adversarial input - added the literal-prefix `indexOf` guard.
3. ce-correctness-reviewer CR-2: the `Math.min(remaining, projected.length)` slice clamp added in the first pass was dead defensive code - `Array.prototype.slice(-N)` on an array of length L returns `min(N, L)` items without help. Restored the original `remaining` expression.
4. ce-maintainability + ce-testing: contract test was missing `assistant_segment`, images-only user, TTS-hint-only user, webchat-envelope-only user, `tool_call`, and `tool_group` cases. All added.

Findings explicitly declined (with reasoning recorded in the run artifact):

- M1 (P1): "userTextProjects pipeline missing UPLOAD_MANIFEST_RE" - false positive. `splitToolCallMessage` strips the upload manifest *after* its empty-check, so a manifest-only message produces 1 ChatMsg with empty `rawText`, not `[]`. Applying the suggested fix would invert the direction of drift.
- KT-001 (P0): "countUserChatMsgs strip pipeline diverges from projectUserItem" - false positive. The reviewer's analysis stopped at `stripVoiceTTSHint`; `projectUserItem` then passes the result through `splitMessageWithStableIds -> splitToolCallMessage`, which applies the same TTS / webchat / `[voice]` strips internally. The full pipelines are equivalent.
- KT-002 (P1): "system_event with empty text projects 0 but counts 1" - false positive. The `if (!rawText.trim()) return []` guard in `splitToolCallMessage` is gated on `m.role === 'user'`; for `role === 'system'` the function returns a single ChatMsg regardless of text content.
- M2 (P2), KT-003, KT-004, T4, T5 - placement preference / style nits / made moot by CR-2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized message-counting so projected message totals stay consistent with visible messages, improving handling when user content collapses (voice-only, TTS hints, metadata-only) and when single inputs expand into multiple system-event segments; tool-grouping respects items that contribute zero visible messages.

* **Bug Fixes**
  * Ensure user messages with only hidden/voice content or envelopes don't inflate counts; attachments still count correctly.

* **Tests**
  * Expanded coverage verifying total message synchronization and projection behavior across varied message formats and grouping scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/daggerhashimoto/openclaw-nerve/pull/355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->