### PR TITLE
fix(chat): dedupe assistant final history delivery

### DIFF
--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -593,7 +593,8 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const handleSend = useCallback(async (text: string, images?: ImageAttachment[], uploadPayload?: OutgoingUploadPayload) => {
     ttsHook.trackVoiceMessage(text);
 
-    const { msg: userMsg, tempId } = buildUserMessage({ text, images, uploadPayload });
+    const idempotencyKey = crypto.randomUUID ? crypto.randomUUID() : 'ik-' + Date.now();
+    const { msg: userMsg, tempId } = buildUserMessage({ text, images, uploadPayload, idempotencyKey });
 
     incrementGeneration();
 
@@ -604,7 +605,6 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     streamHook.setStream((prev: ChatStreamState) => ({ ...prev, html: '', runId: undefined }));
     setProcessingStage('thinking');
 
-    const idempotencyKey = crypto.randomUUID ? crypto.randomUUID() : 'ik-' + Date.now();
     try {
       const ack = await sendChatMessage({
         rpc,

--- a/src/features/chat/operations/loadHistory.test.ts
+++ b/src/features/chat/operations/loadHistory.test.ts
@@ -380,6 +380,19 @@ describe('processChatMessages', () => {
       'https://example.com/other.png',
     ]);
   });
+
+  it('disambiguates repeated derived identities inside one processed batch', () => {
+    const result = processChatMessages([
+      { role: 'assistant', content: 'Done.', timestamp: '2026-08-08T01:00:00.000Z' },
+      { role: 'assistant', content: 'Done.', timestamp: '2026-08-08T01:00:00.000Z' },
+    ], { sessionKey: 'agent:main:main' });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].sourceId).toBeTruthy();
+    expect(result[1].sourceId).toBe(`${result[0].sourceId}:occurrence:2`);
+    expect(result[1].alternateSourceIds).toContain(result[0].sourceId);
+    expect(result[0].msgId).not.toBe(result[1].msgId);
+  });
 });
 
 describe('loadChatHistory', () => {

--- a/src/features/chat/operations/loadHistory.ts
+++ b/src/features/chat/operations/loadHistory.ts
@@ -4,7 +4,7 @@
  * Extracted from ChatContext to keep the context a thin state-management wrapper.
  * All functions here are pure (no React hooks, setState, or refs).
  */
-import { generateMsgId } from '@/features/chat/types';
+import { generateMsgId, stableMsgId } from '@/features/chat/types';
 import type { ChatMsg, ChatMsgRole, ToolGroupEntry, UploadAttachmentDescriptor } from '@/features/chat/types';
 import type { ChatMessage, ContentBlock, ChatHistoryResponse } from '@/types';
 import { extractText, describeToolUse, renderMarkdown, renderToolResults } from '@/utils/helpers';
@@ -18,6 +18,76 @@ import type { MessageImage } from '@/features/chat/types';
 function toArray<T>(value: T | T[] | undefined): T[] {
   if (Array.isArray(value)) return value;
   return value ? [value] : [];
+}
+
+function stableHash(input: string): string {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) - hash + input.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function getMessageTimestampValue(message: ChatMessage): string {
+  const value = message.timestamp ?? message.createdAt ?? message.ts ?? message.__openclaw?.recordTimestampMs;
+  return value === undefined || value === null ? '' : String(value);
+}
+
+function getDurableMessageBase(message: ChatMessage, options: { sessionKey?: string; messageIndex?: number } = {}): string | null {
+  const openclaw = message.__openclaw;
+  if (openclaw?.mirrorIdentity) return `openclaw:mirror:${openclaw.mirrorIdentity}`;
+  if (openclaw?.id) return `openclaw:id:${openclaw.id}`;
+  if (message.id) return `message:id:${message.id}`;
+  if (message.messageId) return `message:id:${message.messageId}`;
+  if (message.message_id) return `message:id:${message.message_id}`;
+  if (message.idempotencyKey) return `message:idempotency:${message.idempotencyKey}`;
+  if (message.toolCallId) return `message:tool:${message.toolCallId}:${message.role}`;
+
+  const timestamp = getMessageTimestampValue(message);
+  if (timestamp) {
+    const session = options.sessionKey || 'unknown-session';
+    return `derived:${session}:${message.role}:${timestamp}:${stableHash(JSON.stringify(message.content))}`;
+  }
+
+  if (typeof options.messageIndex === 'number') {
+    const session = options.sessionKey || 'unknown-session';
+    return `derived:${session}:${message.role}:index:${options.messageIndex}:${stableHash(JSON.stringify(message.content))}`;
+  }
+
+  return null;
+}
+
+function getDurableMessageAliases(message: ChatMessage): string[] {
+  const aliases = [
+    message.idempotencyKey ? `message:idempotency:${message.idempotencyKey}` : null,
+    message.toolCallId ? `message:tool:${message.toolCallId}:${message.role}` : null,
+    message.id ? `message:id:${message.id}` : null,
+    message.messageId ? `message:id:${message.messageId}` : null,
+    message.message_id ? `message:id:${message.message_id}` : null,
+    message.__openclaw?.id ? `openclaw:id:${message.__openclaw.id}` : null,
+    message.__openclaw?.mirrorIdentity ? `openclaw:mirror:${message.__openclaw.mirrorIdentity}` : null,
+  ].filter((value): value is string => Boolean(value));
+
+  return [...new Set(aliases)];
+}
+
+function withSourceIdentity(
+  msg: ChatMsg,
+  base: string | null,
+  aliases: string[],
+  part: string,
+): ChatMsg {
+  if (!base) return msg;
+  const sourceId = part ? `${base}:${part}` : base;
+  const alternateSourceIds = aliases
+    .filter((alias) => alias !== base)
+    .map((alias) => (part ? `${alias}:${part}` : alias));
+  return {
+    ...msg,
+    sourceId,
+    ...(alternateSourceIds.length > 0 ? { alternateSourceIds } : {}),
+    msgId: stableMsgId(sourceId),
+  };
 }
 
 function getFilenameFromPathish(value: string, fallback: string): string {
@@ -292,11 +362,13 @@ function splitSystemEvents(text: string): Array<{ role: 'event' | 'user'; text: 
   return segments;
 }
 
-export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: string } = {}): ChatMsg[] {
+export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: string; messageIndex?: number } = {}): ChatMsg[] {
   const ts = m.timestamp || m.createdAt || m.ts || null;
   const parsedTimestamp = ts ? new Date(ts as string | number) : null;
   const hasPersistedTimestamp = Boolean(parsedTimestamp && Number.isFinite(parsedTimestamp.getTime()));
   const timestamp = hasPersistedTimestamp ? parsedTimestamp as Date : new Date();
+  const identityBase = getDurableMessageBase(m, options);
+  const identityAliases = getDurableMessageAliases(m);
 
   // Only interleave for assistant messages with array content containing tool_use
   if (m.role === 'assistant' && Array.isArray(m.content)) {
@@ -318,7 +390,7 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
         const { cleaned: chartCleaned, charts } = extractChartMarkers(ttsStripped);
         const { cleaned, images: extractedImages } = extractImages(chartCleaned);
         if (cleaned.trim() || extractedImages.length > 0) {
-          result.push({
+          result.push(withSourceIdentity({
             role: 'assistant',
             html: renderToolResults(renderMarkdown(cleaned)),
             rawText: cleaned,
@@ -326,7 +398,7 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
             streaming: false,
             ...(charts.length > 0 ? { charts } : {}),
             ...(extractedImages.length > 0 ? { extractedImages } : {}),
-          });
+          }, identityBase, identityAliases, `text:${result.length}`));
         }
         textBuffer = '';
       };
@@ -336,13 +408,13 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
           flushText();
           const thinkingContent = (block as unknown as { thinking?: string }).thinking || block.text || '';
           if (thinkingContent.trim()) {
-            result.push({
+            result.push(withSourceIdentity({
               role: 'assistant',
               html: renderMarkdown(thinkingContent),
               rawText: thinkingContent,
               timestamp,
               isThinking: true,
-            });
+            }, identityBase, identityAliases, `thinking:${result.length}`));
           }
         } else if (block.type === 'text' && block.text) {
           textBuffer += (textBuffer ? '\n' : '') + block.text;
@@ -353,13 +425,13 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
             ? (() => { try { return JSON.parse(rawArgs); } catch { return { value: rawArgs }; } })()
             : rawArgs;
           const desc = describeToolUse(block.name || 'unknown', args) || block.name || 'unknown';
-          result.push({
+          result.push(withSourceIdentity({
             role: 'tool',
             html: renderMarkdown(desc),
             rawText: `**tool:** \`${block.name}\`\n\`\`\`json\n${JSON.stringify(args, null, 2)}\n\`\`\``,
             timestamp,
             streaming: false,
-          });
+          }, identityBase, identityAliases, block.id || block.toolCallId || `tool:${result.length}`));
         }
       }
       flushText(); // Final text block
@@ -371,13 +443,13 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
         if (lastAssistant) {
           lastAssistant.images = [...(lastAssistant.images || []), ...contentImages];
         } else {
-          result.push({
+          result.push(withSourceIdentity({
             role: m.role as ChatMsgRole,
             html: '',
             rawText: '',
             timestamp,
             images: contentImages,
-          });
+          }, identityBase, identityAliases, 'images'));
         }
       }
 
@@ -412,10 +484,10 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
   if (m.role === 'user' && SYSTEM_EVENT_LINE.test(rawText)) {
     const segments = splitSystemEvents(rawText);
     if (segments.some(s => s.role === 'event')) {
-      return segments.map(seg => {
+      return segments.map((seg, index) => {
         const { cleaned: ttsStripped } = extractTTSMarkers(seg.text);
         const { cleaned: chartCleaned, charts } = extractChartMarkers(ttsStripped);
-        return {
+        return withSourceIdentity({
           role: seg.role as ChatMsgRole,
           html: renderToolResults(renderMarkdown(chartCleaned)),
           rawText: chartCleaned,
@@ -424,7 +496,7 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
           ...(charts.length > 0 ? { charts } : {}),
           ...(isVoice && seg.role === 'user' ? { isVoice: true } : {}),
           ...(uploadAttachments && seg.role === 'user' ? { uploadAttachments } : {}),
-        };
+        }, identityBase, identityAliases, `${seg.role}:${index}`);
       });
     }
   }
@@ -447,7 +519,7 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
   // Tag system notifications (subagent/cron completions) for collapsible strip rendering
   const sysNotif = m.role === 'user' ? detectSystemNotification(rawText) : { match: false, label: '' };
 
-  return [{
+  return [withSourceIdentity({
     role: m.role as ChatMsgRole,
     html: renderToolResults(renderMarkdown(text)),
     rawText: text,
@@ -459,7 +531,7 @@ export function splitToolCallMessage(m: ChatMessage, options: { sessionKey?: str
     ...(uploadAttachments ? { uploadAttachments } : {}),
     ...(isVoice ? { isVoice: true } : {}),
     ...(sysNotif.match ? { isSystemNotification: true, systemLabel: sysNotif.label } : {}),
-  }];
+  }, identityBase, identityAliases, '')];
 }
 
 // ─── Grouping ──────────────────────────────────────────────────────────────────
@@ -503,7 +575,10 @@ export function groupToolMessages(msgs: ChatMsg[]): ChatMsg[] {
         const plainPreview = decodeHtmlEntities(t.html.replace(/<[^>]*>/g, '').trim());
         return { html: t.html, rawText: t.rawText, preview: plainPreview || t.rawText.slice(0, 80) };
       });
+      const groupedSourceIds = filtered.map(t => t.sourceId).filter(Boolean);
+      const sourceId = groupedSourceIds.length > 0 ? `group:${groupedSourceIds.join('+')}` : undefined;
       grouped.push({
+        ...(sourceId ? { sourceId, msgId: stableMsgId(sourceId) } : {}),
         role: 'tool',
         html: `Used ${entries.length} tools`,
         rawText: entries.map(e => e.preview).join('\n'),
@@ -589,7 +664,7 @@ export function tagIntermediateMessages(msgs: ChatMsg[]): ChatMsg[] {
 export function processChatMessages(messages: ChatMessage[], options: { sessionKey?: string } = {}): ChatMsg[] {
   const chatMsgs: ChatMsg[] = messages
     .filter(filterMessage)
-    .flatMap((message) => splitToolCallMessage(message, options));
+    .flatMap((message, messageIndex) => splitToolCallMessage(message, { ...options, messageIndex }));
 
   const grouped = groupToolMessages(chatMsgs);
   const tagged = tagIntermediateMessages(grouped);

--- a/src/features/chat/operations/loadHistory.ts
+++ b/src/features/chat/operations/loadHistory.ts
@@ -90,6 +90,26 @@ function withSourceIdentity(
   };
 }
 
+function disambiguateRepeatedSourceIdentities(msgs: ChatMsg[]): ChatMsg[] {
+  const seen = new Map<string, number>();
+
+  return msgs.map((msg) => {
+    if (!msg.sourceId) return msg;
+
+    const occurrence = seen.get(msg.sourceId) || 0;
+    seen.set(msg.sourceId, occurrence + 1);
+    if (occurrence === 0) return msg;
+
+    const sourceId = `${msg.sourceId}:occurrence:${occurrence + 1}`;
+    return {
+      ...msg,
+      sourceId,
+      alternateSourceIds: [...new Set([...(msg.alternateSourceIds || []), msg.sourceId])],
+      msgId: stableMsgId(sourceId),
+    };
+  });
+}
+
 function getFilenameFromPathish(value: string, fallback: string): string {
   const trimmed = value.trim();
   if (!trimmed) return fallback;
@@ -662,9 +682,9 @@ export function tagIntermediateMessages(msgs: ChatMsg[]): ChatMsg[] {
  * filter → split → group → tag
  */
 export function processChatMessages(messages: ChatMessage[], options: { sessionKey?: string } = {}): ChatMsg[] {
-  const chatMsgs: ChatMsg[] = messages
+  const chatMsgs: ChatMsg[] = disambiguateRepeatedSourceIdentities(messages
     .filter(filterMessage)
-    .flatMap((message, messageIndex) => splitToolCallMessage(message, { ...options, messageIndex }));
+    .flatMap((message, messageIndex) => splitToolCallMessage(message, { ...options, messageIndex })));
 
   const grouped = groupToolMessages(chatMsgs);
   const tagged = tagIntermediateMessages(grouped);

--- a/src/features/chat/operations/mergeRecoveredTail.test.ts
+++ b/src/features/chat/operations/mergeRecoveredTail.test.ts
@@ -167,6 +167,22 @@ describe('mergeRecoveredTail', () => {
     ]);
   });
 
+  it('does not reuse one live msgId for two repeated durable finals', () => {
+    const existing = [
+      makeIdentifiedMsg('assistant', 'Done.', 'derived:unknown-session:assistant:1700000000000:abc', 1700000000000),
+    ];
+    const recovered = [
+      makeIdentifiedMsg('assistant', 'Done.', 'openclaw:mirror:run-1:assistant', 1700000000000),
+      makeIdentifiedMsg('assistant', 'Done.', 'openclaw:mirror:run-2:assistant', 1700000005000),
+    ];
+
+    const result = mergeRecoveredTail(existing, recovered);
+
+    expect(result).toHaveLength(2);
+    expect(new Set(result.map(m => m.msgId)).size).toBe(2);
+    expect(result[0].msgId).toBe(existing[0].msgId);
+  });
+
   it('does not alias tool-group assistant-adjacent rich messages by matching text alone', () => {
     const existing = [
       makeIdentifiedMsg('assistant', 'Used tools', 'derived:unknown-session:assistant:1700000000000:abc', 1700000000000),

--- a/src/features/chat/operations/mergeRecoveredTail.test.ts
+++ b/src/features/chat/operations/mergeRecoveredTail.test.ts
@@ -12,6 +12,14 @@ function makeMsg(role: string, text: string, ts?: number): ChatMsg {
   };
 }
 
+function makeIdentifiedMsg(role: string, text: string, sourceId: string, ts?: number): ChatMsg {
+  return {
+    ...makeMsg(role, text, ts),
+    msgId: `ui-${sourceId}`,
+    sourceId,
+  };
+}
+
 describe('mergeRecoveredTail', () => {
   it('returns recovered when existing is empty', () => {
     const recovered = [makeMsg('user', 'Hello')];
@@ -90,5 +98,87 @@ describe('mergeRecoveredTail', () => {
     const recovered = [makeMsg('user', 'Only msg', ts), makeMsg('assistant', 'Reply', ts + 1000)];
     const result = mergeRecoveredTail(existing, recovered);
     expect(result).toHaveLength(2);
+  });
+
+  it('merges recovered messages by stable identity even when content changes', () => {
+    const existing = [
+      makeIdentifiedMsg('user', 'Question', 'u-1', 1000),
+      makeIdentifiedMsg('assistant', 'Streaming partial answer', 'a-1', 2000),
+    ];
+    const recovered = [
+      makeIdentifiedMsg('assistant', 'Final answer', 'a-1', 2000),
+      makeIdentifiedMsg('user', 'Next question', 'u-2', 3000),
+    ];
+
+    const result = mergeRecoveredTail(existing, recovered);
+
+    expect(result.map(m => m.rawText)).toEqual(['Question', 'Final answer', 'Next question']);
+    expect(result[1].msgId).toBe('ui-a-1');
+  });
+
+  it('does not let a stale recovered tail drop newer local state', () => {
+    const existing = [
+      makeIdentifiedMsg('user', 'Question', 'u-1', 1000),
+      makeIdentifiedMsg('assistant', 'Answer', 'a-1', 2000),
+      makeIdentifiedMsg('user', 'Optimistic next', 'u-2', 4000),
+    ];
+    existing[2].pending = true;
+    const recovered = [
+      makeIdentifiedMsg('assistant', 'Answer from stale tail', 'a-1', 2000),
+    ];
+
+    const result = mergeRecoveredTail(existing, recovered);
+
+    expect(result.map(m => m.rawText)).toEqual(['Question', 'Answer from stale tail', 'Optimistic next']);
+    expect(result[2].pending).toBe(true);
+  });
+
+  it('aliases a live assistant final to a recovered durable OpenClaw identity', () => {
+    const existing = [
+      makeIdentifiedMsg('user', 'Question', 'message:idempotency:user-1', 1786147200000),
+      makeIdentifiedMsg('assistant', 'Task 10 audit is verified complete.', 'derived:unknown-session:assistant:1786147218006:abc', 1786147218006),
+    ];
+    const recovered = [
+      makeIdentifiedMsg('assistant', 'Task 10 audit is verified complete.', 'openclaw:mirror:019fdeaa-eb0d-7ed1-96dd-08243ee90d95:assistant', 1786147303367),
+    ];
+
+    const result = mergeRecoveredTail(existing, recovered);
+
+    expect(result).toHaveLength(2);
+    expect(result.map(m => m.rawText)).toEqual(['Question', 'Task 10 audit is verified complete.']);
+    expect(result[1].sourceId).toBe('openclaw:mirror:019fdeaa-eb0d-7ed1-96dd-08243ee90d95:assistant');
+    expect(result[1].msgId).toBe(existing[1].msgId);
+  });
+
+  it('preserves repeated assistant messages when both recovered rows are durable', () => {
+    const existing = [
+      makeIdentifiedMsg('assistant', 'Done.', 'openclaw:mirror:run-1:assistant', 1700000000000),
+    ];
+    const recovered = [
+      makeIdentifiedMsg('assistant', 'Done.', 'openclaw:mirror:run-1:assistant', 1700000000000),
+      makeIdentifiedMsg('assistant', 'Done.', 'openclaw:mirror:run-2:assistant', 1700000005000),
+    ];
+
+    const result = mergeRecoveredTail(existing, recovered);
+
+    expect(result.map(m => m.sourceId)).toEqual([
+      'openclaw:mirror:run-1:assistant',
+      'openclaw:mirror:run-2:assistant',
+    ]);
+  });
+
+  it('does not alias tool-group assistant-adjacent rich messages by matching text alone', () => {
+    const existing = [
+      makeIdentifiedMsg('assistant', 'Used tools', 'derived:unknown-session:assistant:1700000000000:abc', 1700000000000),
+    ];
+    existing[0].toolGroup = [{ html: 'Used tools', rawText: 'Used tools', preview: 'Used tools' }];
+    const recovered = [
+      makeIdentifiedMsg('assistant', 'Used tools', 'openclaw:mirror:run-1:assistant', 1700000100000),
+    ];
+    recovered[0].toolGroup = [{ html: 'Used tools', rawText: 'Used tools', preview: 'Used tools' }];
+
+    const result = mergeRecoveredTail(existing, recovered);
+
+    expect(result).toEqual(recovered);
   });
 });

--- a/src/features/chat/operations/mergeRecoveredTail.ts
+++ b/src/features/chat/operations/mergeRecoveredTail.ts
@@ -104,11 +104,14 @@ function mergeByIdentity(existing: ChatMsg[], recovered: ChatMsg[], anchor: { ex
     for (const sourceId of getMessageSourceIds(msg)) existingById.set(sourceId, msg);
   }
 
+  const claimed = new Set<ChatMsg>();
   const mergedRecovered = recovered.slice(anchor.recoveredIdx).map((msg) => {
     const sourceIds = getMessageSourceIds(msg);
-    const prior = sourceIds.map((sourceId) => existingById.get(sourceId)).find(Boolean);
-    const assistantFinalPrior = prior || existingTail.find((candidate) => isSameAssistantFinalDelivery(candidate, msg));
-    return assistantFinalPrior ? mergeMessageState(assistantFinalPrior, msg) : msg;
+    const prior = sourceIds.map((sourceId) => existingById.get(sourceId)).find((candidate) => candidate && !claimed.has(candidate));
+    const assistantFinalPrior = prior || existingTail.find((candidate) => !claimed.has(candidate) && isSameAssistantFinalDelivery(candidate, msg));
+    if (!assistantFinalPrior) return msg;
+    claimed.add(assistantFinalPrior);
+    return mergeMessageState(assistantFinalPrior, msg);
   });
 
   const represented = new Set(mergedRecovered.flatMap(getMessageSourceIds));

--- a/src/features/chat/operations/mergeRecoveredTail.ts
+++ b/src/features/chat/operations/mergeRecoveredTail.ts
@@ -1,4 +1,9 @@
 import type { ChatMsg } from '@/features/chat/types';
+import {
+  getMessageSourceIds,
+  isSameAssistantFinalDelivery,
+  mergeMessageState,
+} from './messageReconciliation';
 
 function hashString(input: string): number {
   let hash = 0;
@@ -61,6 +66,65 @@ function findTailAnchor(existingSigs: string[], recoveredSigs: string[]) {
   return null;
 }
 
+function findIdentityAnchor(existing: ChatMsg[], recovered: ChatMsg[]) {
+  const recoveredIds = new Map<string, number>();
+  recovered.forEach((msg, index) => {
+    for (const sourceId of getMessageSourceIds(msg)) recoveredIds.set(sourceId, index);
+  });
+  if (recoveredIds.size === 0) return null;
+
+  const tailStart = Math.max(0, existing.length - 240);
+  for (let existingIdx = existing.length - 1; existingIdx >= tailStart; existingIdx--) {
+    const sourceIds = getMessageSourceIds(existing[existingIdx]);
+    for (const sourceId of sourceIds) {
+      const recoveredIdx = recoveredIds.get(sourceId);
+      if (recoveredIdx !== undefined) return { existingIdx, recoveredIdx };
+    }
+  }
+  return null;
+}
+
+function findAssistantFinalDeliveryAnchor(existing: ChatMsg[], recovered: ChatMsg[]) {
+  const tailStart = Math.max(0, existing.length - 240);
+  for (let existingIdx = existing.length - 1; existingIdx >= tailStart; existingIdx--) {
+    for (let recoveredIdx = 0; recoveredIdx < recovered.length; recoveredIdx++) {
+      if (isSameAssistantFinalDelivery(existing[existingIdx], recovered[recoveredIdx])) {
+        return { existingIdx, recoveredIdx };
+      }
+    }
+  }
+  return null;
+}
+
+function mergeByIdentity(existing: ChatMsg[], recovered: ChatMsg[], anchor: { existingIdx: number; recoveredIdx: number }): ChatMsg[] {
+  const prefix = existing.slice(0, anchor.existingIdx);
+  const existingTail = existing.slice(anchor.existingIdx);
+  const existingById = new Map<string, ChatMsg>();
+  for (const msg of existingTail) {
+    for (const sourceId of getMessageSourceIds(msg)) existingById.set(sourceId, msg);
+  }
+
+  const mergedRecovered = recovered.slice(anchor.recoveredIdx).map((msg) => {
+    const sourceIds = getMessageSourceIds(msg);
+    const prior = sourceIds.map((sourceId) => existingById.get(sourceId)).find(Boolean);
+    const assistantFinalPrior = prior || existingTail.find((candidate) => isSameAssistantFinalDelivery(candidate, msg));
+    return assistantFinalPrior ? mergeMessageState(assistantFinalPrior, msg) : msg;
+  });
+
+  const represented = new Set(mergedRecovered.flatMap(getMessageSourceIds));
+  const newestRecoveredTs = Math.max(...recovered.map((msg) => msg.timestamp.getTime()).filter(Number.isFinite));
+  const preserveNewer = existing
+    .slice(anchor.existingIdx + 1)
+    .filter((msg) => {
+      if (getMessageSourceIds(msg).some((sourceId) => represented.has(sourceId))) return false;
+      if (mergedRecovered.some((candidate) => isSameAssistantFinalDelivery(msg, candidate))) return false;
+      if (msg.pending || msg.failed || msg.streaming) return true;
+      return Number.isFinite(newestRecoveredTs) && msg.timestamp.getTime() > newestRecoveredTs;
+    });
+
+  return [...prefix, ...mergedRecovered, ...preserveNewer];
+}
+
 /**
  * Merge a recovered history tail into the current transcript without replacing
  * unaffected prefix messages.
@@ -68,6 +132,16 @@ function findTailAnchor(existingSigs: string[], recoveredSigs: string[]) {
 export function mergeRecoveredTail(existing: ChatMsg[], recovered: ChatMsg[]): ChatMsg[] {
   if (recovered.length === 0) return existing;
   if (existing.length === 0) return recovered;
+
+  const identityAnchor = findIdentityAnchor(existing, recovered);
+  if (identityAnchor) {
+    return mergeByIdentity(existing, recovered, identityAnchor);
+  }
+
+  const assistantFinalDeliveryAnchor = findAssistantFinalDeliveryAnchor(existing, recovered);
+  if (assistantFinalDeliveryAnchor) {
+    return mergeByIdentity(existing, recovered, assistantFinalDeliveryAnchor);
+  }
 
   const existingSigs = existing.map(messageSignature);
   const recoveredSigs = recovered.map(messageSignature);

--- a/src/features/chat/operations/messageReconciliation.ts
+++ b/src/features/chat/operations/messageReconciliation.ts
@@ -20,11 +20,17 @@ export function isSameMessageIdentity(a: ChatMsg, b: ChatMsg): boolean {
 }
 
 export function mergeMessageState(existing: ChatMsg, incoming: ChatMsg): ChatMsg {
+  const alternateSourceIds = [...new Set([
+    ...(existing.alternateSourceIds || []),
+    ...(incoming.alternateSourceIds || []),
+    ...(existing.sourceId && existing.sourceId !== incoming.sourceId ? [existing.sourceId] : []),
+  ])];
+
   return {
     ...incoming,
     msgId: existing.msgId || incoming.msgId || generateMsgId(),
     sourceId: incoming.sourceId || existing.sourceId,
-    alternateSourceIds: incoming.alternateSourceIds || existing.alternateSourceIds,
+    ...(alternateSourceIds.length > 0 ? { alternateSourceIds } : {}),
     collapsed: existing.collapsed ?? incoming.collapsed,
     pending: incoming.pending ?? false,
     failed: incoming.failed ?? false,
@@ -32,11 +38,11 @@ export function mergeMessageState(existing: ChatMsg, incoming: ChatMsg): ChatMsg
   };
 }
 
-export function normalizeComparableText(text: string): string {
-  return text.trim().replace(/\s+/g, ' ');
+export function normalizeComparableText(text: string | undefined): string {
+  return (text || '').trim().replace(/\s+/g, ' ');
 }
 
-function hasOpenClawDurableIdentity(msg: ChatMsg): boolean {
+export function hasOpenClawDurableIdentity(msg: ChatMsg): boolean {
   return getMessageSourceIds(msg).some((id) => id.startsWith('openclaw:mirror:') || id.startsWith('openclaw:id:'));
 }
 

--- a/src/features/chat/operations/messageReconciliation.ts
+++ b/src/features/chat/operations/messageReconciliation.ts
@@ -1,0 +1,71 @@
+import { generateMsgId } from '@/features/chat/types';
+import type { ChatMsg } from '@/features/chat/types';
+
+function isString(value: string | undefined): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+export function getMessageSourceIds(msg: ChatMsg): string[] {
+  return [msg.sourceId, ...(msg.alternateSourceIds || [])].filter(isString);
+}
+
+export function isSameMessageIdentity(a: ChatMsg, b: ChatMsg): boolean {
+  const aIds = getMessageSourceIds(a);
+  const bIds = getMessageSourceIds(b);
+  if (aIds.length > 0 && bIds.length > 0) {
+    return aIds.some((id) => bIds.includes(id));
+  }
+  if (a.tempId && b.tempId) return a.tempId === b.tempId;
+  return false;
+}
+
+export function mergeMessageState(existing: ChatMsg, incoming: ChatMsg): ChatMsg {
+  return {
+    ...incoming,
+    msgId: existing.msgId || incoming.msgId || generateMsgId(),
+    sourceId: incoming.sourceId || existing.sourceId,
+    alternateSourceIds: incoming.alternateSourceIds || existing.alternateSourceIds,
+    collapsed: existing.collapsed ?? incoming.collapsed,
+    pending: incoming.pending ?? false,
+    failed: incoming.failed ?? false,
+    tempId: existing.tempId,
+  };
+}
+
+export function normalizeComparableText(text: string): string {
+  return text.trim().replace(/\s+/g, ' ');
+}
+
+function hasOpenClawDurableIdentity(msg: ChatMsg): boolean {
+  return getMessageSourceIds(msg).some((id) => id.startsWith('openclaw:mirror:') || id.startsWith('openclaw:id:'));
+}
+
+function hasRichAssistantPayload(msg: ChatMsg): boolean {
+  return Boolean(
+    msg.isThinking ||
+    msg.intermediate ||
+    msg.toolGroup?.length ||
+    msg.images?.length ||
+    msg.extractedImages?.length ||
+    msg.charts?.length ||
+    msg.uploadAttachments?.length ||
+    msg.isSystemNotification
+  );
+}
+
+export function isSameAssistantFinalDelivery(a: ChatMsg, b: ChatMsg): boolean {
+  if (a.role !== 'assistant' || b.role !== 'assistant') return false;
+  if (a.streaming || b.streaming || a.pending || b.pending || a.failed || b.failed) return false;
+  if (hasRichAssistantPayload(a) || hasRichAssistantPayload(b)) return false;
+
+  const aHasOpenClawIdentity = hasOpenClawDurableIdentity(a);
+  const bHasOpenClawIdentity = hasOpenClawDurableIdentity(b);
+  if (aHasOpenClawIdentity === bHasOpenClawIdentity) return false;
+
+  const aText = normalizeComparableText(a.rawText);
+  const bText = normalizeComparableText(b.rawText);
+  if (!aText || aText !== bText) return false;
+
+  const timeDiffMs = Math.abs(a.timestamp.getTime() - b.timestamp.getTime());
+  return Number.isFinite(timeDiffMs) && timeDiffMs <= 180_000;
+}

--- a/src/features/chat/operations/sendMessage.test.ts
+++ b/src/features/chat/operations/sendMessage.test.ts
@@ -194,6 +194,11 @@ describe('buildUserMessage', () => {
     const { msg } = buildUserMessage({ text: 'test' });
     expect(msg.msgId).toBeTruthy();
   });
+
+  it('attaches the idempotency source identity when provided', () => {
+    const { msg } = buildUserMessage({ text: 'test', idempotencyKey: 'key-1' });
+    expect(msg.sourceId).toBe('message:idempotency:key-1');
+  });
 });
 
 describe('sendChatMessage', () => {

--- a/src/features/chat/operations/sendMessage.ts
+++ b/src/features/chat/operations/sendMessage.ts
@@ -76,12 +76,14 @@ export function buildUserMessage(params: {
   text: string;
   images?: ImageAttachment[];
   uploadPayload?: OutgoingUploadPayload;
+  idempotencyKey?: string;
 }): { msg: ChatMsg; tempId: string } {
-  const { text, images, uploadPayload } = params;
+  const { text, images, uploadPayload, idempotencyKey } = params;
   const tempId = crypto.randomUUID ? crypto.randomUUID() : 'temp-' + Date.now();
 
   const msg: ChatMsg = {
     msgId: generateMsgId(),
+    sourceId: idempotencyKey ? `message:idempotency:${idempotencyKey}` : undefined,
     role: 'user',
     html: renderToolResults(renderMarkdown(text)),
     rawText: text,

--- a/src/features/chat/types.ts
+++ b/src/features/chat/types.ts
@@ -104,9 +104,26 @@ export function generateMsgId(): string {
   return `m-${Date.now()}-${++_msgIdCounter}`;
 }
 
+function hashString(input: string): string {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) - hash + input.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+}
+
+/** Deterministic UI-safe id for messages whose durable gateway identity is known. */
+export function stableMsgId(identity: string): string {
+  return `msg:${hashString(identity)}:${identity.replace(/[^a-zA-Z0-9:_-]/g, '_').slice(0, 80)}`;
+}
+
 export interface ChatMsg {
   /** Stable unique ID for React keying — assigned once at creation, never changes. */
   msgId?: string;
+  /** Durable identity from OpenClaw/history/live events, used for reconciliation. */
+  sourceId?: string;
+  /** Additional durable aliases, such as send idempotency keys, that may confirm optimistic UI rows. */
+  alternateSourceIds?: string[];
   role: ChatMsgRole;
   html: string;
   rawText: string;

--- a/src/hooks/useChatMessages.test.ts
+++ b/src/hooks/useChatMessages.test.ts
@@ -1,0 +1,116 @@
+/** Tests for chat message reconciliation helpers. */
+import { describe, expect, it } from 'vitest';
+import { mergeFinalMessages, mergeHistoryMessages } from './useChatMessages';
+import type { ChatMsg } from '@/features/chat/types';
+
+function msg(role: ChatMsg['role'], rawText: string, sourceId: string, pending = false): ChatMsg {
+  return {
+    msgId: `ui-${sourceId}`,
+    sourceId,
+    role,
+    html: rawText,
+    rawText,
+    timestamp: new Date(1700000000000),
+    pending,
+    tempId: pending ? `temp-${sourceId}` : undefined,
+  };
+}
+
+function openclawAssistant(rawText: string, sourceId: string, ts = 1700000000000): ChatMsg {
+  return {
+    ...msg('assistant', rawText, sourceId),
+    timestamp: new Date(ts),
+  };
+}
+
+describe('chat message reconciliation', () => {
+  it('dedupes live final messages by stable identity', () => {
+    const existing = [msg('assistant', 'Streaming text', 'assistant-1')];
+    const incoming = [msg('assistant', 'Final text', 'assistant-1')];
+
+    const result = mergeFinalMessages(existing, incoming);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].rawText).toBe('Final text');
+    expect(result[0].msgId).toBe('ui-assistant-1');
+  });
+
+  it('replaces a pending optimistic user message when history confirms the same idempotency key', () => {
+    const existing = [msg('user', 'hello', 'message:idempotency:ik-1', true)];
+    const history = [msg('user', 'hello', 'message:idempotency:ik-1')];
+
+    const result = mergeHistoryMessages(existing, history);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].pending).toBe(false);
+    expect(result[0].tempId).toBe('temp-message:idempotency:ik-1');
+  });
+
+  it('matches optimistic user messages against history aliases when OpenClaw wrapper ids are primary', () => {
+    const existing = [msg('user', 'hello', 'message:idempotency:ik-1', true)];
+    const history = [{
+      ...msg('user', 'hello', 'openclaw:id:wrapper-1'),
+      alternateSourceIds: ['message:idempotency:ik-1'],
+    }];
+
+    const result = mergeHistoryMessages(existing, history);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].sourceId).toBe('openclaw:id:wrapper-1');
+    expect(result[0].pending).toBe(false);
+  });
+
+  it('preserves pending optimistic messages absent from an authoritative refresh', () => {
+    const existing = [
+      msg('assistant', 'old', 'assistant-1'),
+      msg('user', 'still sending', 'message:idempotency:ik-2', true),
+    ];
+    const history = [msg('assistant', 'old', 'assistant-1')];
+
+    const result = mergeHistoryMessages(existing, history);
+
+    expect(result.map(m => m.rawText)).toEqual(['old', 'still sending']);
+    expect(result[1].pending).toBe(true);
+  });
+
+  it('aliases a local streamed assistant final to the later durable OpenClaw history identity', () => {
+    const existing = [
+      openclawAssistant('Task 10 audit is verified complete.', 'derived:unknown-session:assistant:1786147218006:abc', 1786147218006),
+    ];
+    const history = [
+      openclawAssistant('Task 10 audit is verified complete.', 'openclaw:mirror:019fdeaa-eb0d-7ed1-96dd-08243ee90d95:assistant', 1786147303367),
+    ];
+
+    const result = mergeHistoryMessages(existing, history);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].sourceId).toBe('openclaw:mirror:019fdeaa-eb0d-7ed1-96dd-08243ee90d95:assistant');
+    expect(result[0].msgId).toBe(existing[0].msgId);
+  });
+
+  it('preserves legitimate repeated assistant finals that both have durable OpenClaw identities', () => {
+    const first = openclawAssistant('Done.', 'openclaw:mirror:run-1:assistant', 1700000000000);
+    const second = openclawAssistant('Done.', 'openclaw:mirror:run-2:assistant', 1700000005000);
+
+    const result = mergeFinalMessages([first], [second]);
+
+    expect(result.map(m => m.sourceId)).toEqual([
+      'openclaw:mirror:run-1:assistant',
+      'openclaw:mirror:run-2:assistant',
+    ]);
+  });
+
+  it('does not alias rich assistant messages with images by matching text alone', () => {
+    const local = openclawAssistant('Here is the image.', 'derived:unknown-session:assistant:1700000000000:abc', 1700000000000);
+    const durable = {
+      ...openclawAssistant('Here is the image.', 'openclaw:mirror:run-1:assistant', 1700000005000),
+      extractedImages: [{ url: '/api/files?path=image.png', alt: 'image.png' }],
+    };
+
+    const result = mergeHistoryMessages([local], [durable]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].sourceId).toBe('openclaw:mirror:run-1:assistant');
+    expect(result[0].msgId).not.toBe(local.msgId);
+  });
+});

--- a/src/hooks/useChatMessages.test.ts
+++ b/src/hooks/useChatMessages.test.ts
@@ -100,6 +100,47 @@ describe('chat message reconciliation', () => {
     ]);
   });
 
+  it('preserves a repeated current-turn assistant final instead of aliasing an earlier durable turn', () => {
+    const priorUser = msg('user', 'First request', 'message:idempotency:ik-1');
+    const priorDone = openclawAssistant('Done.', 'openclaw:mirror:run-1:assistant', 1700000000000);
+    const currentUser = msg('user', 'Second request', 'message:idempotency:ik-2');
+    const currentDone = openclawAssistant('Done.', 'derived:unknown-session:assistant:1700000005000:abc', 1700000005000);
+
+    const result = mergeFinalMessages([priorUser, priorDone, currentUser], [currentDone]);
+
+    expect(result.map(m => m.sourceId)).toEqual([
+      'message:idempotency:ik-1',
+      'openclaw:mirror:run-1:assistant',
+      'message:idempotency:ik-2',
+      'derived:unknown-session:assistant:1700000005000:abc',
+    ]);
+  });
+
+  it('matches a repeated current-turn assistant final only after the latest user during history refresh', () => {
+    const existing = [
+      msg('user', 'First request', 'message:idempotency:ik-1'),
+      openclawAssistant('Done.', 'openclaw:mirror:run-1:assistant', 1700000000000),
+      msg('user', 'Second request', 'message:idempotency:ik-2'),
+      openclawAssistant('Done.', 'derived:unknown-session:assistant:1700000005000:abc', 1700000005000),
+    ];
+    const history = [
+      msg('user', 'First request', 'message:idempotency:ik-1'),
+      openclawAssistant('Done.', 'openclaw:mirror:run-1:assistant', 1700000000000),
+      msg('user', 'Second request', 'message:idempotency:ik-2'),
+      openclawAssistant('Done.', 'openclaw:mirror:run-2:assistant', 1700000006000),
+    ];
+
+    const result = mergeHistoryMessages(existing, history);
+
+    expect(result.map(m => m.sourceId)).toEqual([
+      'message:idempotency:ik-1',
+      'openclaw:mirror:run-1:assistant',
+      'message:idempotency:ik-2',
+      'openclaw:mirror:run-2:assistant',
+    ]);
+    expect(result[3].msgId).toBe(existing[3].msgId);
+  });
+
   it('does not alias rich assistant messages with images by matching text alone', () => {
     const local = openclawAssistant('Here is the image.', 'derived:unknown-session:assistant:1700000000000:abc', 1700000000000);
     const durable = {

--- a/src/hooks/useChatMessages.test.ts
+++ b/src/hooks/useChatMessages.test.ts
@@ -1,6 +1,6 @@
 /** Tests for chat message reconciliation helpers. */
 import { describe, expect, it } from 'vitest';
-import { mergeFinalMessages, mergeHistoryMessages } from './useChatMessages';
+import { isLikelyDuplicateMessage, mergeFinalMessages, mergeHistoryMessages } from './useChatMessages';
 import type { ChatMsg } from '@/features/chat/types';
 
 function msg(role: ChatMsg['role'], rawText: string, sourceId: string, pending = false): ChatMsg {
@@ -60,6 +60,25 @@ describe('chat message reconciliation', () => {
     expect(result[0].pending).toBe(false);
   });
 
+  it('preserves existing aliases when history confirms a row with new aliases', () => {
+    const existing = [{
+      ...msg('user', 'hello', 'openclaw:mirror:local-user', true),
+      alternateSourceIds: ['message:idempotency:ik-1'],
+    }];
+    const history = [{
+      ...msg('user', 'hello', 'openclaw:id:wrapper-1'),
+      alternateSourceIds: ['openclaw:mirror:local-user'],
+    }];
+
+    const result = mergeHistoryMessages(existing, history);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].alternateSourceIds).toEqual([
+      'message:idempotency:ik-1',
+      'openclaw:mirror:local-user',
+    ]);
+  });
+
   it('preserves pending optimistic messages absent from an authoritative refresh', () => {
     const existing = [
       msg('assistant', 'old', 'assistant-1'),
@@ -71,6 +90,18 @@ describe('chat message reconciliation', () => {
 
     expect(result.map(m => m.rawText)).toEqual(['old', 'still sending']);
     expect(result[1].pending).toBe(true);
+  });
+
+  it('preserves streaming assistant messages when an authoritative refresh is empty', () => {
+    const existing = [{
+      ...msg('assistant', 'still streaming', 'derived:assistant-stream'),
+      streaming: true,
+    }];
+
+    const result = mergeHistoryMessages(existing, []);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].streaming).toBe(true);
   });
 
   it('aliases a local streamed assistant final to the later durable OpenClaw history identity', () => {
@@ -98,6 +129,13 @@ describe('chat message reconciliation', () => {
       'openclaw:mirror:run-1:assistant',
       'openclaw:mirror:run-2:assistant',
     ]);
+  });
+
+  it('dedupes live-only assistant messages with identical text inside the legacy window', () => {
+    const first = openclawAssistant('Working on it.', 'derived:assistant:1', 1700000000000);
+    const second = openclawAssistant('Working on it.', 'derived:assistant:2', 1700000005000);
+
+    expect(isLikelyDuplicateMessage(first, second)).toBe(true);
   });
 
   it('preserves a repeated current-turn assistant final instead of aliasing an earlier durable turn', () => {
@@ -139,6 +177,25 @@ describe('chat message reconciliation', () => {
       'openclaw:mirror:run-2:assistant',
     ]);
     expect(result[3].msgId).toBe(existing[3].msgId);
+  });
+
+  it('does not match one existing assistant final to multiple history rows', () => {
+    const existing = [
+      msg('user', 'Question', 'message:idempotency:ik-1'),
+      openclawAssistant('Done.', 'derived:unknown-session:assistant:1700000000000:abc', 1700000000000),
+    ];
+    const history = [
+      msg('user', 'Question', 'message:idempotency:ik-1'),
+      openclawAssistant('Done.', 'openclaw:mirror:run-1:assistant', 1700000000000),
+      openclawAssistant('Done.', 'openclaw:mirror:run-2:assistant', 1700000005000),
+    ];
+
+    const result = mergeHistoryMessages(existing, history);
+
+    expect(result).toHaveLength(3);
+    expect(new Set(result.map(m => m.msgId)).size).toBe(3);
+    expect(result[1].msgId).toBe(existing[1].msgId);
+    expect(result[2].sourceId).toBe('openclaw:mirror:run-2:assistant');
   });
 
   it('does not alias rich assistant messages with images by matching text alone', () => {

--- a/src/hooks/useChatMessages.ts
+++ b/src/hooks/useChatMessages.ts
@@ -7,6 +7,12 @@
 import { useState, useRef, useCallback, useMemo } from 'react';
 import { loadChatHistory } from '@/features/chat/operations';
 import { generateMsgId } from '@/features/chat/types';
+import {
+  isSameAssistantFinalDelivery,
+  isSameMessageIdentity,
+  mergeMessageState,
+  normalizeComparableText,
+} from '@/features/chat/operations/messageReconciliation';
 import type { ChatMsg } from '@/features/chat/types';
 
 // ─── Constants ──────────────────────────────────────────────────────────────────
@@ -16,11 +22,12 @@ const LOAD_MORE_BATCH = 30;
 
 // ─── Pure helpers (exported for testing / reuse) ────────────────────────────────
 
-export function normalizeComparableText(text: string): string {
-  return text.trim().replace(/\s+/g, ' ');
-}
-
 export function isLikelyDuplicateMessage(a: ChatMsg, b: ChatMsg): boolean {
+  if (a.sourceId && b.sourceId && a.sourceId === b.sourceId) return true;
+  if (a.role === 'assistant' || b.role === 'assistant') {
+    return isSameAssistantFinalDelivery(a, b);
+  }
+
   // Require timestamps within 60s to avoid suppressing legitimately repeated messages.
   const timeDiffMs = Math.abs(a.timestamp.getTime() - b.timestamp.getTime());
   if (timeDiffMs > 60_000) return false;
@@ -44,10 +51,18 @@ export function mergeFinalMessages(existing: ChatMsg[], incoming: ChatMsg[]): Ch
   const merged = [...existing];
 
   for (const msg of incoming) {
+    const identityIdx = msg.sourceId
+      ? merged.findIndex((candidate) => isSameMessageIdentity(candidate, msg) || isSameAssistantFinalDelivery(candidate, msg))
+      : merged.findIndex((candidate) => isSameAssistantFinalDelivery(candidate, msg));
+    if (identityIdx >= 0) {
+      merged[identityIdx] = mergeMessageState(merged[identityIdx], msg);
+      continue;
+    }
+
     const last = merged[merged.length - 1];
 
     if (last && isLikelyDuplicateMessage(last, msg)) {
-      merged[merged.length - 1] = msg;
+      merged[merged.length - 1] = mergeMessageState(last, msg);
       continue;
     }
 
@@ -67,6 +82,29 @@ export function mergeFinalMessages(existing: ChatMsg[], incoming: ChatMsg[]): Ch
     }
 
     merged.push(msg.msgId ? msg : { ...msg, msgId: generateMsgId() });
+  }
+
+  return merged;
+}
+
+export function mergeHistoryMessages(existing: ChatMsg[], history: ChatMsg[]): ChatMsg[] {
+  if (history.length === 0) {
+    const pending = existing.filter((msg) => msg.pending || msg.failed);
+    return pending.length > 0 ? pending : history;
+  }
+  if (existing.length === 0) return history;
+
+  const merged = history.map((historyMsg) => {
+    const existingMatch = historyMsg.sourceId
+      ? existing.find((candidate) => isSameMessageIdentity(candidate, historyMsg) || isSameAssistantFinalDelivery(candidate, historyMsg))
+      : undefined;
+    return existingMatch ? mergeMessageState(existingMatch, historyMsg) : historyMsg;
+  });
+
+  for (const existingMsg of existing) {
+    if (!existingMsg.pending && !existingMsg.failed && !existingMsg.streaming) continue;
+    const alreadyRepresented = merged.some((candidate) => isSameMessageIdentity(candidate, existingMsg));
+    if (!alreadyRepresented) merged.push(existingMsg);
   }
 
   return merged;
@@ -129,7 +167,7 @@ export function useChatMessages({ rpc, currentSessionRef }: UseChatMessagesDeps)
     const sk = session || currentSessionRef.current;
     try {
       const result = await loadChatHistory({ rpc, sessionKey: sk, limit: 500 });
-      applyMessageWindow(result, true);
+      applyMessageWindow(mergeHistoryMessages(allMessagesRef.current, result), true);
     } catch (e) {
       const errMsg = e instanceof Error ? e.message : String(e);
       allMessagesRef.current = [];

--- a/src/hooks/useChatMessages.ts
+++ b/src/hooks/useChatMessages.ts
@@ -46,14 +46,33 @@ export function isLikelyDuplicateMessage(a: ChatMsg, b: ChatMsg): boolean {
   );
 }
 
+function latestUserIndex(messages: ChatMsg[]): number {
+  return messages.reduce((latest, msg, index) => (msg.role === 'user' ? index : latest), -1);
+}
+
+function findExactIdentityIndex(messages: ChatMsg[], msg: ChatMsg): number {
+  return msg.sourceId
+    ? messages.findIndex((candidate) => isSameMessageIdentity(candidate, msg))
+    : -1;
+}
+
+function findCurrentTurnAssistantFinalIndex(messages: ChatMsg[], msg: ChatMsg, latestUser: number): number {
+  if (msg.role !== 'assistant') return -1;
+  return messages.findIndex((candidate, index) =>
+    index > latestUser && isSameAssistantFinalDelivery(candidate, msg)
+  );
+}
+
 export function mergeFinalMessages(existing: ChatMsg[], incoming: ChatMsg[]): ChatMsg[] {
   if (incoming.length === 0) return existing;
   const merged = [...existing];
 
   for (const msg of incoming) {
-    const identityIdx = msg.sourceId
-      ? merged.findIndex((candidate) => isSameMessageIdentity(candidate, msg) || isSameAssistantFinalDelivery(candidate, msg))
-      : merged.findIndex((candidate) => isSameAssistantFinalDelivery(candidate, msg));
+    const latestUser = latestUserIndex(merged);
+    const exactIdentityIdx = findExactIdentityIndex(merged, msg);
+    const identityIdx = exactIdentityIdx >= 0
+      ? exactIdentityIdx
+      : findCurrentTurnAssistantFinalIndex(merged, msg, latestUser);
     if (identityIdx >= 0) {
       merged[identityIdx] = mergeMessageState(merged[identityIdx], msg);
       continue;
@@ -94,10 +113,16 @@ export function mergeHistoryMessages(existing: ChatMsg[], history: ChatMsg[]): C
   }
   if (existing.length === 0) return history;
 
-  const merged = history.map((historyMsg) => {
-    const existingMatch = historyMsg.sourceId
-      ? existing.find((candidate) => isSameMessageIdentity(candidate, historyMsg) || isSameAssistantFinalDelivery(candidate, historyMsg))
-      : undefined;
+  const latestExistingUser = latestUserIndex(existing);
+  const latestHistoryUser = latestUserIndex(history);
+
+  const merged = history.map((historyMsg, historyIndex) => {
+    const exactIdentityIdx = findExactIdentityIndex(existing, historyMsg);
+    const assistantFinalIdx = historyIndex > latestHistoryUser
+      ? findCurrentTurnAssistantFinalIndex(existing, historyMsg, latestExistingUser)
+      : -1;
+    const matchIdx = exactIdentityIdx >= 0 ? exactIdentityIdx : assistantFinalIdx;
+    const existingMatch = matchIdx >= 0 ? existing[matchIdx] : undefined;
     return existingMatch ? mergeMessageState(existingMatch, historyMsg) : historyMsg;
   });
 

--- a/src/hooks/useChatMessages.ts
+++ b/src/hooks/useChatMessages.ts
@@ -10,6 +10,7 @@ import { generateMsgId } from '@/features/chat/types';
 import {
   isSameAssistantFinalDelivery,
   isSameMessageIdentity,
+  hasOpenClawDurableIdentity,
   mergeMessageState,
   normalizeComparableText,
 } from '@/features/chat/operations/messageReconciliation';
@@ -24,9 +25,8 @@ const LOAD_MORE_BATCH = 30;
 
 export function isLikelyDuplicateMessage(a: ChatMsg, b: ChatMsg): boolean {
   if (a.sourceId && b.sourceId && a.sourceId === b.sourceId) return true;
-  if (a.role === 'assistant' || b.role === 'assistant') {
-    return isSameAssistantFinalDelivery(a, b);
-  }
+  if (isSameAssistantFinalDelivery(a, b)) return true;
+  if (hasOpenClawDurableIdentity(a) || hasOpenClawDurableIdentity(b)) return false;
 
   // Require timestamps within 60s to avoid suppressing legitimately repeated messages.
   const timeDiffMs = Math.abs(a.timestamp.getTime() - b.timestamp.getTime());
@@ -50,16 +50,16 @@ function latestUserIndex(messages: ChatMsg[]): number {
   return messages.reduce((latest, msg, index) => (msg.role === 'user' ? index : latest), -1);
 }
 
-function findExactIdentityIndex(messages: ChatMsg[], msg: ChatMsg): number {
+function findExactIdentityIndex(messages: ChatMsg[], msg: ChatMsg, claimed = new Set<number>()): number {
   return msg.sourceId
-    ? messages.findIndex((candidate) => isSameMessageIdentity(candidate, msg))
+    ? messages.findIndex((candidate, index) => !claimed.has(index) && isSameMessageIdentity(candidate, msg))
     : -1;
 }
 
-function findCurrentTurnAssistantFinalIndex(messages: ChatMsg[], msg: ChatMsg, latestUser: number): number {
+function findCurrentTurnAssistantFinalIndex(messages: ChatMsg[], msg: ChatMsg, latestUser: number, claimed = new Set<number>()): number {
   if (msg.role !== 'assistant') return -1;
   return messages.findIndex((candidate, index) =>
-    index > latestUser && isSameAssistantFinalDelivery(candidate, msg)
+    !claimed.has(index) && index > latestUser && isSameAssistantFinalDelivery(candidate, msg)
   );
 }
 
@@ -108,20 +108,22 @@ export function mergeFinalMessages(existing: ChatMsg[], incoming: ChatMsg[]): Ch
 
 export function mergeHistoryMessages(existing: ChatMsg[], history: ChatMsg[]): ChatMsg[] {
   if (history.length === 0) {
-    const pending = existing.filter((msg) => msg.pending || msg.failed);
-    return pending.length > 0 ? pending : history;
+    const inFlight = existing.filter((msg) => msg.pending || msg.failed || msg.streaming);
+    return inFlight.length > 0 ? inFlight : history;
   }
   if (existing.length === 0) return history;
 
   const latestExistingUser = latestUserIndex(existing);
   const latestHistoryUser = latestUserIndex(history);
+  const claimedExisting = new Set<number>();
 
   const merged = history.map((historyMsg, historyIndex) => {
-    const exactIdentityIdx = findExactIdentityIndex(existing, historyMsg);
+    const exactIdentityIdx = findExactIdentityIndex(existing, historyMsg, claimedExisting);
     const assistantFinalIdx = historyIndex > latestHistoryUser
-      ? findCurrentTurnAssistantFinalIndex(existing, historyMsg, latestExistingUser)
+      ? findCurrentTurnAssistantFinalIndex(existing, historyMsg, latestExistingUser, claimedExisting)
       : -1;
     const matchIdx = exactIdentityIdx >= 0 ? exactIdentityIdx : assistantFinalIdx;
+    if (matchIdx >= 0) claimedExisting.add(matchIdx);
     const existingMatch = matchIdx >= 0 ? existing[matchIdx] : undefined;
     return existingMatch ? mergeMessageState(existingMatch, historyMsg) : historyMsg;
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,12 +118,26 @@ export type ContentBlockType = 'text' | 'tool_use' | 'toolCall' | 'tool_result' 
 
 /** A single chat message (user, assistant, tool, or system). */
 export interface ChatMessage {
+  id?: string;
+  messageId?: string;
+  message_id?: string;
   role: ChatMessageRole;
   content: string | ContentBlock[];
   text?: string;
   timestamp?: string | number;
   createdAt?: string | number;
   ts?: string | number;
+  seq?: number;
+  idempotencyKey?: string;
+  toolCallId?: string;
+  toolName?: string;
+  __openclaw?: {
+    id?: string;
+    mirrorIdentity?: string;
+    recordTimestampMs?: number;
+    seq?: number;
+    kind?: string;
+  };
   MediaPath?: string;
   MediaPaths?: string[];
   MediaType?: string;


### PR DESCRIPTION
In Plain English

Sometimes a completed assistant answer could appear twice after Nerve reconciled live chat with recovered history. This keeps the real durable history row, aliases the matching live final to it, and preserves legitimate repeated answers plus rich/tool/image messages.

## What

Fixes duplicate assistant-final delivery during chat history recovery/reconciliation.

## Why

A live assistant final can initially render with a local derived identity, then recovered history can return the same completed answer with a durable OpenClaw identity. Without aliasing those two forms, the same final answer can remain visible twice. Closes #376.

## How

- Adds shared chat message reconciliation helpers for source ids, final-message aliasing, and state merging.
- Carries durable message identities and aliases from history rows into `ChatMsg` objects.
- Merges live/recovered assistant finals only when one side has a durable OpenClaw identity, the plain assistant text matches, timestamps are close, and neither side is streaming, pending, failed, thinking, tool-rich, chart, upload, or image-bearing.
- Adds focused regression coverage for the duplicate-final path and preservation cases for repeated durable finals, tool groups, images, optimistic user rows, and stale recovery tails.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactor / chore (no functional change)

## Checklist

- [x] `npm run lint` passes
- [x] `npm run build && npm run build:server` succeeds
- [x] `npm test -- --run` passes
- [x] New features include tests
- [ ] UI changes include a screenshot or screen recording

## Validation

- Pre-fix proof on unpatched `upstream/master` (`312e273`): `src/features/chat/operations/messageReconciliation.ts` and `src/hooks/useChatMessages.test.ts` were absent, and existing chat tests had no Cookie-style local-to-durable assistant-final aliasing coverage. Running `npm test -- --run src/features/chat/operations/mergeRecoveredTail.test.ts src/hooks/useChatMessages.test.ts` only discovered the old `mergeRecoveredTail` suite (7 tests), proving the focused regression coverage was absent before the patch.
- `npm test -- --run src/hooks/useChatMessages.test.ts src/features/chat/operations/mergeRecoveredTail.test.ts src/features/chat/operations/loadHistory.test.ts src/features/chat/operations/streamEventHandler.test.ts` passed: 4 files, 105 tests.
- `npm run lint` passed.
- `npm run build && npm run build:server` passed with existing Vite dynamic-import/chunk-size warnings.
- `npm test -- --run` passed: 143 files, 1882 tests.

## Screenshots

Not applicable; this is chat reconciliation logic with regression tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat history reconciliation to prevent duplicate messages.
  * Preserved pending, failed, and streaming messages when refreshed history arrives.
  * Improved matching of locally created messages with their saved counterparts.
  * Prevented incorrect merging of repeated assistant responses and rich-content messages.

* **Reliability**
  * Added stable message identities for consistent recovery, updates, and deduplication.
  * Improved optimistic message handling so locally sent messages transition smoothly to confirmed responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->