### PR TITLE
fix(chat): preserve message identity during history recovery

### DIFF
--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -48,7 +48,7 @@ import { generateMsgId } from '@/features/chat/types';
 import type { ImageAttachment, ChatMsg, OutgoingUploadPayload } from '@/features/chat/types';
 import type { RecoveryReason, RunState } from '@/features/chat/operations';
 
-import { useChatMessages, mergeFinalMessages, patchThinkingDuration } from '@/hooks/useChatMessages';
+import { useChatMessages, mergeFinalMessages, mergeHistoryMessages, patchThinkingDuration } from '@/hooks/useChatMessages';
 import { useChatStreaming } from '@/hooks/useChatStreaming';
 import { useChatRecovery } from '@/hooks/useChatRecovery';
 import { useChatTTS } from '@/hooks/useChatTTS';
@@ -252,7 +252,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
           result[result.length - 1]?.rawText === prev[prev.length - 1]?.rawText &&
           result[result.length - 1]?.role === prev[prev.length - 1]?.role
         ) return;
-        applyMessageWindow(result, false);
+        applyMessageWindow(mergeHistoryMessages(prev, result), false);
       } catch { /* best-effort */ } finally {
         subagentPollInFlightRef.current = false;
       }
@@ -593,7 +593,8 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const handleSend = useCallback(async (text: string, images?: ImageAttachment[], uploadPayload?: OutgoingUploadPayload) => {
     ttsHook.trackVoiceMessage(text);
 
-    const { msg: userMsg, tempId } = buildUserMessage({ text, images, uploadPayload });
+    const idempotencyKey = crypto.randomUUID ? crypto.randomUUID() : 'ik-' + Date.now();
+    const { msg: userMsg, tempId } = buildUserMessage({ text, images, uploadPayload, idempotencyKey });
 
     incrementGeneration();
 
@@ -604,7 +605,6 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     streamHook.setStream((prev: ChatStreamState) => ({ ...prev, html: '', runId: undefined }));
     setProcessingStage('thinking');
 
-    const idempotencyKey = crypto.randomUUID ? crypto.randomUUID() : 'ik-' + Date.now();
     try {
       const ack = await sendChatMessage({
         rpc,

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -246,12 +246,6 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         const result = await loadChatHistory({ rpc, sessionKey: sk, limit: 500 });
         if (sk !== currentSessionRef.current) return;
         const prev = getAllMessages();
-        if (
-          result.length === prev.length &&
-          result.length > 0 &&
-          result[result.length - 1]?.rawText === prev[prev.length - 1]?.rawText &&
-          result[result.length - 1]?.role === prev[prev.length - 1]?.role
-        ) return;
         applyMessageWindow(mergeHistoryMessages(prev, result), false);
       } catch { /* best-effort */ } finally {
         subagentPollInFlightRef.current = false;

--- a/src/features/chat/operations/loadHistory.test.ts
+++ b/src/features/chat/operations/loadHistory.test.ts
@@ -333,8 +333,77 @@ describe('processChatMessages', () => {
     const first = processChatMessages([msg], { sessionKey: 'agent:main:main' });
     const second = processChatMessages([msg], { sessionKey: 'agent:main:main' });
 
-    expect(first[0].sourceId).toMatch(/^derived:agent:main:main:assistant:1775131617235:/);
+    expect(first[0].sourceId).toBe('derived:agent:main:main:assistant:index:0:1775131617235');
     expect(second[0].msgId).toBe(first[0].msgId);
+  });
+
+  it('uses gateway sequence to distinguish repeated fallback rows', () => {
+    const msgs: ChatMessage[] = [
+      { role: 'assistant', content: 'Same answer', timestamp: 1775131617235, seq: 10 },
+      { role: 'assistant', content: 'Same answer', timestamp: 1775131617235, __openclaw: { seq: 11 } },
+    ];
+
+    const result = processChatMessages(msgs, { sessionKey: 'agent:main:main' });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].sourceId).toBe('derived:agent:main:main:assistant:10:1775131617235');
+    expect(result[1].sourceId).toBe('derived:agent:main:main:assistant:11:1775131617235');
+    expect(result[0].msgId).not.toBe(result[1].msgId);
+  });
+
+  it('keeps fallback identity stable when only assistant content changes', () => {
+    const partial = processChatMessages([{
+      role: 'assistant',
+      content: 'Partial',
+      timestamp: 1775131617235,
+      seq: 10,
+    }], { sessionKey: 'agent:main:main' });
+    const final = processChatMessages([{
+      role: 'assistant',
+      content: 'Final answer',
+      timestamp: 1775131617235,
+      seq: 10,
+    }], { sessionKey: 'agent:main:main' });
+
+    expect(final[0].sourceId).toBe(partial[0].sourceId);
+    expect(final[0].msgId).toBe(partial[0].msgId);
+  });
+
+  it('uses OpenClaw record timestamps for rendered history rows', () => {
+    const result = processChatMessages([{
+      role: 'assistant',
+      content: 'Timestamped by wrapper',
+      __openclaw: { recordTimestampMs: 1775131617235 },
+    }], { sessionKey: 'agent:main:main' });
+
+    expect(result[0].timestamp.getTime()).toBe(1775131617235);
+  });
+
+  it('preserves original history index for fallback identities after filtering', () => {
+    const result = processChatMessages([
+      { role: 'assistant', content: 'NO_REPLY' },
+      { role: 'assistant', content: 'Visible', timestamp: 1775131617235 },
+    ], { sessionKey: 'agent:main:main' });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].sourceId).toBe('derived:agent:main:main:assistant:index:1:1775131617235');
+  });
+
+  it('preserves grouped tool aliases from component tool messages', () => {
+    const result = processChatMessages([{
+      role: 'assistant',
+      timestamp: 1775131617235,
+      content: [
+        { type: 'tool_use', id: 'tool-a', name: 'read', input: {} },
+        { type: 'tool_use', id: 'tool-b', name: 'write', input: {} },
+      ],
+      __openclaw: { id: 'wrapper-1', mirrorIdentity: 'run-1:assistant:tools' },
+    }], { sessionKey: 'agent:main:main' });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].sourceId).toBe('group:openclaw:mirror:run-1:assistant:tools:tool-a+openclaw:mirror:run-1:assistant:tools:tool-b');
+    expect(result[0].alternateSourceIds).toContain('group:openclaw:id:wrapper-1:tool-a+openclaw:mirror:run-1:assistant:tools:tool-b');
+    expect(result[0].alternateSourceIds).toContain('group:openclaw:mirror:run-1:assistant:tools:tool-a+openclaw:id:wrapper-1:tool-b');
   });
 
   it('tags background task notifications as system notifications', () => {

--- a/src/features/chat/operations/loadHistory.test.ts
+++ b/src/features/chat/operations/loadHistory.test.ts
@@ -301,6 +301,42 @@ describe('processChatMessages', () => {
     expect(result.every(m => m.msgId)).toBe(true);
   });
 
+  it('preserves OpenClaw transcript identity as stable UI ids', () => {
+    const msgs: ChatMessage[] = [
+      {
+        role: 'assistant',
+        content: 'Durable reply',
+        timestamp: 1775131617235,
+        __openclaw: {
+          mirrorIdentity: 'run-1:assistant:final',
+          id: 'wrapper-id-1',
+          recordTimestampMs: 1775131617235,
+          seq: 10,
+        },
+      },
+    ];
+
+    const first = processChatMessages(msgs, { sessionKey: 'agent:main:main' });
+    const second = processChatMessages(msgs, { sessionKey: 'agent:main:main' });
+
+    expect(first[0].sourceId).toBe('openclaw:mirror:run-1:assistant:final');
+    expect(second[0].msgId).toBe(first[0].msgId);
+  });
+
+  it('derives deterministic ids when gateway history lacks wrapper ids', () => {
+    const msg: ChatMessage = {
+      role: 'assistant',
+      content: 'Fallback identity',
+      timestamp: 1775131617235,
+    };
+
+    const first = processChatMessages([msg], { sessionKey: 'agent:main:main' });
+    const second = processChatMessages([msg], { sessionKey: 'agent:main:main' });
+
+    expect(first[0].sourceId).toMatch(/^derived:agent:main:main:assistant:1775131617235:/);
+    expect(second[0].msgId).toBe(first[0].msgId);
+  });
+
   it('tags background task notifications as system notifications', () => {
     const msgs: ChatMessage[] = [
       { role: 'user', content: 'A background task "x" just completed.' },

--- a/src/features/chat/operations/loadHistory.ts
+++ b/src/features/chat/operations/loadHistory.ts
@@ -43,10 +43,15 @@ function getDurableMessageBase(message: ChatMessage, options: { sessionKey?: str
   if (message.idempotencyKey) return `message:idempotency:${message.idempotencyKey}`;
   if (message.toolCallId) return `message:tool:${message.toolCallId}:${message.role}`;
 
+  const sequence = message.seq ?? message.__openclaw?.seq;
   const timestamp = getMessageTimestampValue(message);
   if (timestamp) {
     const session = options.sessionKey || 'unknown-session';
-    return `derived:${session}:${message.role}:${timestamp}:${stableHash(JSON.stringify(message.content))}`;
+    const stablePosition = sequence ?? (typeof options.messageIndex === 'number' ? `index:${options.messageIndex}` : null);
+    if (stablePosition !== null) {
+      return `derived:${session}:${message.role}:${stablePosition}:${timestamp}`;
+    }
+    return `derived:${session}:${message.role}:${timestamp}`;
   }
 
   if (typeof options.messageIndex === 'number') {
@@ -363,7 +368,7 @@ function splitSystemEvents(text: string): Array<{ role: 'event' | 'user'; text: 
 }
 
 export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: string; messageIndex?: number } = {}): ChatMsg[] {
-  const ts = m.timestamp || m.createdAt || m.ts || null;
+  const ts = m.timestamp ?? m.createdAt ?? m.ts ?? m.__openclaw?.recordTimestampMs ?? null;
   const parsedTimestamp = ts ? new Date(ts as string | number) : null;
   const hasPersistedTimestamp = Boolean(parsedTimestamp && Number.isFinite(parsedTimestamp.getTime()));
   const timestamp = hasPersistedTimestamp ? parsedTimestamp as Date : new Date();
@@ -577,8 +582,21 @@ export function groupToolMessages(msgs: ChatMsg[]): ChatMsg[] {
       });
       const groupedSourceIds = filtered.map(t => t.sourceId).filter(Boolean);
       const sourceId = groupedSourceIds.length > 0 ? `group:${groupedSourceIds.join('+')}` : undefined;
+      const groupedAliasParts = filtered.map(t => [t.sourceId, ...(t.alternateSourceIds || [])].filter(Boolean));
+      const alternateSourceIds = sourceId
+        ? groupedAliasParts.reduce<string[]>((aliases, parts, index) => {
+          for (const part of parts) {
+            const candidateParts = groupedSourceIds.map((canonical, candidateIndex) => (
+              candidateIndex === index ? part : canonical
+            ));
+            if (candidateParts.every(Boolean)) aliases.push(`group:${candidateParts.join('+')}`);
+          }
+          return aliases;
+        }, []).filter((alias) => alias !== sourceId)
+        : [];
       grouped.push({
         ...(sourceId ? { sourceId, msgId: stableMsgId(sourceId) } : {}),
+        ...(alternateSourceIds.length > 0 ? { alternateSourceIds: [...new Set(alternateSourceIds)] } : {}),
         role: 'tool',
         html: `Used ${entries.length} tools`,
         rawText: entries.map(e => e.preview).join('\n'),
@@ -662,9 +680,11 @@ export function tagIntermediateMessages(msgs: ChatMsg[]): ChatMsg[] {
  * filter → split → group → tag
  */
 export function processChatMessages(messages: ChatMessage[], options: { sessionKey?: string } = {}): ChatMsg[] {
-  const chatMsgs: ChatMsg[] = messages
-    .filter(filterMessage)
-    .flatMap((message, messageIndex) => splitToolCallMessage(message, { ...options, messageIndex }));
+  const chatMsgs: ChatMsg[] = messages.flatMap((message, messageIndex) => (
+    filterMessage(message)
+      ? splitToolCallMessage(message, { ...options, messageIndex })
+      : []
+  ));
 
   const grouped = groupToolMessages(chatMsgs);
   const tagged = tagIntermediateMessages(grouped);

--- a/src/features/chat/operations/loadHistory.ts
+++ b/src/features/chat/operations/loadHistory.ts
@@ -4,7 +4,7 @@
  * Extracted from ChatContext to keep the context a thin state-management wrapper.
  * All functions here are pure (no React hooks, setState, or refs).
  */
-import { generateMsgId } from '@/features/chat/types';
+import { generateMsgId, stableMsgId } from '@/features/chat/types';
 import type { ChatMsg, ChatMsgRole, ToolGroupEntry, UploadAttachmentDescriptor } from '@/features/chat/types';
 import type { ChatMessage, ContentBlock, ChatHistoryResponse } from '@/types';
 import { extractText, describeToolUse, renderMarkdown, renderToolResults } from '@/utils/helpers';
@@ -18,6 +18,76 @@ import type { MessageImage } from '@/features/chat/types';
 function toArray<T>(value: T | T[] | undefined): T[] {
   if (Array.isArray(value)) return value;
   return value ? [value] : [];
+}
+
+function stableHash(input: string): string {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) - hash + input.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function getMessageTimestampValue(message: ChatMessage): string {
+  const value = message.timestamp ?? message.createdAt ?? message.ts ?? message.__openclaw?.recordTimestampMs;
+  return value === undefined || value === null ? '' : String(value);
+}
+
+function getDurableMessageBase(message: ChatMessage, options: { sessionKey?: string; messageIndex?: number } = {}): string | null {
+  const openclaw = message.__openclaw;
+  if (openclaw?.mirrorIdentity) return `openclaw:mirror:${openclaw.mirrorIdentity}`;
+  if (openclaw?.id) return `openclaw:id:${openclaw.id}`;
+  if (message.id) return `message:id:${message.id}`;
+  if (message.messageId) return `message:id:${message.messageId}`;
+  if (message.message_id) return `message:id:${message.message_id}`;
+  if (message.idempotencyKey) return `message:idempotency:${message.idempotencyKey}`;
+  if (message.toolCallId) return `message:tool:${message.toolCallId}:${message.role}`;
+
+  const timestamp = getMessageTimestampValue(message);
+  if (timestamp) {
+    const session = options.sessionKey || 'unknown-session';
+    return `derived:${session}:${message.role}:${timestamp}:${stableHash(JSON.stringify(message.content))}`;
+  }
+
+  if (typeof options.messageIndex === 'number') {
+    const session = options.sessionKey || 'unknown-session';
+    return `derived:${session}:${message.role}:index:${options.messageIndex}:${stableHash(JSON.stringify(message.content))}`;
+  }
+
+  return null;
+}
+
+function getDurableMessageAliases(message: ChatMessage): string[] {
+  const aliases = [
+    message.idempotencyKey ? `message:idempotency:${message.idempotencyKey}` : null,
+    message.toolCallId ? `message:tool:${message.toolCallId}:${message.role}` : null,
+    message.id ? `message:id:${message.id}` : null,
+    message.messageId ? `message:id:${message.messageId}` : null,
+    message.message_id ? `message:id:${message.message_id}` : null,
+    message.__openclaw?.id ? `openclaw:id:${message.__openclaw.id}` : null,
+    message.__openclaw?.mirrorIdentity ? `openclaw:mirror:${message.__openclaw.mirrorIdentity}` : null,
+  ].filter((value): value is string => Boolean(value));
+
+  return [...new Set(aliases)];
+}
+
+function withSourceIdentity(
+  msg: ChatMsg,
+  base: string | null,
+  aliases: string[],
+  part: string,
+): ChatMsg {
+  if (!base) return msg;
+  const sourceId = part ? `${base}:${part}` : base;
+  const alternateSourceIds = aliases
+    .filter((alias) => alias !== base)
+    .map((alias) => (part ? `${alias}:${part}` : alias));
+  return {
+    ...msg,
+    sourceId,
+    ...(alternateSourceIds.length > 0 ? { alternateSourceIds } : {}),
+    msgId: stableMsgId(sourceId),
+  };
 }
 
 function getFilenameFromPathish(value: string, fallback: string): string {
@@ -292,11 +362,13 @@ function splitSystemEvents(text: string): Array<{ role: 'event' | 'user'; text: 
   return segments;
 }
 
-export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: string } = {}): ChatMsg[] {
+export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: string; messageIndex?: number } = {}): ChatMsg[] {
   const ts = m.timestamp || m.createdAt || m.ts || null;
   const parsedTimestamp = ts ? new Date(ts as string | number) : null;
   const hasPersistedTimestamp = Boolean(parsedTimestamp && Number.isFinite(parsedTimestamp.getTime()));
   const timestamp = hasPersistedTimestamp ? parsedTimestamp as Date : new Date();
+  const identityBase = getDurableMessageBase(m, options);
+  const identityAliases = getDurableMessageAliases(m);
 
   // Only interleave for assistant messages with array content containing tool_use
   if (m.role === 'assistant' && Array.isArray(m.content)) {
@@ -318,7 +390,7 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
         const { cleaned: chartCleaned, charts } = extractChartMarkers(ttsStripped);
         const { cleaned, images: extractedImages } = extractImages(chartCleaned);
         if (cleaned.trim() || extractedImages.length > 0) {
-          result.push({
+          result.push(withSourceIdentity({
             role: 'assistant',
             html: renderToolResults(renderMarkdown(cleaned)),
             rawText: cleaned,
@@ -326,7 +398,7 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
             streaming: false,
             ...(charts.length > 0 ? { charts } : {}),
             ...(extractedImages.length > 0 ? { extractedImages } : {}),
-          });
+          }, identityBase, identityAliases, `text:${result.length}`));
         }
         textBuffer = '';
       };
@@ -336,13 +408,13 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
           flushText();
           const thinkingContent = (block as unknown as { thinking?: string }).thinking || block.text || '';
           if (thinkingContent.trim()) {
-            result.push({
+            result.push(withSourceIdentity({
               role: 'assistant',
               html: renderMarkdown(thinkingContent),
               rawText: thinkingContent,
               timestamp,
               isThinking: true,
-            });
+            }, identityBase, identityAliases, `thinking:${result.length}`));
           }
         } else if (block.type === 'text' && block.text) {
           textBuffer += (textBuffer ? '\n' : '') + block.text;
@@ -353,13 +425,13 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
             ? (() => { try { return JSON.parse(rawArgs); } catch { return { value: rawArgs }; } })()
             : rawArgs;
           const desc = describeToolUse(block.name || 'unknown', args) || block.name || 'unknown';
-          result.push({
+          result.push(withSourceIdentity({
             role: 'tool',
             html: renderMarkdown(desc),
             rawText: `**tool:** \`${block.name}\`\n\`\`\`json\n${JSON.stringify(args, null, 2)}\n\`\`\``,
             timestamp,
             streaming: false,
-          });
+          }, identityBase, identityAliases, block.id || block.toolCallId || `tool:${result.length}`));
         }
       }
       flushText(); // Final text block
@@ -371,13 +443,13 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
         if (lastAssistant) {
           lastAssistant.images = [...(lastAssistant.images || []), ...contentImages];
         } else {
-          result.push({
+          result.push(withSourceIdentity({
             role: m.role as ChatMsgRole,
             html: '',
             rawText: '',
             timestamp,
             images: contentImages,
-          });
+          }, identityBase, identityAliases, 'images'));
         }
       }
 
@@ -412,10 +484,10 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
   if (m.role === 'user' && SYSTEM_EVENT_LINE.test(rawText)) {
     const segments = splitSystemEvents(rawText);
     if (segments.some(s => s.role === 'event')) {
-      return segments.map(seg => {
+      return segments.map((seg, index) => {
         const { cleaned: ttsStripped } = extractTTSMarkers(seg.text);
         const { cleaned: chartCleaned, charts } = extractChartMarkers(ttsStripped);
-        return {
+        return withSourceIdentity({
           role: seg.role as ChatMsgRole,
           html: renderToolResults(renderMarkdown(chartCleaned)),
           rawText: chartCleaned,
@@ -424,7 +496,7 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
           ...(charts.length > 0 ? { charts } : {}),
           ...(isVoice && seg.role === 'user' ? { isVoice: true } : {}),
           ...(uploadAttachments && seg.role === 'user' ? { uploadAttachments } : {}),
-        };
+        }, identityBase, identityAliases, `${seg.role}:${index}`);
       });
     }
   }
@@ -447,7 +519,7 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
   // Tag system notifications (subagent/cron completions) for collapsible strip rendering
   const sysNotif = m.role === 'user' ? detectSystemNotification(rawText) : { match: false, label: '' };
 
-  return [{
+  return [withSourceIdentity({
     role: m.role as ChatMsgRole,
     html: renderToolResults(renderMarkdown(text)),
     rawText: text,
@@ -459,7 +531,7 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
     ...(uploadAttachments ? { uploadAttachments } : {}),
     ...(isVoice ? { isVoice: true } : {}),
     ...(sysNotif.match ? { isSystemNotification: true, systemLabel: sysNotif.label } : {}),
-  }];
+  }, identityBase, identityAliases, '')];
 }
 
 // ─── Grouping ──────────────────────────────────────────────────────────────────
@@ -503,7 +575,10 @@ export function groupToolMessages(msgs: ChatMsg[]): ChatMsg[] {
         const plainPreview = decodeHtmlEntities(t.html.replace(/<[^>]*>/g, '').trim());
         return { html: t.html, rawText: t.rawText, preview: plainPreview || t.rawText.slice(0, 80) };
       });
+      const groupedSourceIds = filtered.map(t => t.sourceId).filter(Boolean);
+      const sourceId = groupedSourceIds.length > 0 ? `group:${groupedSourceIds.join('+')}` : undefined;
       grouped.push({
+        ...(sourceId ? { sourceId, msgId: stableMsgId(sourceId) } : {}),
         role: 'tool',
         html: `Used ${entries.length} tools`,
         rawText: entries.map(e => e.preview).join('\n'),
@@ -589,7 +664,7 @@ export function tagIntermediateMessages(msgs: ChatMsg[]): ChatMsg[] {
 export function processChatMessages(messages: ChatMessage[], options: { sessionKey?: string } = {}): ChatMsg[] {
   const chatMsgs: ChatMsg[] = messages
     .filter(filterMessage)
-    .flatMap((message) => splitToolCallMessage(message, options));
+    .flatMap((message, messageIndex) => splitToolCallMessage(message, { ...options, messageIndex }));
 
   const grouped = groupToolMessages(chatMsgs);
   const tagged = tagIntermediateMessages(grouped);

--- a/src/features/chat/operations/mergeRecoveredTail.test.ts
+++ b/src/features/chat/operations/mergeRecoveredTail.test.ts
@@ -12,6 +12,14 @@ function makeMsg(role: string, text: string, ts?: number): ChatMsg {
   };
 }
 
+function makeIdentifiedMsg(role: string, text: string, sourceId: string, ts?: number): ChatMsg {
+  return {
+    ...makeMsg(role, text, ts),
+    msgId: `ui-${sourceId}`,
+    sourceId,
+  };
+}
+
 describe('mergeRecoveredTail', () => {
   it('returns recovered when existing is empty', () => {
     const recovered = [makeMsg('user', 'Hello')];
@@ -90,5 +98,38 @@ describe('mergeRecoveredTail', () => {
     const recovered = [makeMsg('user', 'Only msg', ts), makeMsg('assistant', 'Reply', ts + 1000)];
     const result = mergeRecoveredTail(existing, recovered);
     expect(result).toHaveLength(2);
+  });
+
+  it('merges recovered messages by stable identity even when content changes', () => {
+    const existing = [
+      makeIdentifiedMsg('user', 'Question', 'u-1', 1000),
+      makeIdentifiedMsg('assistant', 'Streaming partial answer', 'a-1', 2000),
+    ];
+    const recovered = [
+      makeIdentifiedMsg('assistant', 'Final answer', 'a-1', 2000),
+      makeIdentifiedMsg('user', 'Next question', 'u-2', 3000),
+    ];
+
+    const result = mergeRecoveredTail(existing, recovered);
+
+    expect(result.map(m => m.rawText)).toEqual(['Question', 'Final answer', 'Next question']);
+    expect(result[1].msgId).toBe('ui-a-1');
+  });
+
+  it('does not let a stale recovered tail drop newer local state', () => {
+    const existing = [
+      makeIdentifiedMsg('user', 'Question', 'u-1', 1000),
+      makeIdentifiedMsg('assistant', 'Answer', 'a-1', 2000),
+      makeIdentifiedMsg('user', 'Optimistic next', 'u-2', 4000),
+    ];
+    existing[2].pending = true;
+    const recovered = [
+      makeIdentifiedMsg('assistant', 'Answer from stale tail', 'a-1', 2000),
+    ];
+
+    const result = mergeRecoveredTail(existing, recovered);
+
+    expect(result.map(m => m.rawText)).toEqual(['Question', 'Answer from stale tail', 'Optimistic next']);
+    expect(result[2].pending).toBe(true);
   });
 });

--- a/src/features/chat/operations/mergeRecoveredTail.test.ts
+++ b/src/features/chat/operations/mergeRecoveredTail.test.ts
@@ -116,6 +116,29 @@ describe('mergeRecoveredTail', () => {
     expect(result[1].msgId).toBe('ui-a-1');
   });
 
+  it('preserves aliases and prior primary identity through recovered-tail merges', () => {
+    const existing = [{
+      ...makeIdentifiedMsg('assistant', 'Streaming partial answer', 'local-stream', 2000),
+      alternateSourceIds: ['message:idempotency:ik-1'],
+      collapsed: true,
+    }];
+    const recovered = [{
+      ...makeIdentifiedMsg('assistant', 'Final answer', 'openclaw:id:wrapper-1', 2000),
+      alternateSourceIds: ['message:idempotency:ik-1'],
+    }];
+
+    const result = mergeRecoveredTail(existing, recovered);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].sourceId).toBe('openclaw:id:wrapper-1');
+    expect(result[0].msgId).toBe('ui-local-stream');
+    expect(result[0].alternateSourceIds).toEqual(expect.arrayContaining([
+      'message:idempotency:ik-1',
+      'local-stream',
+    ]));
+    expect(result[0].collapsed).toBe(true);
+  });
+
   it('does not let a stale recovered tail drop newer local state', () => {
     const existing = [
       makeIdentifiedMsg('user', 'Question', 'u-1', 1000),

--- a/src/features/chat/operations/mergeRecoveredTail.ts
+++ b/src/features/chat/operations/mergeRecoveredTail.ts
@@ -84,6 +84,25 @@ function findIdentityAnchor(existing: ChatMsg[], recovered: ChatMsg[]) {
   return null;
 }
 
+function mergeMessageState(existing: ChatMsg, incoming: ChatMsg): ChatMsg {
+  const alternateSourceIds = [...new Set([
+    ...(existing.alternateSourceIds || []),
+    ...(incoming.alternateSourceIds || []),
+    ...(existing.sourceId && existing.sourceId !== incoming.sourceId ? [existing.sourceId] : []),
+  ])];
+
+  return {
+    ...incoming,
+    msgId: existing.msgId || incoming.msgId,
+    sourceId: incoming.sourceId || existing.sourceId,
+    ...(alternateSourceIds.length > 0 ? { alternateSourceIds } : {}),
+    collapsed: existing.collapsed ?? incoming.collapsed,
+    pending: incoming.pending ?? false,
+    failed: incoming.failed ?? false,
+    tempId: existing.tempId,
+  };
+}
+
 function mergeByIdentity(existing: ChatMsg[], recovered: ChatMsg[], anchor: { existingIdx: number; recoveredIdx: number }): ChatMsg[] {
   const prefix = existing.slice(0, anchor.existingIdx);
   const existingById = new Map<string, ChatMsg>();
@@ -95,17 +114,7 @@ function mergeByIdentity(existing: ChatMsg[], recovered: ChatMsg[], anchor: { ex
   const mergedRecovered = recovered.slice(anchor.recoveredIdx).map((msg) => {
     const sourceIds = [msg.sourceId, ...(msg.alternateSourceIds || [])].filter(isString);
     const prior = sourceIds.map((sourceId) => existingById.get(sourceId)).find(Boolean);
-    return prior
-      ? {
-        ...msg,
-        msgId: prior.msgId || msg.msgId,
-        alternateSourceIds: msg.alternateSourceIds || prior.alternateSourceIds,
-        collapsed: prior.collapsed ?? msg.collapsed,
-        pending: msg.pending ?? false,
-        failed: msg.failed ?? false,
-        tempId: prior.tempId,
-      }
-      : msg;
+    return prior ? mergeMessageState(prior, msg) : msg;
   });
 
   const represented = new Set(mergedRecovered.flatMap((msg) => [msg.sourceId, ...(msg.alternateSourceIds || [])]).filter(isString));

--- a/src/features/chat/operations/mergeRecoveredTail.ts
+++ b/src/features/chat/operations/mergeRecoveredTail.ts
@@ -1,5 +1,9 @@
 import type { ChatMsg } from '@/features/chat/types';
 
+function isString(value: string | undefined): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
 function hashString(input: string): number {
   let hash = 0;
   for (let i = 0; i < input.length; i++) {
@@ -61,6 +65,62 @@ function findTailAnchor(existingSigs: string[], recoveredSigs: string[]) {
   return null;
 }
 
+function findIdentityAnchor(existing: ChatMsg[], recovered: ChatMsg[]) {
+  const recoveredIds = new Map<string, number>();
+  recovered.forEach((msg, index) => {
+    if (msg.sourceId) recoveredIds.set(msg.sourceId, index);
+    for (const alias of msg.alternateSourceIds || []) recoveredIds.set(alias, index);
+  });
+  if (recoveredIds.size === 0) return null;
+
+  const tailStart = Math.max(0, existing.length - 240);
+  for (let existingIdx = existing.length - 1; existingIdx >= tailStart; existingIdx--) {
+    const sourceIds = [existing[existingIdx].sourceId, ...(existing[existingIdx].alternateSourceIds || [])].filter(isString);
+    for (const sourceId of sourceIds) {
+      const recoveredIdx = recoveredIds.get(sourceId);
+      if (recoveredIdx !== undefined) return { existingIdx, recoveredIdx };
+    }
+  }
+  return null;
+}
+
+function mergeByIdentity(existing: ChatMsg[], recovered: ChatMsg[], anchor: { existingIdx: number; recoveredIdx: number }): ChatMsg[] {
+  const prefix = existing.slice(0, anchor.existingIdx);
+  const existingById = new Map<string, ChatMsg>();
+  for (const msg of existing.slice(anchor.existingIdx)) {
+    if (msg.sourceId) existingById.set(msg.sourceId, msg);
+    for (const alias of msg.alternateSourceIds || []) existingById.set(alias, msg);
+  }
+
+  const mergedRecovered = recovered.slice(anchor.recoveredIdx).map((msg) => {
+    const sourceIds = [msg.sourceId, ...(msg.alternateSourceIds || [])].filter(isString);
+    const prior = sourceIds.map((sourceId) => existingById.get(sourceId)).find(Boolean);
+    return prior
+      ? {
+        ...msg,
+        msgId: prior.msgId || msg.msgId,
+        alternateSourceIds: msg.alternateSourceIds || prior.alternateSourceIds,
+        collapsed: prior.collapsed ?? msg.collapsed,
+        pending: msg.pending ?? false,
+        failed: msg.failed ?? false,
+        tempId: prior.tempId,
+      }
+      : msg;
+  });
+
+  const represented = new Set(mergedRecovered.flatMap((msg) => [msg.sourceId, ...(msg.alternateSourceIds || [])]).filter(isString));
+  const newestRecoveredTs = Math.max(...recovered.map((msg) => msg.timestamp.getTime()).filter(Number.isFinite));
+  const preserveNewer = existing
+    .slice(anchor.existingIdx + 1)
+    .filter((msg) => {
+      if ([msg.sourceId, ...(msg.alternateSourceIds || [])].filter(isString).some((sourceId) => represented.has(sourceId))) return false;
+      if (msg.pending || msg.failed || msg.streaming) return true;
+      return Number.isFinite(newestRecoveredTs) && msg.timestamp.getTime() > newestRecoveredTs;
+    });
+
+  return [...prefix, ...mergedRecovered, ...preserveNewer];
+}
+
 /**
  * Merge a recovered history tail into the current transcript without replacing
  * unaffected prefix messages.
@@ -68,6 +128,11 @@ function findTailAnchor(existingSigs: string[], recoveredSigs: string[]) {
 export function mergeRecoveredTail(existing: ChatMsg[], recovered: ChatMsg[]): ChatMsg[] {
   if (recovered.length === 0) return existing;
   if (existing.length === 0) return recovered;
+
+  const identityAnchor = findIdentityAnchor(existing, recovered);
+  if (identityAnchor) {
+    return mergeByIdentity(existing, recovered, identityAnchor);
+  }
 
   const existingSigs = existing.map(messageSignature);
   const recoveredSigs = recovered.map(messageSignature);

--- a/src/features/chat/operations/sendMessage.ts
+++ b/src/features/chat/operations/sendMessage.ts
@@ -3,7 +3,7 @@
  *
  * Extracted from ChatContext.handleSend. No React hooks, setState, or refs.
  */
-import { generateMsgId } from '@/features/chat/types';
+import { stableMsgId } from '@/features/chat/types';
 import type { ChatMsg, ImageAttachment, OutgoingUploadPayload, UploadAttachmentDescriptor } from '@/features/chat/types';
 import { renderMarkdown, renderToolResults } from '@/utils/helpers';
 
@@ -76,12 +76,15 @@ export function buildUserMessage(params: {
   text: string;
   images?: ImageAttachment[];
   uploadPayload?: OutgoingUploadPayload;
+  idempotencyKey?: string;
 }): { msg: ChatMsg; tempId: string } {
-  const { text, images, uploadPayload } = params;
+  const { text, images, uploadPayload, idempotencyKey } = params;
   const tempId = crypto.randomUUID ? crypto.randomUUID() : 'temp-' + Date.now();
+  const sourceId = `message:idempotency:${idempotencyKey || tempId}`;
 
   const msg: ChatMsg = {
-    msgId: generateMsgId(),
+    msgId: stableMsgId(sourceId),
+    sourceId,
     role: 'user',
     html: renderToolResults(renderMarkdown(text)),
     rawText: text,

--- a/src/features/chat/types.ts
+++ b/src/features/chat/types.ts
@@ -104,9 +104,26 @@ export function generateMsgId(): string {
   return `m-${Date.now()}-${++_msgIdCounter}`;
 }
 
+function hashString(input: string): string {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) - hash + input.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+}
+
+/** Deterministic UI-safe id for messages whose durable gateway identity is known. */
+export function stableMsgId(identity: string): string {
+  return `msg:${hashString(identity)}:${identity.replace(/[^a-zA-Z0-9:_-]/g, '_').slice(0, 80)}`;
+}
+
 export interface ChatMsg {
   /** Stable unique ID for React keying — assigned once at creation, never changes. */
   msgId?: string;
+  /** Durable identity from OpenClaw/history/live events, used for reconciliation. */
+  sourceId?: string;
+  /** Additional durable aliases, such as send idempotency keys, that may confirm optimistic UI rows. */
+  alternateSourceIds?: string[];
   role: ChatMsgRole;
   html: string;
   rawText: string;

--- a/src/hooks/useChatMessages.test.ts
+++ b/src/hooks/useChatMessages.test.ts
@@ -53,6 +53,26 @@ describe('chat message reconciliation', () => {
     expect(result[0].pending).toBe(false);
   });
 
+  it('preserves aliases and prior primary identity when history confirms a message', () => {
+    const existing = [{
+      ...msg('user', 'hello', 'message:idempotency:ik-1', true),
+      alternateSourceIds: ['message:temp:local-1'],
+    }];
+    const history = [{
+      ...msg('user', 'hello', 'openclaw:id:wrapper-1'),
+      alternateSourceIds: ['message:idempotency:ik-1'],
+    }];
+
+    const result = mergeHistoryMessages(existing, history);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].sourceId).toBe('openclaw:id:wrapper-1');
+    expect(result[0].alternateSourceIds).toEqual(expect.arrayContaining([
+      'message:temp:local-1',
+      'message:idempotency:ik-1',
+    ]));
+  });
+
   it('preserves pending optimistic messages absent from an authoritative refresh', () => {
     const existing = [
       msg('assistant', 'old', 'assistant-1'),
@@ -64,5 +84,17 @@ describe('chat message reconciliation', () => {
 
     expect(result.map(m => m.rawText)).toEqual(['old', 'still sending']);
     expect(result[1].pending).toBe(true);
+  });
+
+  it('preserves streaming messages when history returns empty', () => {
+    const existing = [{
+      ...msg('assistant', 'still streaming', 'assistant-stream'),
+      streaming: true,
+    }];
+
+    const result = mergeHistoryMessages(existing, []);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].streaming).toBe(true);
   });
 });

--- a/src/hooks/useChatMessages.test.ts
+++ b/src/hooks/useChatMessages.test.ts
@@ -1,0 +1,68 @@
+/** Tests for chat message reconciliation helpers. */
+import { describe, expect, it } from 'vitest';
+import { mergeFinalMessages, mergeHistoryMessages } from './useChatMessages';
+import type { ChatMsg } from '@/features/chat/types';
+
+function msg(role: ChatMsg['role'], rawText: string, sourceId: string, pending = false): ChatMsg {
+  return {
+    msgId: `ui-${sourceId}`,
+    sourceId,
+    role,
+    html: rawText,
+    rawText,
+    timestamp: new Date(1700000000000),
+    pending,
+    tempId: pending ? `temp-${sourceId}` : undefined,
+  };
+}
+
+describe('chat message reconciliation', () => {
+  it('dedupes live final messages by stable identity', () => {
+    const existing = [msg('assistant', 'Streaming text', 'assistant-1')];
+    const incoming = [msg('assistant', 'Final text', 'assistant-1')];
+
+    const result = mergeFinalMessages(existing, incoming);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].rawText).toBe('Final text');
+    expect(result[0].msgId).toBe('ui-assistant-1');
+  });
+
+  it('replaces a pending optimistic user message when history confirms the same idempotency key', () => {
+    const existing = [msg('user', 'hello', 'message:idempotency:ik-1', true)];
+    const history = [msg('user', 'hello', 'message:idempotency:ik-1')];
+
+    const result = mergeHistoryMessages(existing, history);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].pending).toBe(false);
+    expect(result[0].tempId).toBe('temp-message:idempotency:ik-1');
+  });
+
+  it('matches optimistic user messages against history aliases when OpenClaw wrapper ids are primary', () => {
+    const existing = [msg('user', 'hello', 'message:idempotency:ik-1', true)];
+    const history = [{
+      ...msg('user', 'hello', 'openclaw:id:wrapper-1'),
+      alternateSourceIds: ['message:idempotency:ik-1'],
+    }];
+
+    const result = mergeHistoryMessages(existing, history);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].sourceId).toBe('openclaw:id:wrapper-1');
+    expect(result[0].pending).toBe(false);
+  });
+
+  it('preserves pending optimistic messages absent from an authoritative refresh', () => {
+    const existing = [
+      msg('assistant', 'old', 'assistant-1'),
+      msg('user', 'still sending', 'message:idempotency:ik-2', true),
+    ];
+    const history = [msg('assistant', 'old', 'assistant-1')];
+
+    const result = mergeHistoryMessages(existing, history);
+
+    expect(result.map(m => m.rawText)).toEqual(['old', 'still sending']);
+    expect(result[1].pending).toBe(true);
+  });
+});

--- a/src/hooks/useChatMessages.ts
+++ b/src/hooks/useChatMessages.ts
@@ -52,11 +52,17 @@ function isSameMessageIdentity(a: ChatMsg, b: ChatMsg): boolean {
 }
 
 function mergeMessageState(existing: ChatMsg, incoming: ChatMsg): ChatMsg {
+  const alternateSourceIds = [...new Set([
+    ...(existing.alternateSourceIds || []),
+    ...(incoming.alternateSourceIds || []),
+    ...(existing.sourceId && existing.sourceId !== incoming.sourceId ? [existing.sourceId] : []),
+  ])];
+
   return {
     ...incoming,
     msgId: existing.msgId || incoming.msgId || generateMsgId(),
     sourceId: incoming.sourceId || existing.sourceId,
-    alternateSourceIds: incoming.alternateSourceIds || existing.alternateSourceIds,
+    ...(alternateSourceIds.length > 0 ? { alternateSourceIds } : {}),
     collapsed: existing.collapsed ?? incoming.collapsed,
     pending: incoming.pending ?? false,
     failed: incoming.failed ?? false,
@@ -107,8 +113,8 @@ export function mergeFinalMessages(existing: ChatMsg[], incoming: ChatMsg[]): Ch
 
 export function mergeHistoryMessages(existing: ChatMsg[], history: ChatMsg[]): ChatMsg[] {
   if (history.length === 0) {
-    const pending = existing.filter((msg) => msg.pending || msg.failed);
-    return pending.length > 0 ? pending : history;
+    const inFlight = existing.filter((msg) => msg.pending || msg.failed || msg.streaming);
+    return inFlight.length > 0 ? inFlight : history;
   }
   if (existing.length === 0) return history;
 

--- a/src/hooks/useChatMessages.ts
+++ b/src/hooks/useChatMessages.ts
@@ -21,6 +21,8 @@ export function normalizeComparableText(text: string): string {
 }
 
 export function isLikelyDuplicateMessage(a: ChatMsg, b: ChatMsg): boolean {
+  if (a.sourceId && b.sourceId && a.sourceId === b.sourceId) return true;
+
   // Require timestamps within 60s to avoid suppressing legitimately repeated messages.
   const timeDiffMs = Math.abs(a.timestamp.getTime() - b.timestamp.getTime());
   if (timeDiffMs > 60_000) return false;
@@ -39,15 +41,46 @@ export function isLikelyDuplicateMessage(a: ChatMsg, b: ChatMsg): boolean {
   );
 }
 
+function isSameMessageIdentity(a: ChatMsg, b: ChatMsg): boolean {
+  const aIds = [a.sourceId, ...(a.alternateSourceIds || [])].filter(Boolean);
+  const bIds = [b.sourceId, ...(b.alternateSourceIds || [])].filter(Boolean);
+  if (aIds.length > 0 && bIds.length > 0) {
+    return aIds.some((id) => bIds.includes(id));
+  }
+  if (a.tempId && b.tempId) return a.tempId === b.tempId;
+  return false;
+}
+
+function mergeMessageState(existing: ChatMsg, incoming: ChatMsg): ChatMsg {
+  return {
+    ...incoming,
+    msgId: existing.msgId || incoming.msgId || generateMsgId(),
+    sourceId: incoming.sourceId || existing.sourceId,
+    alternateSourceIds: incoming.alternateSourceIds || existing.alternateSourceIds,
+    collapsed: existing.collapsed ?? incoming.collapsed,
+    pending: incoming.pending ?? false,
+    failed: incoming.failed ?? false,
+    tempId: existing.tempId,
+  };
+}
+
 export function mergeFinalMessages(existing: ChatMsg[], incoming: ChatMsg[]): ChatMsg[] {
   if (incoming.length === 0) return existing;
   const merged = [...existing];
 
   for (const msg of incoming) {
+    const identityIdx = msg.sourceId
+      ? merged.findIndex((candidate) => isSameMessageIdentity(candidate, msg))
+      : -1;
+    if (identityIdx >= 0) {
+      merged[identityIdx] = mergeMessageState(merged[identityIdx], msg);
+      continue;
+    }
+
     const last = merged[merged.length - 1];
 
     if (last && isLikelyDuplicateMessage(last, msg)) {
-      merged[merged.length - 1] = msg;
+      merged[merged.length - 1] = mergeMessageState(last, msg);
       continue;
     }
 
@@ -67,6 +100,29 @@ export function mergeFinalMessages(existing: ChatMsg[], incoming: ChatMsg[]): Ch
     }
 
     merged.push(msg.msgId ? msg : { ...msg, msgId: generateMsgId() });
+  }
+
+  return merged;
+}
+
+export function mergeHistoryMessages(existing: ChatMsg[], history: ChatMsg[]): ChatMsg[] {
+  if (history.length === 0) {
+    const pending = existing.filter((msg) => msg.pending || msg.failed);
+    return pending.length > 0 ? pending : history;
+  }
+  if (existing.length === 0) return history;
+
+  const merged = history.map((historyMsg) => {
+    const existingMatch = historyMsg.sourceId
+      ? existing.find((candidate) => isSameMessageIdentity(candidate, historyMsg))
+      : undefined;
+    return existingMatch ? mergeMessageState(existingMatch, historyMsg) : historyMsg;
+  });
+
+  for (const existingMsg of existing) {
+    if (!existingMsg.pending && !existingMsg.failed && !existingMsg.streaming) continue;
+    const alreadyRepresented = merged.some((candidate) => isSameMessageIdentity(candidate, existingMsg));
+    if (!alreadyRepresented) merged.push(existingMsg);
   }
 
   return merged;
@@ -129,7 +185,7 @@ export function useChatMessages({ rpc, currentSessionRef }: UseChatMessagesDeps)
     const sk = session || currentSessionRef.current;
     try {
       const result = await loadChatHistory({ rpc, sessionKey: sk, limit: 500 });
-      applyMessageWindow(result, true);
+      applyMessageWindow(mergeHistoryMessages(allMessagesRef.current, result), true);
     } catch (e) {
       const errMsg = e instanceof Error ? e.message : String(e);
       allMessagesRef.current = [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,12 +118,26 @@ export type ContentBlockType = 'text' | 'tool_use' | 'toolCall' | 'tool_result' 
 
 /** A single chat message (user, assistant, tool, or system). */
 export interface ChatMessage {
+  id?: string;
+  messageId?: string;
+  message_id?: string;
   role: ChatMessageRole;
   content: string | ContentBlock[];
   text?: string;
   timestamp?: string | number;
   createdAt?: string | number;
   ts?: string | number;
+  seq?: number;
+  idempotencyKey?: string;
+  toolCallId?: string;
+  toolName?: string;
+  __openclaw?: {
+    id?: string;
+    mirrorIdentity?: string;
+    recordTimestampMs?: number;
+    seq?: number;
+    kind?: string;
+  };
   MediaPath?: string;
   MediaPaths?: string[];
   MediaType?: string;


### PR DESCRIPTION
## In Plain English

Chat history recovery could lose track of which live assistant bubble matched the durable message in gateway history. When the recovered tail started at a finalized assistant response, Nerve could replace the tail and drop earlier local chat context instead of updating the existing bubble in place.

This PR gives chat messages stable source identities from OpenClaw/gateway metadata and send idempotency keys, then uses those identities when merging live, refreshed, and recovered history. That lets Nerve update partial assistant text to the final reply without duplicating messages or losing still-local optimistic state.

## What

- Preserves durable chat message identity through history processing, split message parts, grouped tools, optimistic sends, and live/final message reconciliation.
- Adds identity-aware merge behavior for recovered history tails and full history refreshes.
- Adds regression coverage for stable history ids, identity-based recovered tail merging, live final dedupe, and optimistic user confirmation.

## Why

Closes #370.

Without stable message identity, recovery had to rely on content/timestamp signatures. That breaks when a streaming assistant message changes content between the local bubble and recovered history, which can drop earlier context or create duplicate bubbles.

## How

- Derive `ChatMsg.sourceId` and deterministic `msgId` values from OpenClaw mirror/wrapper ids, message ids, idempotency keys, tool call ids, or a timestamp/content fallback.
- Carry alternate source aliases so optimistic idempotency keys can match later gateway wrapper ids.
- Merge history/live/recovery updates by identity before falling back to the existing content-signature paths.
- Preserve useful local UI state such as collapsed status, optimistic temp ids, and pending/failed/streaming messages where appropriate.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [x] New features include tests
- [x] UI changes include a screenshot or screen recording (not applicable: no visual UI change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat history refreshes to prevent duplicate messages and preserve pending, failed, or streaming messages.
  * Improved reconciliation when messages are updated or receive confirmations, reducing message replacement and ordering issues.
  * Added more reliable handling for tool calls, system events, and recovered conversation content.
  * Improved consistency of message identity across refreshed and recovered conversations.

* **Tests**
  * Added coverage for stable message identification, deduplication, history merging, and preservation of locally pending messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->