### PR TITLE
fix(sessions): prune stale agent session rows

### DIFF
--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -554,6 +554,40 @@ describe('SessionContext', () => {
     expect(rpcMock).toHaveBeenCalledWith('sessions.list', { spawnedBy: 'agent:main:main', limit: 500 });
   });
 
+  it('preserves children under roots whose spawnedBy lookup fails', async () => {
+    rpcMock.mockImplementation(async (method: string, params?: Record<string, unknown>) => {
+      if (method !== 'sessions.list') return {};
+      if (params?.spawnedBy === 'agent:main:main') {
+        return { sessions: [] };
+      }
+      if (params?.spawnedBy === 'agent:reviewer:main') {
+        throw new Error('reviewer spawnedBy failed');
+      }
+      return {
+        sessions: [
+          { sessionKey: 'agent:main:main', label: 'Main' },
+          { sessionKey: 'agent:main:subagent:stale-main-child', label: 'Old main child', status: 'idle' },
+          { sessionKey: 'agent:reviewer:main', label: 'Reviewer' },
+          { sessionKey: 'agent:reviewer:subagent:unknown-child', label: 'Reviewer child', status: 'idle' },
+        ],
+      };
+    });
+
+    render(
+      <SessionProvider>
+        <SessionLabels />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Reviewer child')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Old main child')).not.toBeInTheDocument();
+    expect(rpcMock).toHaveBeenCalledWith('sessions.list', { spawnedBy: 'agent:main:main', limit: 500 });
+    expect(rpcMock).toHaveBeenCalledWith('sessions.list', { spawnedBy: 'agent:reviewer:main', limit: 500 });
+  });
+
   it('hydrates root session labels from IDENTITY.md names', async () => {
     rpcMock.mockImplementation(async (method: string) => {
       if (method === 'sessions.list') {

--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -521,6 +521,39 @@ describe('SessionContext', () => {
     expect(rpcMock).not.toHaveBeenCalledWith('sessions.list', expect.objectContaining({ activeMinutes: expect.any(Number) }));
   });
 
+  it('converges stale cached children from the full list to current spawnedBy truth', async () => {
+    rpcMock.mockImplementation(async (method: string, params?: Record<string, unknown>) => {
+      if (method !== 'sessions.list') return {};
+      if (params?.spawnedBy === 'agent:main:main') {
+        return {
+          sessions: [
+            { sessionKey: 'agent:main:subagent:current-child', label: 'Current child' },
+          ],
+        };
+      }
+      return {
+        sessions: [
+          { sessionKey: 'agent:main:main', label: 'Main' },
+          { sessionKey: 'agent:main:subagent:stale-child', label: 'Old cached child', status: 'idle' },
+          { sessionKey: 'agent:main:subagent:current-child', label: 'Current child', status: 'idle' },
+        ],
+      };
+    });
+
+    render(
+      <SessionProvider>
+        <SessionLabels />
+      </SessionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Current child')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Old cached child')).not.toBeInTheDocument();
+    expect(rpcMock).toHaveBeenCalledWith('sessions.list', { spawnedBy: 'agent:main:main', limit: 500 });
+  });
+
   it('hydrates root session labels from IDENTITY.md names', async () => {
     rpcMock.mockImplementation(async (method: string) => {
       if (method === 'sessions.list') {

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -329,10 +329,10 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         [...spawnedByRoots].map(async (rootSessionKey) => {
           try {
             const spawnedRes = await rpc('sessions.list', { spawnedBy: rootSessionKey, limit: SESSIONS_SPAWNED_LIMIT }) as SessionsListResponse;
-            return { ok: true as const, sessions: spawnedRes?.sessions ?? [] };
+            return { rootSessionKey, ok: true as const, sessions: spawnedRes?.sessions ?? [] };
           } catch (err) {
             console.debug('[SessionContext] Failed to fetch spawned sessions for root:', rootSessionKey, err);
-            return { ok: false as const, sessions: [] as Session[] };
+            return { rootSessionKey, ok: false as const, sessions: [] as Session[] };
           }
         }),
       );
@@ -340,7 +340,12 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       return mergeAuthoritativeSessions(
         baseSessions,
         spawnedResults.map((result) => result.sessions),
-        { spawnedByAuthoritative: spawnedResults.some((result) => result.ok) },
+        {
+          spawnedByAuthoritative: spawnedResults.some((result) => result.ok),
+          authoritativeSpawnedByRoots: new Set(spawnedResults
+            .filter((result) => result.ok)
+            .map((result) => result.rootSessionKey)),
+        },
       );
     } catch (err) {
       console.debug('[SessionContext] Failed to fetch authoritative session list:', err);

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -6,6 +6,7 @@ import { getSessionKey, type Session, type AgentLogEntry, type EventEntry, type 
 import { playPing } from '@/features/voice/audio-feedback';
 import { describeToolUse } from '@/utils/helpers';
 import { buildSessionTree } from '@/features/sessions/sessionTree';
+import { mergeAuthoritativeSessions } from '@/features/sessions/sessionReconciliation';
 import {
   buildAgentRootSessionKey,
   extractIdentityName,
@@ -336,10 +337,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         }),
       );
 
-      return spawnedSessionLists.reduce(
-        (acc, spawnedSessions) => mergeSessionLists(acc, spawnedSessions),
-        baseSessions,
-      );
+      return mergeAuthoritativeSessions(baseSessions, spawnedSessionLists);
     } catch (err) {
       console.debug('[SessionContext] Failed to fetch authoritative session list:', err);
       return sessionsRef.current;

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -325,19 +325,23 @@ export function SessionProvider({ children }: { children: ReactNode }) {
 
       // Keep active child sessions visible even when the full sessions.list
       // result lags behind the recent spawn/discovery flow.
-      const spawnedSessionLists = await Promise.all(
+      const spawnedResults = await Promise.all(
         [...spawnedByRoots].map(async (rootSessionKey) => {
           try {
             const spawnedRes = await rpc('sessions.list', { spawnedBy: rootSessionKey, limit: SESSIONS_SPAWNED_LIMIT }) as SessionsListResponse;
-            return spawnedRes?.sessions ?? [];
+            return { ok: true as const, sessions: spawnedRes?.sessions ?? [] };
           } catch (err) {
             console.debug('[SessionContext] Failed to fetch spawned sessions for root:', rootSessionKey, err);
-            return [];
+            return { ok: false as const, sessions: [] as Session[] };
           }
         }),
       );
 
-      return mergeAuthoritativeSessions(baseSessions, spawnedSessionLists);
+      return mergeAuthoritativeSessions(
+        baseSessions,
+        spawnedResults.map((result) => result.sessions),
+        { spawnedByAuthoritative: spawnedResults.some((result) => result.ok) },
+      );
     } catch (err) {
       console.debug('[SessionContext] Failed to fetch authoritative session list:', err);
       return sessionsRef.current;

--- a/src/features/sessions/sessionReconciliation.test.ts
+++ b/src/features/sessions/sessionReconciliation.test.ts
@@ -32,6 +32,53 @@ describe('session reconciliation', () => {
     expect(merged.map((item) => item.sessionKey)).toEqual(['agent:main:main']);
   });
 
+  it('prunes stale base-list children missing from current spawnedBy truth', () => {
+    const merged = mergeAuthoritativeSessions(
+      [
+        session('agent:main:main'),
+        session('agent:main:subagent:stale-cache-child', { label: 'Old cached child', status: 'idle' }),
+        session('agent:main:subagent:current-child', { label: 'Current child', status: 'idle' }),
+      ],
+      [[session('agent:main:subagent:current-child', { label: 'Current child' })]],
+    );
+
+    expect(merged.map((item) => item.sessionKey)).toEqual([
+      'agent:main:main',
+      'agent:main:subagent:current-child',
+    ]);
+  });
+
+  it('keeps base-list children with live state even before spawnedBy catches up', () => {
+    const merged = mergeAuthoritativeSessions(
+      [
+        session('agent:main:main'),
+        session('agent:main:subagent:streaming-child', { status: 'running' }),
+      ],
+      [[]],
+    );
+
+    expect(merged.map((item) => item.sessionKey)).toEqual([
+      'agent:main:main',
+      'agent:main:subagent:streaming-child',
+    ]);
+  });
+
+  it('preserves base sessions when spawnedBy lookups all fail', () => {
+    const merged = mergeAuthoritativeSessions(
+      [
+        session('agent:main:main'),
+        session('agent:main:subagent:unknown-child', { label: 'Unknown child' }),
+      ],
+      [[]],
+      { spawnedByAuthoritative: false },
+    );
+
+    expect(merged.map((item) => item.sessionKey)).toEqual([
+      'agent:main:main',
+      'agent:main:subagent:unknown-child',
+    ]);
+  });
+
   it('preserves terminal sessions when the full list still reports them', () => {
     const merged = mergeAuthoritativeSessions(
       [

--- a/src/features/sessions/sessionReconciliation.test.ts
+++ b/src/features/sessions/sessionReconciliation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import type { Session } from '@/types';
+import { isLiveSupplementalSession, mergeAuthoritativeSessions } from './sessionReconciliation';
+
+function session(sessionKey: string, extra: Partial<Session> = {}): Session {
+  return { sessionKey, ...extra };
+}
+
+describe('session reconciliation', () => {
+  it('keeps live spawnedBy supplements missing from the full list', () => {
+    const merged = mergeAuthoritativeSessions(
+      [session('agent:main:main')],
+      [[session('agent:main:subagent:active-child', { status: 'running' })]],
+    );
+
+    expect(merged.map((item) => item.sessionKey)).toEqual([
+      'agent:main:main',
+      'agent:main:subagent:active-child',
+    ]);
+  });
+
+  it('prunes terminal spawnedBy supplements missing from the full list', () => {
+    const merged = mergeAuthoritativeSessions(
+      [session('agent:main:main')],
+      [[
+        session('agent:main:subagent:done-child', { status: 'done' }),
+        session('agent:main:subagent:failed-child', { status: 'failed' }),
+        session('agent:main:subagent:archived-child', { status: 'archived' }),
+      ]],
+    );
+
+    expect(merged.map((item) => item.sessionKey)).toEqual(['agent:main:main']);
+  });
+
+  it('preserves terminal sessions when the full list still reports them', () => {
+    const merged = mergeAuthoritativeSessions(
+      [
+        session('agent:main:main'),
+        session('agent:main:subagent:done-child', { status: 'done' }),
+      ],
+      [[session('agent:main:subagent:done-child', { status: 'done', label: 'stale duplicate' })]],
+    );
+
+    expect(merged).toHaveLength(2);
+    expect(merged[1]).toMatchObject({ sessionKey: 'agent:main:subagent:done-child', status: 'done' });
+    expect(merged[1].label).toBeUndefined();
+  });
+
+  it('requires a positive live signal for supplemental sessions with unknown state', () => {
+    expect(isLiveSupplementalSession(session('agent:main:subagent:unknown-child'))).toBe(false);
+    expect(isLiveSupplementalSession(session('agent:main:subagent:busy-child', { processing: true }))).toBe(true);
+  });
+});

--- a/src/features/sessions/sessionReconciliation.test.ts
+++ b/src/features/sessions/sessionReconciliation.test.ts
@@ -79,6 +79,28 @@ describe('session reconciliation', () => {
     ]);
   });
 
+  it('only prunes children for roots with successful spawnedBy lookups', () => {
+    const merged = mergeAuthoritativeSessions(
+      [
+        session('agent:main:main'),
+        session('agent:main:subagent:stale-main-child', { label: 'Old main child', status: 'idle' }),
+        session('agent:reviewer:main'),
+        session('agent:reviewer:subagent:unknown-reviewer-child', { label: 'Reviewer child', status: 'idle' }),
+      ],
+      [[]],
+      {
+        spawnedByAuthoritative: true,
+        authoritativeSpawnedByRoots: new Set(['agent:main:main']),
+      },
+    );
+
+    expect(merged.map((item) => item.sessionKey)).toEqual([
+      'agent:main:main',
+      'agent:reviewer:main',
+      'agent:reviewer:subagent:unknown-reviewer-child',
+    ]);
+  });
+
   it('preserves terminal sessions when the full list still reports them', () => {
     const merged = mergeAuthoritativeSessions(
       [

--- a/src/features/sessions/sessionReconciliation.ts
+++ b/src/features/sessions/sessionReconciliation.ts
@@ -1,0 +1,72 @@
+import type { Session } from '@/types';
+import { getSessionKey } from '@/types';
+
+const LIVE_SUPPLEMENTAL_STATES = new Set([
+  'busy',
+  'delta',
+  'pending',
+  'processing',
+  'queued',
+  'running',
+  'started',
+  'streaming',
+  'thinking',
+  'tool_use',
+  'working',
+]);
+
+const TERMINAL_SUPPLEMENTAL_STATES = new Set([
+  'aborted',
+  'archived',
+  'cancelled',
+  'canceled',
+  'completed',
+  'deleted',
+  'done',
+  'ended',
+  'error',
+  'failed',
+  'final',
+  'finished',
+  'idle',
+  'stopped',
+  'timeout',
+]);
+
+function normalizedState(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+export function isLiveSupplementalSession(session: Session): boolean {
+  if (session.busy || session.processing) return true;
+
+  const states = [
+    normalizedState(session.state),
+    normalizedState(session.agentState),
+    normalizedState(session.status),
+  ].filter(Boolean);
+
+  if (states.some((state) => LIVE_SUPPLEMENTAL_STATES.has(state))) return true;
+  if (states.some((state) => TERMINAL_SUPPLEMENTAL_STATES.has(state))) return false;
+  return false;
+}
+
+export function mergeAuthoritativeSessions(
+  baseSessions: Session[],
+  spawnedSessionLists: Session[][],
+): Session[] {
+  const merged = [...baseSessions];
+  const seen = new Set(baseSessions.map(getSessionKey).filter(Boolean));
+
+  for (const spawnedSessions of spawnedSessionLists) {
+    for (const session of spawnedSessions) {
+      const key = getSessionKey(session);
+      if (!key || seen.has(key)) continue;
+      if (!isLiveSupplementalSession(session)) continue;
+      seen.add(key);
+      merged.push(session);
+    }
+  }
+
+  return merged;
+}

--- a/src/features/sessions/sessionReconciliation.ts
+++ b/src/features/sessions/sessionReconciliation.ts
@@ -77,6 +77,7 @@ export interface MergeAuthoritativeSessionsOptions {
    * false so an RPC outage does not wipe the sidebar down to roots.
    */
   spawnedByAuthoritative?: boolean;
+  authoritativeSpawnedByRoots?: Set<string>;
 }
 
 export function mergeAuthoritativeSessions(
@@ -93,6 +94,7 @@ export function mergeAuthoritativeSessions(
   }
 
   const spawnedByAuthoritative = options.spawnedByAuthoritative ?? spawnedSessionLists.length > 0;
+  const authoritativeSpawnedByRoots = options.authoritativeSpawnedByRoots;
   const baseSessionsToKeep = spawnedByAuthoritative
     ? baseSessions.filter((session) => {
         const key = getSessionKey(session);
@@ -102,6 +104,7 @@ export function mergeAuthoritativeSessions(
         if (hasConfirmedParent(session, spawnedKeys)) return true;
 
         const rootKey = getRootAgentSessionKey(key);
+        if (rootKey && authoritativeSpawnedByRoots && !authoritativeSpawnedByRoots.has(rootKey)) return true;
         return Boolean(rootKey && spawnedKeys.has(rootKey));
       })
     : baseSessions;

--- a/src/features/sessions/sessionReconciliation.ts
+++ b/src/features/sessions/sessionReconciliation.ts
@@ -1,5 +1,12 @@
 import type { Session } from '@/types';
 import { getSessionKey } from '@/types';
+import {
+  getExplicitParentCandidates,
+  getRootAgentSessionKey,
+  isCronRunSessionKey,
+  isCronSessionKey,
+  isTopLevelAgentSessionKey,
+} from './sessionKeys';
 
 const LIVE_SUPPLEMENTAL_STATES = new Set([
   'busy',
@@ -51,12 +58,56 @@ export function isLiveSupplementalSession(session: Session): boolean {
   return false;
 }
 
+function hasConfirmedParent(session: Session, confirmedKeys: Set<string>): boolean {
+  return getExplicitParentCandidates(session).some((parentKey) => confirmedKeys.has(parentKey));
+}
+
+function isSessionEligibleWithoutSpawnedConfirmation(session: Session): boolean {
+  const key = getSessionKey(session);
+  if (!key) return false;
+  if (isTopLevelAgentSessionKey(key)) return true;
+  if (isCronSessionKey(key) || isCronRunSessionKey(key)) return true;
+  return isLiveSupplementalSession(session);
+}
+
+export interface MergeAuthoritativeSessionsOptions {
+  /**
+   * True when spawnedBy calls succeeded and can be treated as the current child
+   * source of truth. When every spawnedBy call fails, callers should leave this
+   * false so an RPC outage does not wipe the sidebar down to roots.
+   */
+  spawnedByAuthoritative?: boolean;
+}
+
 export function mergeAuthoritativeSessions(
   baseSessions: Session[],
   spawnedSessionLists: Session[][],
+  options: MergeAuthoritativeSessionsOptions = {},
 ): Session[] {
-  const merged = [...baseSessions];
-  const seen = new Set(baseSessions.map(getSessionKey).filter(Boolean));
+  const spawnedKeys = new Set<string>();
+  for (const spawnedSessions of spawnedSessionLists) {
+    for (const session of spawnedSessions) {
+      const key = getSessionKey(session);
+      if (key) spawnedKeys.add(key);
+    }
+  }
+
+  const spawnedByAuthoritative = options.spawnedByAuthoritative ?? spawnedSessionLists.length > 0;
+  const baseSessionsToKeep = spawnedByAuthoritative
+    ? baseSessions.filter((session) => {
+        const key = getSessionKey(session);
+        if (!key) return false;
+        if (isSessionEligibleWithoutSpawnedConfirmation(session)) return true;
+        if (spawnedKeys.has(key)) return true;
+        if (hasConfirmedParent(session, spawnedKeys)) return true;
+
+        const rootKey = getRootAgentSessionKey(key);
+        return Boolean(rootKey && spawnedKeys.has(rootKey));
+      })
+    : baseSessions;
+
+  const merged = [...baseSessionsToKeep];
+  const seen = new Set(baseSessionsToKeep.map(getSessionKey).filter(Boolean));
 
   for (const spawnedSessions of spawnedSessionLists) {
     for (const session of spawnedSessions) {


### PR DESCRIPTION
In Plain English

The Agents panel can keep showing old spawned-session rows after the gateway no longer reports them as current children. This PR makes the full session list converge with current `spawnedBy` truth while still keeping live children visible during gateway lag or transient spawnedBy lookup failures.

## What

- Adds session reconciliation logic for authoritative full-list plus `spawnedBy` session results.
- Keeps live supplemental sessions when the full list lags behind a recent spawn.
- Prunes terminal or stale child rows that are no longer confirmed by the current spawnedBy list.
- Adds targeted regression tests for stale supplemental and stale base-list child sessions.

## Why

Closes #372.

Without this, the Agents panel can show stale subagent/session rows after a spawned session is deleted, archived, or no longer returned by the gateway's current child lookup.

## How

- Introduces `mergeAuthoritativeSessions` in `src/features/sessions/sessionReconciliation.ts`.
- Updates `SessionContext` to fetch `spawnedBy` child lists with success/failure metadata and reconcile them against the full list.
- Leaves base sessions untouched when all spawnedBy lookups fail, avoiding sidebar data loss during RPC outages.
- Covers the behavior in `sessionReconciliation.test.ts` and `SessionContext.test.tsx`.

Pre-patch proof:

- On unpatched upstream master `312e27333e14f841b95bf4f2b205a856b4a4c370`, adding only the stale-child regression test and running `npm test -- --run src/contexts/SessionContext.test.tsx` failed because `Old cached child` remained in the document.

Validation:

- `npm test -- --run src/features/sessions/sessionReconciliation.test.ts src/contexts/SessionContext.test.tsx` passed: 2 files, 27 tests.
- `npm run lint` passed.
- `npm run build` passed. Vite reported existing chunk-size/dynamic-import warnings.
- `npm run build:server` passed.
- `npm test -- --run` passed: 143 files, 1878 tests. The run emitted existing React `act(...)` and nested-button warning noise from unrelated tests.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [x] New features include tests
- [ ] UI changes include a screenshot or screen recording

## Screenshots

Not applicable; this is a session reconciliation behavior fix covered by tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session list accuracy by removing stale or completed spawned sessions when authoritative updates confirm they are no longer active.
  - Preserved active sessions and live child sessions during reconciliation, including when some session lookups fail.
  - Prevented successful empty responses from being confused with failed requests, reducing unintended session removal.
  - Improved handling of duplicate and supplemental session records for a more consistent session view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->