### PR TITLE
fix(gateway): update handshake protocol to v4

### DIFF
--- a/server/lib/gateway-rpc.test.ts
+++ b/server/lib/gateway-rpc.test.ts
@@ -132,6 +132,8 @@ describe('gateway-rpc (persistent WebSocket)', () => {
         nonce: 'test-nonce',
       });
       expect(lastConnectParams).toMatchObject({
+        minProtocol: 4,
+        maxProtocol: 4,
         client: {
           id: 'openclaw-control-ui',
           mode: 'webchat',

--- a/server/lib/gateway-rpc.ts
+++ b/server/lib/gateway-rpc.ts
@@ -109,8 +109,8 @@ function buildConnectParams(nonce: string) {
   const token = config.gatewayToken;
 
   return {
-    minProtocol: 3,
-    maxProtocol: 3,
+    minProtocol: 4,
+    maxProtocol: 4,
     client: {
       id: clientId,
       version: '0.1.0',

--- a/src/hooks/useWebSocket.test.ts
+++ b/src/hooks/useWebSocket.test.ts
@@ -302,8 +302,14 @@ describe('useWebSocket', () => {
       });
 
       const connectReq = getConnectRequest(ws);
-      const client = (connectReq?.params as { client?: { id?: string; mode?: string } } | undefined)?.client;
+      const params = connectReq?.params as {
+        minProtocol?: number;
+        maxProtocol?: number;
+        client?: { id?: string; mode?: string };
+      } | undefined;
+      const client = params?.client;
 
+      expect(params).toMatchObject({ minProtocol: 4, maxProtocol: 4 });
       expect(client?.id).toBe('openclaw-control-ui');
       expect(client?.mode).toBe('webchat');
     });

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -211,7 +211,7 @@ export function useWebSocket(): UseWebSocketReturn {
           ws.send(JSON.stringify({
             type: 'req', id, method: 'connect',
             params: {
-              minProtocol: 3, maxProtocol: 3,
+              minProtocol: 4, maxProtocol: 4,
               client: {
                 id: 'openclaw-control-ui',
                 version: '0.1.0',


### PR DESCRIPTION
# Fix gateway handshake compatibility with OpenClaw protocol v4

Closes #361.

## What changed

- advertise gateway protocol 4 in the browser WebSocket handshake
- advertise gateway protocol 4 in the server-side RPC handshake
- assert the protocol range in both existing handshake test suites

## Why

Current OpenClaw gateways require protocol 4. Nerve advertised only protocol 3 from both connection implementations, so the gateway closed the WebSocket with code 1002 before authentication completed.

## Verification

- `npx vitest run src/hooks/useWebSocket.test.ts server/lib/gateway-rpc.test.ts` — 37 passed
- scoped ESLint — passed
- `git diff --check` — passed
- full suite — 1,869 passed, 1 unrelated existing failure in `server/routes/gateway.test.ts` (`node:child_process` mock has no default export)
- full build remains blocked by existing strict-null TypeScript errors in cron, kanban, sessions, and workspace routes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated WebSocket and gateway connections to use protocol version 4 during the connection handshake.
  * Improved compatibility between clients and gateways using the updated protocol range.

* **Tests**
  * Added coverage to verify that connection handshakes include the required protocol version parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->