### PR TITLE
feat(gateway): request OpenClaw protocol v4 in connect handshake

### DIFF
--- a/server/lib/gateway-rpc.test.ts
+++ b/server/lib/gateway-rpc.test.ts
@@ -171,6 +171,18 @@ describe('gateway-rpc (persistent WebSocket)', () => {
       });
     });
 
+    it('requests gateway protocol v4 during connect handshake', async () => {
+      rpcHandler = () => ({ ok: true });
+
+      const { gatewayRpcCall } = await importFreshGatewayRpc();
+      await gatewayRpcCall('test.method', { foo: 'bar' });
+
+      expect(lastConnectParams).toMatchObject({
+        minProtocol: 4,
+        maxProtocol: 4,
+      });
+    });
+
     it('uses the configured public origin for the gateway websocket handshake', async () => {
       process.env.NERVE_PUBLIC_ORIGIN = 'https://192.168.192.252:3443';
       rpcHandler = () => ({ ok: true });

--- a/server/lib/gateway-rpc.ts
+++ b/server/lib/gateway-rpc.ts
@@ -132,8 +132,8 @@ function buildConnectParams(nonce: string) {
   const token = config.gatewayToken;
 
   return {
-    minProtocol: 3,
-    maxProtocol: 3,
+    minProtocol: 4,
+    maxProtocol: 4,
     client: {
       id: clientId,
       version: '0.1.0',

--- a/src/hooks/useWebSocket.test.ts
+++ b/src/hooks/useWebSocket.test.ts
@@ -261,6 +261,38 @@ describe('useWebSocket', () => {
       expect(client?.mode).toBe('webchat');
     });
 
+    it('requests gateway protocol v4 during connect handshake', async () => {
+      const wsInstances: MockWebSocket[] = [];
+      const OriginalMockWS = MockWebSocket;
+      (globalThis as unknown as { WebSocket: typeof MockWebSocket }).WebSocket = class extends OriginalMockWS {
+        constructor(url: string) {
+          super(url);
+          wsInstances.push(this);
+        }
+      };
+
+      const { result } = renderHook(() => useWebSocket());
+
+      act(() => {
+        result.current.connect('ws://localhost:8080', 'test-token').catch(() => {});
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      const ws = wsInstances[0];
+      act(() => {
+        ws.simulateMessage({ type: 'event', event: 'connect.challenge', payload: { nonce: 'n-protocol' } });
+      });
+
+      const connectReq = getConnectRequest(ws);
+      const params = connectReq?.params as { minProtocol?: number; maxProtocol?: number } | undefined;
+
+      expect(params?.minProtocol).toBe(4);
+      expect(params?.maxProtocol).toBe(4);
+    });
+
     it('should include a stable per-tab client.instanceId in connect params', async () => {
       const wsInstances: MockWebSocket[] = [];
       const OriginalMockWS = MockWebSocket;

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -199,7 +199,7 @@ export function useWebSocket(): UseWebSocketReturn {
           ws.send(JSON.stringify({
             type: 'req', id, method: 'connect',
             params: {
-              minProtocol: 3, maxProtocol: 3,
+              minProtocol: 4, maxProtocol: 4,
               client: {
                 id: 'openclaw-control-ui',
                 version: '0.1.0',


### PR DESCRIPTION
## Summary

Bumps the OpenClaw gateway connect handshake to **protocol v4** (`minProtocol`/`maxProtocol`) on both sides:

- Client: `src/hooks/useWebSocket.ts` (the `connect.challenge` handler's connect request)
- Server gateway RPC: `server/lib/gateway-rpc.ts` (`buildConnectParams`)

Each side gets a handshake test asserting v4 is requested.

## Context

Part of the openclaw-protocol-v4 effort. Verified against the running local nerve service: it connects with **"Gateway reachable"** using the v4 handshake.

This is split out from the local protocol-v4 WIP as a focused PR; the related active-history hydration change (#3) is intentionally held back pending a design pass.

## Test plan

- [x] `npx vitest run src/hooks/useWebSocket.test.ts server/lib/gateway-rpc.test.ts` — 43 passing (incl. the two new v4 handshake assertions)
- [x] `tsc --noEmit` clean (app + server)
- [x] Smoke: local service on :3080 logs "Gateway reachable" with the v4 handshake


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Gateway WebSocket protocol upgraded to v4 to improve connection compatibility.

* **Tests**
  * Added tests validating the WebSocket handshake now negotiates the v4 protocol to ensure reliable connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->