### PR TITLE
fix(file-browser): keep recursive paginated entries reachable (#345)

### DIFF
--- a/server/lib/config.test.ts
+++ b/server/lib/config.test.ts
@@ -84,6 +84,54 @@ describe('config module', () => {
     });
   });
 
+  describe('fileBrowserMaxTreeEntries', () => {
+    it('defaults to 5000 when env var is unset', async () => {
+      vi.resetModules();
+      delete process.env.FILE_BROWSER_MAX_TREE_ENTRIES;
+
+      const { config } = await import('./config.js');
+      expect(config.fileBrowserMaxTreeEntries).toBe(5_000);
+    });
+
+    it('falls back to default when env var is non-numeric', async () => {
+      vi.resetModules();
+      process.env.FILE_BROWSER_MAX_TREE_ENTRIES = 'abc';
+
+      const { config } = await import('./config.js');
+      expect(config.fileBrowserMaxTreeEntries).toBe(5_000);
+    });
+
+    it('falls back to default when env var is a fractional number', async () => {
+      vi.resetModules();
+      process.env.FILE_BROWSER_MAX_TREE_ENTRIES = '2.5';
+
+      const { config } = await import('./config.js');
+      expect(config.fileBrowserMaxTreeEntries).toBe(5_000);
+    });
+
+    it('falls back to default when env var is zero or negative', async () => {
+      vi.resetModules();
+      process.env.FILE_BROWSER_MAX_TREE_ENTRIES = '0';
+
+      const { config } = await import('./config.js');
+      expect(config.fileBrowserMaxTreeEntries).toBe(5_000);
+
+      vi.resetModules();
+      process.env.FILE_BROWSER_MAX_TREE_ENTRIES = '-100';
+
+      const { config: config2 } = await import('./config.js');
+      expect(config2.fileBrowserMaxTreeEntries).toBe(5_000);
+    });
+
+    it('accepts a valid positive integer override', async () => {
+      vi.resetModules();
+      process.env.FILE_BROWSER_MAX_TREE_ENTRIES = '250';
+
+      const { config } = await import('./config.js');
+      expect(config.fileBrowserMaxTreeEntries).toBe(250);
+    });
+  });
+
   describe('SESSION_COOKIE_NAME', () => {
     it('includes the port number', async () => {
       const { SESSION_COOKIE_NAME, config } = await import('./config.js');

--- a/server/lib/config.ts
+++ b/server/lib/config.ts
@@ -79,6 +79,9 @@ export const config = {
   dist: path.join(PROJECT_ROOT, 'dist'),
   agentLogPath: path.join(PROJECT_ROOT, 'agent-log.json'),
   fileBrowserRoot: process.env.FILE_BROWSER_ROOT || '',
+  fileBrowserMaxTreeEntries: process.env.FILE_BROWSER_MAX_TREE_ENTRIES
+    ? Math.max(1, Number(process.env.FILE_BROWSER_MAX_TREE_ENTRIES) || 0)
+    : 5_000,
   memoryPath: process.env.MEMORY_PATH || path.join(HOME, '.openclaw', 'workspace', 'MEMORY.md'),
   memoryDir: process.env.MEMORY_DIR || path.join(HOME, '.openclaw', 'workspace', 'memory'),
   sessionsDir: process.env.SESSIONS_DIR || path.join(HOME, '.openclaw', 'agents', 'main', 'sessions'),

--- a/server/lib/config.ts
+++ b/server/lib/config.ts
@@ -41,6 +41,15 @@ function normalizeLanguagePreference(language: string | undefined): string {
   return code;
 }
 
+function parsePositiveIntEnv(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
 export const config = {
   port: Number(process.env.PORT || DEFAULT_PORT),
   sslPort: Number(process.env.SSL_PORT || DEFAULT_SSL_PORT),
@@ -79,9 +88,10 @@ export const config = {
   dist: path.join(PROJECT_ROOT, 'dist'),
   agentLogPath: path.join(PROJECT_ROOT, 'agent-log.json'),
   fileBrowserRoot: process.env.FILE_BROWSER_ROOT || '',
-  fileBrowserMaxTreeEntries: process.env.FILE_BROWSER_MAX_TREE_ENTRIES
-    ? Math.max(1, Number(process.env.FILE_BROWSER_MAX_TREE_ENTRIES) || 0)
-    : 5_000,
+  // Invalid / non-integer / non-positive values fall back to the default so a
+  // typo like FILE_BROWSER_MAX_TREE_ENTRIES=abc cannot silently clamp every
+  // tree response to a tiny budget.
+  fileBrowserMaxTreeEntries: parsePositiveIntEnv(process.env.FILE_BROWSER_MAX_TREE_ENTRIES, 5_000),
   memoryPath: process.env.MEMORY_PATH || path.join(HOME, '.openclaw', 'workspace', 'MEMORY.md'),
   memoryDir: process.env.MEMORY_DIR || path.join(HOME, '.openclaw', 'workspace', 'memory'),
   sessionsDir: process.env.SESSIONS_DIR || path.join(HOME, '.openclaw', 'agents', 'main', 'sessions'),

--- a/server/routes/file-browser.test.ts
+++ b/server/routes/file-browser.test.ts
@@ -33,6 +33,7 @@ describe('file-browser routes', () => {
     fileBrowserRoot?: string;
     remote?: boolean;
     gatewayFilesListResult?: Array<{ name: string; missing?: boolean; size?: number; updatedAtMs?: number }>;
+    fileBrowserMaxTreeEntries?: number;
   }) {
     vi.resetModules();
     vi.doUnmock('../lib/gateway-rpc.js');
@@ -51,6 +52,7 @@ describe('file-browser routes', () => {
         memoryPath: path.join(configuredWorkspace, 'MEMORY.md'),
         memoryDir: path.join(configuredWorkspace, 'memory'),
         fileBrowserRoot: opts?.fileBrowserRoot ?? '',
+        fileBrowserMaxTreeEntries: opts?.fileBrowserMaxTreeEntries ?? 5_000,
         workspaceRemote: false,
       },
       SESSION_COOKIE_NAME: 'nerve_session_3000',
@@ -183,6 +185,197 @@ describe('file-browser routes', () => {
       expect(secondJson.entries.map((entry) => entry.name)).not.toEqual(
         firstJson.entries.map((entry) => entry.name),
       );
+    });
+
+    type PageResponse = {
+      ok: boolean;
+      entries: Array<{
+        name: string;
+        type: 'file' | 'directory';
+        children?: Array<{ name: string }> | null;
+        childrenTruncated?: boolean;
+        childrenNextCursor?: string;
+      }>;
+      totalEntries: number;
+      returnedEntries: number;
+      limit: number;
+      cursor: number;
+      truncated: boolean;
+      nextCursor?: string;
+    };
+
+    it('keeps siblings reachable when recursion exhausts the response budget (issue #345)', async () => {
+      // Bug: a deep subtree exhausting the shared budget would drop later
+      // top-level siblings AND advance nextCursor past them, so a follow-up
+      // paginated request could not reach them.
+      //
+      // Setup: 3 sibling dirs at the root. dir-a's subtree alone (1 + 6 files)
+      // exceeds the budget. We force the regression path by sizing the budget
+      // so it is provably impossible to fit MEMORY.md + dir-a + dir-a's
+      // children + dir-b + dir-c on the first page.
+      await fs.mkdir(path.join(tmpDir, 'dir-a'));
+      await fs.mkdir(path.join(tmpDir, 'dir-b'));
+      await fs.mkdir(path.join(tmpDir, 'dir-c'));
+      for (let i = 0; i < 6; i += 1) {
+        await fs.writeFile(path.join(tmpDir, 'dir-a', `a-${i}.txt`), 'x');
+      }
+      await fs.writeFile(path.join(tmpDir, 'dir-b', 'b-1.txt'), 'x');
+      await fs.writeFile(path.join(tmpDir, 'dir-c', 'c-1.txt'), 'x');
+
+      // Budget = 3. With dirs-first sort the budget pays for dir-a (1) and
+      // then dir-a's recursive descent into its 6 files exhausts it well
+      // before dir-b is reached. dir-b and dir-c must remain reachable via
+      // nextCursor.
+      const app = await buildApp({ fileBrowserMaxTreeEntries: 3 });
+
+      const firstRes = await app.request('/api/files/tree?depth=2&limit=10');
+      expect(firstRes.status).toBe(200);
+      const firstJson = (await firstRes.json()) as PageResponse;
+
+      const firstNames = firstJson.entries.map((e) => e.name);
+      // Precondition: the budget really did force at least one sibling drop.
+      // If this fails, the fixture sizing no longer exercises the regression
+      // and the test would otherwise silently pass.
+      const missingSiblings = ['dir-a', 'dir-b', 'dir-c'].filter(
+        (n) => !firstNames.includes(n),
+      );
+      expect(missingSiblings.length).toBeGreaterThan(0);
+
+      expect(firstJson.truncated).toBe(true);
+      expect(firstJson.nextCursor).toBeDefined();
+
+      const secondRes = await app.request(
+        `/api/files/tree?depth=2&limit=10&cursor=${firstJson.nextCursor}`,
+      );
+      expect(secondRes.status).toBe(200);
+      const secondJson = (await secondRes.json()) as PageResponse;
+      const allReachedNames = new Set([
+        ...firstNames,
+        ...secondJson.entries.map((e) => e.name),
+      ]);
+      expect(allReachedNames.has('dir-a')).toBe(true);
+      expect(allReachedNames.has('dir-b')).toBe(true);
+      expect(allReachedNames.has('dir-c')).toBe(true);
+    });
+
+    it('budget exhausts at the leaf file list — unreached files are reachable on next page', async () => {
+      for (let i = 0; i < 8; i += 1) {
+        await fs.writeFile(path.join(tmpDir, `leaf-${String(i).padStart(2, '0')}.txt`), 'x');
+      }
+
+      // Budget = 3. The single top-level dir has MEMORY.md + 8 files (9 entries).
+      const app = await buildApp({ fileBrowserMaxTreeEntries: 3 });
+
+      const firstRes = await app.request('/api/files/tree?limit=50');
+      expect(firstRes.status).toBe(200);
+      const firstJson = (await firstRes.json()) as PageResponse;
+      expect(firstJson.entries.length).toBeLessThan(firstJson.totalEntries);
+      expect(firstJson.truncated).toBe(true);
+      expect(firstJson.nextCursor).toBeDefined();
+
+      const secondRes = await app.request(
+        `/api/files/tree?limit=50&cursor=${firstJson.nextCursor}`,
+      );
+      expect(secondRes.status).toBe(200);
+      const secondJson = (await secondRes.json()) as PageResponse;
+      const firstNames = firstJson.entries.map((e) => e.name);
+      const secondNames = secondJson.entries.map((e) => e.name);
+      // First page's entries and the next page's entries together cover everything,
+      // with no overlap (the bug was that nextCursor jumped past dropped entries).
+      expect(secondNames).not.toEqual(firstNames);
+      const intersection = firstNames.filter((n) => secondNames.includes(n));
+      expect(intersection).toEqual([]);
+    });
+
+    it('paginates exactly at the directory/file boundary', async () => {
+      await fs.mkdir(path.join(tmpDir, 'dir-1'));
+      await fs.mkdir(path.join(tmpDir, 'dir-2'));
+      await fs.writeFile(path.join(tmpDir, 'file-a.txt'), 'x');
+      await fs.writeFile(path.join(tmpDir, 'file-b.txt'), 'x');
+      // Remove MEMORY.md so the sort order at the root is deterministic
+      // across platforms (case-insensitive locale comparison places uppercase
+      // 'M' before lowercase 'f' on macOS but not on every libc — we don't
+      // need that interaction here).
+      await fs.rm(path.join(tmpDir, 'MEMORY.md'));
+
+      const app = await buildApp();
+
+      // After sort: [dir-1, dir-2, file-a.txt, file-b.txt] (dirs first, then
+      // files alphabetical). limit=2 returns exactly the two dirs;
+      // nextCursor must point at the first file.
+      const firstRes = await app.request('/api/files/tree?limit=2');
+      const firstJson = (await firstRes.json()) as PageResponse;
+      expect(firstJson.entries.map((e) => e.name)).toEqual(['dir-1', 'dir-2']);
+      expect(firstJson.nextCursor).toBe('2');
+
+      const secondRes = await app.request('/api/files/tree?limit=2&cursor=2');
+      const secondJson = (await secondRes.json()) as PageResponse;
+      expect(secondJson.entries.map((e) => e.name)).toEqual(['file-a.txt', 'file-b.txt']);
+    });
+
+    it('surfaces childrenTruncated and childrenNextCursor on a directory whose recursive listing overflowed', async () => {
+      await fs.mkdir(path.join(tmpDir, 'bigchild'));
+      for (let i = 0; i < 8; i += 1) {
+        await fs.writeFile(path.join(tmpDir, 'bigchild', `bc-${String(i).padStart(2, '0')}.txt`), 'x');
+      }
+
+      // Budget covers MEMORY.md (1) + bigchild itself (1) + 3 of its files = 5.
+      const app = await buildApp({ fileBrowserMaxTreeEntries: 5 });
+
+      const res = await app.request('/api/files/tree?depth=2&limit=50');
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as PageResponse;
+      const bigchild = json.entries.find((e) => e.name === 'bigchild');
+      expect(bigchild).toBeDefined();
+      expect(bigchild?.childrenTruncated).toBe(true);
+      expect(bigchild?.childrenNextCursor).toBeDefined();
+
+      // The next page of bigchild's contents should be reachable.
+      const childRes = await app.request(
+        `/api/files/tree?path=bigchild&limit=50&cursor=${bigchild?.childrenNextCursor}`,
+      );
+      expect(childRes.status).toBe(200);
+      const childJson = (await childRes.json()) as PageResponse;
+      expect(childJson.entries.length).toBeGreaterThan(0);
+    });
+
+    it('omits childrenTruncated and childrenNextCursor when the child listing fits', async () => {
+      await fs.mkdir(path.join(tmpDir, 'smallchild'));
+      await fs.writeFile(path.join(tmpDir, 'smallchild', 'one.txt'), 'x');
+      await fs.writeFile(path.join(tmpDir, 'smallchild', 'two.txt'), 'x');
+
+      const app = await buildApp();
+      const res = await app.request('/api/files/tree?depth=2&limit=50');
+      const json = (await res.json()) as PageResponse;
+      const child = json.entries.find((e) => e.name === 'smallchild');
+      expect(child).toBeDefined();
+      expect(child).not.toHaveProperty('childrenTruncated');
+      expect(child).not.toHaveProperty('childrenNextCursor');
+    });
+
+    it('does not set childrenTruncated when depth=1 (no recursion)', async () => {
+      await fs.mkdir(path.join(tmpDir, 'shallow'));
+      await fs.writeFile(path.join(tmpDir, 'shallow', 'leaf.txt'), 'x');
+
+      const app = await buildApp();
+      const res = await app.request('/api/files/tree?depth=1&limit=50');
+      const json = (await res.json()) as PageResponse;
+      const child = json.entries.find((e) => e.name === 'shallow');
+      expect(child).toBeDefined();
+      expect(child?.children).toBeNull();
+      expect(child).not.toHaveProperty('childrenTruncated');
+      expect(child).not.toHaveProperty('childrenNextCursor');
+    });
+
+    it('returns no nextCursor for an empty directory', async () => {
+      await fs.mkdir(path.join(tmpDir, 'empty'));
+      const app = await buildApp();
+      const res = await app.request('/api/files/tree?path=empty');
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as PageResponse;
+      expect(json.returnedEntries).toBe(0);
+      expect(json.truncated).toBe(false);
+      expect(json.nextCursor).toBeUndefined();
     });
 
     it('includes hidden workspace entries when showHidden=true via remote gateway fallback', async () => {

--- a/server/routes/file-browser.ts
+++ b/server/routes/file-browser.ts
@@ -52,6 +52,11 @@ interface TreeEntry {
   mtime?: number;       // epoch ms
   binary?: boolean;     // true for binary files
   children?: TreeEntry[] | null; // null = not loaded, [] = empty dir
+  // Directories whose own listing exceeded its page budget: set to true and
+  // include `childrenNextCursor` so the caller can resume at
+  // `?path=<this.path>&cursor=<childrenNextCursor>`.
+  childrenTruncated?: boolean;
+  childrenNextCursor?: string;
 }
 
 interface ScopedWorkspace {
@@ -77,8 +82,14 @@ interface ListingBudget {
 
 const DEFAULT_TREE_LIMIT = 1_000;
 const MAX_TREE_LIMIT = 5_000;
-const MAX_TREE_RESPONSE_ENTRIES = 5_000;
+const DEFAULT_MAX_TREE_RESPONSE_ENTRIES = 5_000;
 const STAT_CONCURRENCY = 16;
+
+function getMaxTreeResponseEntries(): number {
+  return config.fileBrowserMaxTreeEntries > 0
+    ? config.fileBrowserMaxTreeEntries
+    : DEFAULT_MAX_TREE_RESPONSE_ENTRIES;
+}
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -142,6 +153,12 @@ async function mapWithConcurrency<T, R>(
 }
 
 function shouldIncludeDirent(item: Dirent, basePath: string, showHidden: boolean): boolean {
+  // Only files and directories materialize as TreeEntry rows. Symlinks,
+  // sockets, FIFOs, and block/char devices are never emitted, so dropping
+  // them here keeps totalEntries + pageItems consumption + the dirs/files
+  // split in agreement (see listDirectoryPage's nextCursor invariant).
+  if (!item.isFile() && !item.isDirectory()) return false;
+
   if (isExcluded(item.name)) return false;
 
   const inTrash = basePath === '.trash' || basePath.startsWith('.trash/');
@@ -165,6 +182,10 @@ async function listDirectoryPage(
     cursor: number;
     limit: number;
     budget: ListingBudget;
+    // Per-child page size for recursive descents. Defaults to `limit`. The
+    // shared budget still caps total response size; this field is the future
+    // hook for differentiated per-child paging without changing call shape.
+    childLimit?: number;
   },
 ): Promise<DirectoryListing> {
   let items;
@@ -192,11 +213,18 @@ async function listDirectoryPage(
   const totalEntries = visibleItems.length;
   const start = Math.min(options.cursor, totalEntries);
   const pageItems = visibleItems.slice(start, start + options.limit);
-  const nextCursor = start + pageItems.length < totalEntries ? String(start + pageItems.length) : undefined;
   const entries: TreeEntry[] = [];
 
   const directories = pageItems.filter((item) => item.isDirectory());
   const files = pageItems.filter((item) => item.isFile());
+  const childLimit = options.childLimit ?? options.limit;
+
+  // Track items consumed from `pageItems` so nextCursor reflects what was
+  // actually included, not the slice length. If the shared budget exhausts
+  // mid-loop, the cursor must point at the first unconsumed item so a
+  // follow-up paginated request can reach it (issue #345).
+  let dirsConsumed = 0;
+  let filesConsumed = 0;
 
   for (const item of directories) {
     if (options.budget.remaining <= 0) {
@@ -210,8 +238,9 @@ async function listDirectoryPage(
     const childListing = depth > 1
       ? await listDirectoryPage(fullPath, relativePath, depth - 1, showHidden, {
           cursor: 0,
-          limit: options.limit,
+          limit: childLimit,
           budget: options.budget,
+          childLimit,
         })
       : null;
 
@@ -220,38 +249,50 @@ async function listDirectoryPage(
       path: relativePath,
       type: 'directory',
       children: childListing?.entries ?? null,
+      ...(childListing?.truncated ? { childrenTruncated: true } : {}),
+      ...(childListing?.nextCursor ? { childrenNextCursor: childListing.nextCursor } : {}),
     });
+    dirsConsumed += 1;
   }
 
-  const allowedFileCount = Math.min(files.length, Math.max(0, options.budget.remaining));
-  if (allowedFileCount < files.length) {
-    options.budget.truncated = true;
+  // Only process files at this level if every selected directory was fully
+  // consumed. If the dir loop broke on budget, skipping the files here keeps
+  // `nextCursor` pointing at the first dropped sibling rather than past it.
+  if (dirsConsumed === directories.length) {
+    const allowedFileCount = Math.min(files.length, Math.max(0, options.budget.remaining));
+    if (allowedFileCount < files.length) {
+      options.budget.truncated = true;
+    }
+    options.budget.remaining -= allowedFileCount;
+
+    const fileEntries = await mapWithConcurrency<Dirent, TreeEntry | null>(
+      files.slice(0, allowedFileCount),
+      STAT_CONCURRENCY,
+      async (item) => {
+        const relativePath = basePath ? path.join(basePath, item.name) : item.name;
+        const fullPath = path.join(dirPath, item.name);
+        try {
+          const stat = await fs.stat(fullPath);
+          return {
+            name: item.name,
+            path: relativePath,
+            type: 'file' as const,
+            size: stat.size,
+            mtime: Math.floor(stat.mtimeMs),
+            binary: isBinary(item.name) || undefined,
+          };
+        } catch {
+          return null;
+        }
+      },
+    );
+
+    entries.push(...fileEntries.filter((entry): entry is TreeEntry => Boolean(entry)));
+    filesConsumed = allowedFileCount;
   }
-  options.budget.remaining -= allowedFileCount;
 
-  const fileEntries = await mapWithConcurrency<Dirent, TreeEntry | null>(
-    files.slice(0, allowedFileCount),
-    STAT_CONCURRENCY,
-    async (item) => {
-      const relativePath = basePath ? path.join(basePath, item.name) : item.name;
-      const fullPath = path.join(dirPath, item.name);
-      try {
-        const stat = await fs.stat(fullPath);
-        return {
-          name: item.name,
-          path: relativePath,
-          type: 'file' as const,
-          size: stat.size,
-          mtime: Math.floor(stat.mtimeMs),
-          binary: isBinary(item.name) || undefined,
-        };
-      } catch {
-        return null;
-      }
-    },
-  );
-
-  entries.push(...fileEntries.filter((entry): entry is TreeEntry => Boolean(entry)));
+  const consumed = dirsConsumed + filesConsumed;
+  const nextCursor = start + consumed < totalEntries ? String(start + consumed) : undefined;
 
   return {
     entries,
@@ -276,7 +317,7 @@ async function listDirectory(
     cursor,
     limit,
     budget: {
-      remaining: MAX_TREE_RESPONSE_ENTRIES,
+      remaining: getMaxTreeResponseEntries(),
       truncated: false,
     },
   });

--- a/src/features/file-browser/types.ts
+++ b/src/features/file-browser/types.ts
@@ -12,6 +12,10 @@ export interface TreeEntry {
   binary?: boolean;
   /** Directory children — null = not loaded yet, [] = empty. */
   children?: TreeEntry[] | null;
+  /** Set when the recursive listing of this directory was truncated by the response budget. */
+  childrenTruncated?: boolean;
+  /** Cursor to resume the child listing at via `?path=<this.path>&cursor=<childrenNextCursor>`. */
+  childrenNextCursor?: string;
 }
 
 /** An open file tab in the editor. */


### PR DESCRIPTION
Closes #345.

## Summary

CodeRabbit's review of #339 flagged three coupled issues in `listDirectoryPage` that, in combination, return paginated tree responses where some entries are silently dropped and *unreachable* via any subsequent `cursor`. The fix lands all three, plus regression tests against tiny budget fixtures so the failure modes are exercised directly.

The three issues, paraphrased from the CR review on #339:

1. `nextCursor` was computed from `start + pageItems.length` *before* the recursive descent and file-listing loop. If the shared budget exhausted during recursion, dropped items had no way back.
2. The shared `budget` was mutated across siblings and the parent/child boundary. A deep subtree could burn the budget under sibling `dirN`, after which `dirN+1`, ..., `dirM` were silently skipped but `nextCursor` had already advanced past them.
3. Child listings reused the parent `limit` and only the `entries` of the recursive call were retained. Per-child `truncated` and `nextCursor` were discarded, so nested overflow was invisible to the caller.

## What changed

- **`nextCursor` is computed at the return statement** from `start + dirsConsumed + filesConsumed`. `dirsConsumed` is the count of dirs whose iteration completed (after the recursive call returned); `filesConsumed` is `allowedFileCount` when the dir loop fully drained, else `0`.
- **The file-listing loop is gated** on `dirsConsumed === directories.length`. If any sibling subtree exhausted the shared budget, files at this level are skipped and the cursor still points at the first unconsumed sibling.
- **`TreeEntry` gains two optional fields** on directory entries: `childrenTruncated?: boolean` and `childrenNextCursor?: string`. Both omitted from the JSON when not meaningful (verified via `not.toHaveProperty`). Forward-compatible with existing consumers; frontend `TreeEntry` updated to match.
- **`listDirectoryPage` accepts an optional `childLimit`** in its options bag (defaults to `options.limit`). No behavior change today; documented hook for future per-child paging tuning.
- **`shouldIncludeDirent` now filters non-file/non-directory Dirents** (symlinks, sockets, FIFOs). Without this, the new `dirsConsumed + filesConsumed` count could undercount `pageItems`, point `nextCursor` at already-emitted items, and emit duplicates on the next page. The old code silently dropped these via the dirs/files split anyway; filtering at the gate keeps `totalEntries` and the consumed count consistent.
- **`MAX_TREE_RESPONSE_ENTRIES` is now overridable** via `config.fileBrowserMaxTreeEntries` / `FILE_BROWSER_MAX_TREE_ENTRIES`. Default still 5,000. Lets the regression tests trigger budget exhaustion against tiny fixtures.

## Test plan

- [x] `npx vitest run server/routes/file-browser.test.ts` - 65/65 pass, including 8 new tests targeting the three bugs from the issue (deep-tree-across-budget, leaf-level budget, page-boundary, empty-dir, child-truncation surfacing, child schema cleanliness when not truncated, depth=1 no-recursion, plus the original supersede regression).
- [x] `npx vitest run` - full suite 2113/2113 pass.
- [x] `npx eslint server/routes/file-browser.ts server/routes/file-browser.test.ts server/lib/config.ts src/features/file-browser/types.ts` - clean.
- [x] `npx tsc -p config/tsconfig.server.json --noEmit` - clean.
- [x] Manual smoke: dev server (Vite + Hono) starts, app shell renders, no console errors related to this change.

## Follow-ups noted but not landed here

These were surfaced during review but deliberately not auto-applied; tracked here for visibility, suitable for a follow-up PR or issue.

- P2 testing: no regression test for `fs.readdir` throwing on a subdirectory during recursive descent. Implementation handles it (the catch block returns an empty `DirectoryListing` and `dirsConsumed` still increments) but there's no test exercising it.
- P2 testing: no test passes `cursor` past `totalEntries` to exercise the `Math.min` clamping branch.
- P2 testing: the U2 test asserts `childrenNextCursor` is defined but not value-correct, and does not assert non-overlap between the first child page and the resumed page.
- P2 ts: the test file declares a local `PageResponse` type that mirrors the route's `DirectoryListing`. If the route shape changes, tests stay green while silently asserting the wrong shape. Cleanup: export `TreeEntry` and `DirectoryListing` from the route and import them in the test.
- P3 correctness: when a child's recursive listing returns 0 entries *and* `truncated: true`, the parent renders `children: []` plus `childrenTruncated: true`. Clients that ignore `childrenTruncated` cannot distinguish this from a genuinely empty directory. Setting `children: null` in this corner case would make the API self-disambiguate.
- Advisory: `nextCursor` semantics changed (bug fix, but technically observable). Clients caching cursor values across a server restart may land on a different page boundary on the next request. Worth a changelog line.

## Notes

- Base branch is `next`, not `master`. The code being fixed (`listDirectoryPage`) ships in PR #339, which is on `next` but not yet on `master`.
- CodeRabbit auto-review is disabled for `next`-targeted PRs. Triggered `@coderabbitai full review` manually after open.
