### PR TITLE
fix(chat): filter internal control turns from history

### DIFF
--- a/src/features/chat/operations/loadHistory.test.ts
+++ b/src/features/chat/operations/loadHistory.test.ts
@@ -23,6 +23,39 @@ describe('filterMessage', () => {
   it('hides exact internal assistant control replies', () => {
     expect(filterMessage({ role: 'assistant', content: 'NO_REPLY' })).toBe(false);
     expect(filterMessage({ role: 'assistant', content: '  HEARTBEAT_OK\n' })).toBe(false);
+    expect(filterMessage({ role: 'assistant', content: '{"action":"NO_REPLY"}' })).toBe(false);
+    expect(filterMessage({ role: 'assistant', content: 'NO_REPLY NO_REPLY' })).toBe(false);
+  });
+
+  it('hides internal compaction and memory-flush status rows', () => {
+    expect(filterMessage({ role: 'assistant', content: 'Compaction complete.' })).toBe(false);
+    expect(filterMessage({ role: 'assistant', content: 'Memory flush completed' })).toBe(false);
+    expect(filterMessage({ role: 'system', content: 'checkpoint saved' })).toBe(false);
+  });
+
+  it('hides messages marked internal by OpenClaw metadata', () => {
+    expect(filterMessage({
+      role: 'assistant',
+      content: 'The compacted context has been saved.',
+      __openclaw: { kind: 'session.compaction_complete' },
+    })).toBe(false);
+
+    expect(filterMessage({
+      role: 'assistant',
+      content: 'Memory state synchronized.',
+      kind: 'memory-flush',
+    } as ChatMessage)).toBe(false);
+  });
+
+  it('shows substantive assistant progress messages even when they mention compaction or memory', () => {
+    expect(filterMessage({
+      role: 'assistant',
+      content: 'I compacted the notes and pushed the branch. Next I am running the focused tests.',
+    })).toBe(true);
+    expect(filterMessage({
+      role: 'assistant',
+      content: 'Memory sync is still running, so I am waiting for the next event before refreshing history.',
+    })).toBe(true);
   });
 
   it('hides pure internal wake bundles', () => {
@@ -314,7 +347,7 @@ describe('processChatMessages', () => {
 
   it('drops internal wake bundles and silent control replies from rendered history', () => {
     const msgs: ChatMessage[] = [
-      { role: 'assistant', content: 'Already did it ⚡' },
+      { role: 'assistant', content: 'Already did it' },
       {
         role: 'user',
         content: 'System (untrusted): [2026-04-16 18:27:55 GMT+3] Exec completed (wild-orb, code 0) :: done\nSystem (untrusted): [2026-04-16 18:28:54 GMT+3] Exec completed (rapid-sa, code 0) :: https://github.com/daggerhashimoto/openclaw-nerve/pull/278\n\nAn async command you ran earlier has completed. The result is shown in the system messages above. Handle the result internally. Do not relay it to the user unless explicitly requested.\nCurrent time: Thursday, April 16th, 2026 - 6:29 PM (Europe/Istanbul) / 2026-04-16 15:29 UTC',
@@ -324,7 +357,29 @@ describe('processChatMessages', () => {
     const result = processChatMessages(msgs);
     expect(result).toHaveLength(1);
     expect(result[0].role).toBe('assistant');
-    expect(result[0].rawText).toBe('Already did it ⚡');
+    expect(result[0].rawText).toBe('Already did it');
+  });
+
+  it('drops internal compaction and memory rows from rendered history', () => {
+    const result = processChatMessages([
+      { role: 'user', content: 'Please continue with the Nerve fixes.' },
+      {
+        role: 'assistant',
+        content: 'Compaction complete.',
+        __openclaw: { kind: 'session.compaction_complete', id: 'compaction-1' },
+      },
+      { role: 'assistant', content: '{"action":"NO_REPLY"}' },
+      {
+        role: 'assistant',
+        content: 'I am updating the chat adapter now.',
+        __openclaw: { mirrorIdentity: 'run-1:assistant:final' },
+      },
+    ], { sessionKey: 'agent:main:main' });
+
+    expect(result.map((m) => m.rawText)).toEqual([
+      'Please continue with the Nerve fixes.',
+      'I am updating the chat adapter now.',
+    ]);
   });
 
   it('handles empty input', () => {

--- a/src/features/chat/operations/loadHistory.test.ts
+++ b/src/features/chat/operations/loadHistory.test.ts
@@ -24,6 +24,7 @@ describe('filterMessage', () => {
     expect(filterMessage({ role: 'assistant', content: 'NO_REPLY' })).toBe(false);
     expect(filterMessage({ role: 'assistant', content: '  HEARTBEAT_OK\n' })).toBe(false);
     expect(filterMessage({ role: 'assistant', content: '{"action":"NO_REPLY"}' })).toBe(false);
+    expect(filterMessage({ role: 'assistant', content: '{"action":"NO_REPLY","reason":"idle"}' })).toBe(false);
     expect(filterMessage({ role: 'assistant', content: 'NO_REPLY NO_REPLY' })).toBe(false);
   });
 
@@ -380,6 +381,20 @@ describe('processChatMessages', () => {
       'Please continue with the Nerve fixes.',
       'I am updating the chat adapter now.',
     ]);
+  });
+
+  it('removes embedded runtime context while retaining assistant prose', () => {
+    const result = processChatMessages([
+      {
+        role: 'assistant',
+        content: 'I will keep working.\n<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\n{"token":"secret"}\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>\nVisible follow-up.',
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].rawText).toBe('I will keep working.\n\nVisible follow-up.');
+    expect(result[0].rawText).not.toContain('BEGIN_OPENCLAW_INTERNAL_CONTEXT');
+    expect(result[0].html).not.toContain('BEGIN_OPENCLAW_INTERNAL_CONTEXT');
   });
 
   it('handles empty input', () => {

--- a/src/features/chat/operations/loadHistory.ts
+++ b/src/features/chat/operations/loadHistory.ts
@@ -131,7 +131,6 @@ const SYSTEM_EVENT_FOLLOWUP_LINE = /^(?:An async command you ran earlier has com
 
 /** Internal assistant control replies that should never render as chat bubbles. */
 const INTERNAL_CONTROL_REPLY_RE = /^(?:NO_REPLY|HEARTBEAT_OK)(?:\s+(?:NO_REPLY|HEARTBEAT_OK))*$/i;
-const INTERNAL_CONTROL_ENVELOPE_RE = /^\{\s*"action"\s*:\s*"(?:NO_REPLY|HEARTBEAT_OK)"\s*\}$/i;
 const INTERNAL_MESSAGE_KIND_RE = /(?:^|[._:-])(?:internal|compaction|checkpoint|memory[-_. ]?flush|memory[-_. ]?sync)(?:$|[._:-])/i;
 const INTERNAL_ASSISTANT_STATUS_RE = /^(?:\[?(?:internal|system)\]?\s*)?(?:(?:session|context|history)\s+)?(?:compaction|memory[-_ ]?flush|memory\s+sync|memory\s+checkpoint|checkpoint)(?:\s+(?:started|complete|completed|finished|failed|succeeded|skipped|saved|written|updated))?(?:[.:]\s*)?$/i;
 const INTERNAL_RUNTIME_CONTEXT_RE = /<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>[\s\S]*<<<END_OPENCLAW_INTERNAL_CONTEXT>>>/;
@@ -164,7 +163,19 @@ function hasInternalMessageMetadata(message: ChatMessage): boolean {
 function isSilentControlReply(text: string): boolean {
   const trimmed = text.trim();
   if (!trimmed) return false;
-  return INTERNAL_CONTROL_REPLY_RE.test(trimmed) || INTERNAL_CONTROL_ENVELOPE_RE.test(trimmed);
+  if (INTERNAL_CONTROL_REPLY_RE.test(trimmed)) return true;
+  try {
+    const envelope: unknown = JSON.parse(trimmed);
+    if (!envelope || typeof envelope !== 'object' || Array.isArray(envelope)) return false;
+    const action = (envelope as Record<string, unknown>).action;
+    return typeof action === 'string' && /^(?:NO_REPLY|HEARTBEAT_OK)$/i.test(action);
+  } catch {
+    return false;
+  }
+}
+
+function stripInternalRuntimeContext(text: string): string {
+  return text.replace(INTERNAL_RUNTIME_CONTEXT_RE, '').trim();
 }
 
 function isInternalAssistantStatus(text: string): boolean {
@@ -172,7 +183,7 @@ function isInternalAssistantStatus(text: string): boolean {
   if (!trimmed) return false;
   if (isSilentControlReply(trimmed)) return true;
   if (INTERNAL_RUNTIME_CONTEXT_RE.test(trimmed)) {
-    return !trimmed.replace(INTERNAL_RUNTIME_CONTEXT_RE, '').trim();
+    return !stripInternalRuntimeContext(trimmed);
   }
   return INTERNAL_ASSISTANT_STATUS_RE.test(trimmed);
 }
@@ -363,7 +374,9 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
 
       const flushText = () => {
         if (!textBuffer.trim()) { textBuffer = ''; return; }
-        const { cleaned: ttsStripped } = extractTTSMarkers(textBuffer.trim());
+        const displayText = stripInternalRuntimeContext(textBuffer.trim());
+        if (!displayText) { textBuffer = ''; return; }
+        const { cleaned: ttsStripped } = extractTTSMarkers(displayText);
         const { cleaned: chartCleaned, charts } = extractChartMarkers(ttsStripped);
         const { cleaned, images: extractedImages } = extractImages(chartCleaned);
         if (cleaned.trim() || extractedImages.length > 0) {
@@ -436,6 +449,9 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
 
   // Normal message (no tool calls, or non-assistant)
   let rawText = extractText(m);
+  if (m.role === 'assistant') {
+    rawText = stripInternalRuntimeContext(rawText);
+  }
 
   // Strip gateway decorations from user messages
   let isVoice = false;

--- a/src/features/chat/operations/loadHistory.ts
+++ b/src/features/chat/operations/loadHistory.ts
@@ -130,7 +130,52 @@ const SYSTEM_EVENT_LINE = /^System(?: \(untrusted\))?: \[\d{4}-\d{2}-\d{2} \d{2}
 const SYSTEM_EVENT_FOLLOWUP_LINE = /^(?:An async command you ran earlier has completed\.|A scheduled reminder has been triggered\.|A scheduled cron event was triggered(?:, but no event content was found)?\.|Handle this reminder internally\.|Handle this internally\.|Handle the result internally\.?|Do not relay it to the user unless explicitly requested\.|Please relay the command output to the user in a helpful way\.|Please relay this reminder to the user in a helpful and friendly way\.|Current time:)/i;
 
 /** Internal assistant control replies that should never render as chat bubbles. */
-const INTERNAL_CONTROL_REPLY_RE = /^(?:NO_REPLY|HEARTBEAT_OK)$/;
+const INTERNAL_CONTROL_REPLY_RE = /^(?:NO_REPLY|HEARTBEAT_OK)(?:\s+(?:NO_REPLY|HEARTBEAT_OK))*$/i;
+const INTERNAL_CONTROL_ENVELOPE_RE = /^\{\s*"action"\s*:\s*"(?:NO_REPLY|HEARTBEAT_OK)"\s*\}$/i;
+const INTERNAL_MESSAGE_KIND_RE = /(?:^|[._:-])(?:internal|compaction|checkpoint|memory[-_. ]?flush|memory[-_. ]?sync)(?:$|[._:-])/i;
+const INTERNAL_ASSISTANT_STATUS_RE = /^(?:\[?(?:internal|system)\]?\s*)?(?:(?:session|context|history)\s+)?(?:compaction|memory[-_ ]?flush|memory\s+sync|memory\s+checkpoint|checkpoint)(?:\s+(?:started|complete|completed|finished|failed|succeeded|skipped|saved|written|updated))?(?:[.:]\s*)?$/i;
+const INTERNAL_RUNTIME_CONTEXT_RE = /<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>[\s\S]*<<<END_OPENCLAW_INTERNAL_CONTEXT>>>/;
+
+function readStringField(value: unknown, key: string): string | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const field = (value as Record<string, unknown>)[key];
+  return typeof field === 'string' ? field : undefined;
+}
+
+function hasInternalMessageMetadata(message: ChatMessage): boolean {
+  const messageRecord = message as unknown as Record<string, unknown>;
+  const openclaw = (!Array.isArray(messageRecord.__openclaw)
+    && typeof messageRecord.__openclaw === 'object')
+    ? messageRecord.__openclaw
+    : undefined;
+  const candidates = [
+    readStringField(openclaw, 'kind'),
+    readStringField(message, 'kind'),
+    readStringField(message, 'type'),
+    readStringField(message, 'source'),
+    readStringField(message, 'event'),
+    readStringField(message, 'category'),
+    readStringField(message, 'subtype'),
+  ].filter((value): value is string => Boolean(value));
+
+  return candidates.some((value) => INTERNAL_MESSAGE_KIND_RE.test(value));
+}
+
+function isSilentControlReply(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  return INTERNAL_CONTROL_REPLY_RE.test(trimmed) || INTERNAL_CONTROL_ENVELOPE_RE.test(trimmed);
+}
+
+function isInternalAssistantStatus(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  if (isSilentControlReply(trimmed)) return true;
+  if (INTERNAL_RUNTIME_CONTEXT_RE.test(trimmed)) {
+    return !trimmed.replace(INTERNAL_RUNTIME_CONTEXT_RE, '').trim();
+  }
+  return INTERNAL_ASSISTANT_STATUS_RE.test(trimmed);
+}
 
 function isInternalWakeBundle(text: string): boolean {
   let sawSystemEvent = false;
@@ -183,7 +228,11 @@ export function filterMessage(m: ChatMessage): boolean {
   const text = extractText(m);
   const trimmedText = text.trim();
 
-  if (m.role === 'assistant' && INTERNAL_CONTROL_REPLY_RE.test(trimmedText)) {
+  if (hasInternalMessageMetadata(m)) {
+    return false;
+  }
+
+  if ((m.role === 'assistant' || m.role === 'system') && isInternalAssistantStatus(trimmedText)) {
     return false;
   }
 


### PR DESCRIPTION
## In Plain English

Nerve should not show internal OpenClaw control/status rows as chat bubbles. This filters JSON/repeated silent replies, compaction/checkpoint/memory status rows, and metadata-marked internal messages while keeping real assistant progress text visible.

## What

Filters additional internal chat history turns from `loadHistory`, including JSON control envelopes like `{\"action\":\"NO_REPLY\"}`, repeated `NO_REPLY`/`HEARTBEAT_OK` tokens, compaction/checkpoint/memory status rows, runtime internal-context blocks, and internal metadata-marked transcript rows.

Adds regression coverage for both direct filtering and the full `processChatMessages` history pipeline.

## Why

Closes #371.

These rows are control flow between OpenClaw/Nerve, not user-facing assistant messages. When they render in chat history, they make the transcript noisy and confusing.

## How

- Expands silent-control matching in `src/features/chat/operations/loadHistory.ts`.
- Adds structural metadata checks without requiring a shared type change.
- Keeps substantive assistant prose visible even when it mentions compaction or memory work.
- Adds focused regression tests in `src/features/chat/operations/loadHistory.test.ts`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [ ] New features include tests
- [ ] UI changes include a screenshot or screen recording

## Screenshots

Not applicable; this is chat-history filtering logic covered by tests.

## Validation

Pre-patch proof on upstream `master` (`312e27333e14f841b95bf4f2b205a856b4a4c370`): temporarily added the new regression assertions and ran `npm test -- --run src/features/chat/operations/loadHistory.test.ts`; it failed because `filterMessage` returned `true` for `{\"action\":\"NO_REPLY\"}` and `Compaction complete.`.

After patch:

- `npm test -- --run src/features/chat/operations/loadHistory.test.ts` — 48 tests passed
- `npm test -- --run src/features/chat/operations/loadHistory.test.ts src/features/chat/operations/mergeRecoveredTail.test.ts src/features/chat/operations/sendMessage.test.ts src/features/chat/operations/streamEventHandler.test.ts src/contexts/ChatContext.subscription.test.tsx` — 5 files / 120 tests passed
- `npm run lint` — passed
- `npm run build` — passed
- `npm run build:server` — passed
- `npm test -- --run` — 142 files / 1874 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat history filtering to hide internal control messages, metadata, runtime context, and compaction or memory-status entries.
  * Preserved meaningful assistant and system updates while removing non-user-facing responses.
  * Improved handling of repeated control messages and JSON-formatted control data.
  * Removed embedded runtime context from displayed assistant messages.
  * Updated displayed history to remove an unintended emoji from an assistant message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->