### PR TITLE
feat(tts): secure service auth and return Edge word timings

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -35,7 +35,7 @@ startFileWatcher();
 
 const httpServer = serve(
   {
-    fetch: app.fetch,
+    fetch: (request, env) => app.fetch(request, env),
     port: config.port,
     hostname: config.host,
   },

--- a/server/lib/config.ts
+++ b/server/lib/config.ts
@@ -107,6 +107,7 @@ export const config = {
 
   // Authentication
   auth: (process.env.NERVE_AUTH || 'false').toLowerCase() === 'true',
+  serviceToken: process.env.NERVE_SERVICE_TOKEN || '',
   passwordHash: process.env.NERVE_PASSWORD_HASH || '',
   sessionSecret: process.env.NERVE_SESSION_SECRET || '',
   sessionTtlMs: Number(process.env.NERVE_SESSION_TTL || 30 * 24 * 60 * 60 * 1000), // 30 days

--- a/server/middleware/auth.test.ts
+++ b/server/middleware/auth.test.ts
@@ -8,6 +8,7 @@ vi.mock('../lib/config.js', () => {
     config: {
       auth: false,
       sessionSecret: 'test-secret-123',
+      serviceToken: '',
     },
     SESSION_COOKIE_NAME: 'nerve_session_3080',
   };
@@ -23,13 +24,14 @@ import { authMiddleware } from './auth.js';
 import { config } from '../lib/config.js';
 import { verifySession } from '../lib/session.js';
 
-const mockedConfig = config as { auth: boolean; sessionSecret: string };
+const mockedConfig = config as { auth: boolean; sessionSecret: string; serviceToken: string };
 const mockedVerifySession = verifySession as ReturnType<typeof vi.fn>;
 
 function createTestApp(): Hono {
   const app = new Hono();
   app.use('*', authMiddleware);
   app.get('/api/test', (c) => c.json({ ok: true }));
+  app.post('/api/tts', (c) => c.json({ ok: true }));
   app.get('/api/auth/login', (c) => c.json({ login: true }));
   app.get('/api/auth/logout', (c) => c.json({ logout: true }));
   app.get('/api/auth/status', (c) => c.json({ status: true }));
@@ -44,6 +46,7 @@ function createTestApp(): Hono {
 describe('authMiddleware', () => {
   beforeEach(() => {
     mockedConfig.auth = false;
+    mockedConfig.serviceToken = '';
     mockedVerifySession.mockReset();
   });
 
@@ -95,6 +98,46 @@ describe('authMiddleware', () => {
       });
       expect(res.status).toBe(200);
       expect(await res.json()).toEqual({ ok: true });
+    });
+
+    it('authenticates service-token TTS without a browser session', async () => {
+      mockedConfig.serviceToken = 'tok-123';
+      const app = createTestApp();
+      const res = await app.request('/api/tts', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer tok-123' },
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ ok: true });
+      expect(mockedVerifySession).not.toHaveBeenCalled();
+    });
+
+    it('rejects a wrong service token', async () => {
+      mockedConfig.serviceToken = 'tok-123';
+      const app = createTestApp();
+      const res = await app.request('/api/tts', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer wrong' },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it('does not grant the TTS token access to other API routes', async () => {
+      mockedConfig.serviceToken = 'tok-123';
+      const app = createTestApp();
+      const res = await app.request('/api/test', {
+        headers: { Authorization: 'Bearer tok-123' },
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it('does not enable bearer auth when the service token is empty', async () => {
+      const app = createTestApp();
+      const res = await app.request('/api/tts', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer tok-123' },
+      });
+      expect(res.status).toBe(401);
     });
 
     describe('public routes bypass auth', () => {

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -9,6 +9,7 @@
 
 import { createMiddleware } from 'hono/factory';
 import { getCookie } from 'hono/cookie';
+import crypto from 'node:crypto';
 import { config, SESSION_COOKIE_NAME } from '../lib/config.js';
 import { verifySession } from '../lib/session.js';
 
@@ -21,6 +22,15 @@ const PUBLIC_ROUTES = [
   '/api/version',
   '/health',
 ];
+
+function hasValidServiceBearer(header: string | undefined): boolean {
+  const token = header?.match(/^Bearer\s+(.+)$/i)?.[1]?.trim();
+  if (!token || !config.serviceToken) return false;
+
+  const provided = Buffer.from(token);
+  const expected = Buffer.from(config.serviceToken);
+  return provided.length === expected.length && crypto.timingSafeEqual(provided, expected);
+}
 
 /**
  * Authentication middleware.
@@ -37,6 +47,10 @@ export const authMiddleware = createMiddleware(async (c, next) => {
 
   // Public API routes — always accessible
   if (PUBLIC_ROUTES.some(route => c.req.path === route)) return next();
+
+  // LPV may synthesize speech without borrowing a browser session.
+  if (c.req.method === 'POST' && c.req.path === '/api/tts'
+    && hasValidServiceBearer(c.req.header('Authorization'))) return next();
 
   // Check session cookie
   const token = getCookie(c, SESSION_COOKIE_NAME);

--- a/server/routes/tts.test.ts
+++ b/server/routes/tts.test.ts
@@ -15,7 +15,14 @@ describe('TTS routes', () => {
     openaiKey?: string;
     replicateToken?: string;
     mimoKey?: string;
-    edgeResult?: { ok: boolean; buf?: Buffer; message?: string; status?: number; contentType?: string };
+    edgeResult?: {
+      ok: boolean;
+      buf?: Buffer;
+      message?: string;
+      status?: number;
+      contentType?: string;
+      words?: Array<{ word: string; start: number; end: number }>;
+    };
     openaiResult?: { ok: boolean; buf?: Buffer; message?: string; status?: number };
     replicateResult?: { ok: boolean; buf?: Buffer; message?: string; status?: number };
     xiaomiResult?: { ok: boolean; buf?: Buffer; message?: string; status?: number; contentType?: string };
@@ -130,6 +137,36 @@ describe('TTS routes', () => {
         body: JSON.stringify({ text: 'Hello', provider: 'edge' }),
       });
       expect(res.status).toBe(200);
+    });
+
+    it('returns Edge audio with provider word boundaries only when requested', async () => {
+      mockDeps({
+        edgeResult: {
+          ok: true,
+          buf: Buffer.from('timed-edge-audio'),
+          words: [{ word: 'Hello', start: 0.1, end: 0.4 }],
+        },
+      });
+      const app = await buildApp();
+      const { synthesizeEdge } = await import('../services/edge-tts.js');
+      const res = await app.request('/api/tts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          text: 'Hello',
+          provider: 'edge',
+          voice: 'en-GB-RyanNeural',
+          include_word_timestamps: true,
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Content-Type')).toContain('application/json');
+      expect(await res.json()).toEqual({
+        audio_base64: Buffer.from('timed-edge-audio').toString('base64'),
+        words: [{ word: 'Hello', start: 0.1, end: 0.4 }],
+      });
+      expect(synthesizeEdge).toHaveBeenCalledWith('Hello', 'en-GB-RyanNeural', true);
     });
 
     it('uses explicit Xiaomi provider and returns WAV audio', async () => {

--- a/server/routes/tts.ts
+++ b/server/routes/tts.ts
@@ -43,6 +43,7 @@ const ttsSchema = z.object({
   // Accept both old ("qwen") and new ("replicate") values
   provider: z.enum(['openai', 'replicate', 'qwen', 'edge', 'xiaomi']).optional(),
   model: z.string().optional(),
+  include_word_timestamps: z.boolean().optional(),
 });
 
 function audioResponse(buf: Buffer, contentType = 'audio/mpeg'): Response {
@@ -62,7 +63,13 @@ app.post(
   }),
   async (c) => {
     try {
-      const { text, voice: rawVoice, provider: rawProvider, model: rawModel } = c.req.valid('json');
+      const {
+        text,
+        voice: rawVoice,
+        provider: rawProvider,
+        model: rawModel,
+        include_word_timestamps: includeWordTimestamps = false,
+      } = c.req.valid('json');
 
       // Normalize "qwen" → "replicate" + model "qwen-tts" for backward compat
       const isLegacyQwen = rawProvider === 'qwen';
@@ -87,6 +94,9 @@ app.post(
           : useReplicate
             ? 'replicate'
             : 'openai';
+      if (includeWordTimestamps && effectiveProvider !== 'edge') {
+        return c.text('Word timestamps are available only for Edge TTS', 400);
+      }
       console.log(`[tts] provider=${effectiveProvider} voice=${voice} text="${text.slice(0, 50)}..."`);
 
       const xiaomiStyle = effectiveProvider === 'xiaomi' ? getTTSConfig().xiaomi.style : '';
@@ -97,7 +107,7 @@ app.post(
         .update(`${effectiveProvider}:${model || ''}:${voice || ''}:${xiaomiStyle}:${text}`)
         .digest('hex');
 
-      const cached = getTtsCache(hash);
+      const cached = includeWordTimestamps ? null : getTtsCache(hash);
       if (cached) {
         // Detect WAV (starts with "RIFF") vs MP3 for correct content type
         const cachedCt = cached.length > 4 && cached.toString('ascii', 0, 4) === 'RIFF' ? 'audio/wav' : 'audio/mpeg';
@@ -108,7 +118,7 @@ app.post(
       if (effectiveProvider === 'xiaomi') {
         result = await synthesizeXiaomi(text, { model, voice });
       } else if (effectiveProvider === 'edge') {
-        result = await synthesizeEdge(text, voice);
+        result = await synthesizeEdge(text, voice, includeWordTimestamps);
       } else if (effectiveProvider === 'replicate') {
         result = await synthesizeReplicate(text, { model, voice });
       } else {
@@ -120,6 +130,12 @@ app.post(
       }
 
       const ct = 'contentType' in result ? (result as { contentType: string }).contentType : 'audio/mpeg';
+      if (includeWordTimestamps) {
+        return c.json({
+          audio_base64: result.buf.toString('base64'),
+          words: 'words' in result ? result.words : [],
+        });
+      }
       setTtsCache(hash, result.buf);
       return audioResponse(result.buf, ct);
     } catch (err) {

--- a/server/services/edge-tts.test.ts
+++ b/server/services/edge-tts.test.ts
@@ -1,0 +1,28 @@
+import {describe, expect, it} from 'vitest';
+import {parseEdgeWordBoundaryMessage} from './edge-tts.js';
+
+describe('Edge TTS word boundaries', () => {
+  it('converts provider 100ns offsets into ordered seconds', () => {
+    const message = [
+      'X-RequestId:test',
+      'Content-Type:application/json; charset=utf-8',
+      'Path:audio.metadata',
+      '',
+      JSON.stringify({
+        Metadata: [{
+          Type: 'WordBoundary',
+          Data: {
+            Offset: 1_000_000,
+            Duration: 2_875_000,
+            text: {Text: 'One', BoundaryType: 'WordBoundary'},
+          },
+        }],
+      }),
+    ].join('\r\n');
+
+    expect(parseEdgeWordBoundaryMessage(message)).toEqual([
+      {word: 'One', start: 0.1, end: 0.3875},
+    ]);
+    expect(parseEdgeWordBoundaryMessage('Path:turn.end\r\n\r\n')).toEqual([]);
+  });
+});

--- a/server/services/edge-tts.ts
+++ b/server/services/edge-tts.ts
@@ -25,6 +25,8 @@ import { getTTSConfig, resolveEdgeTTSVoice } from '../lib/tts-config.js';
 
 const DEFAULT_VOICE = 'en-US-AriaNeural';
 
+export type EdgeWordTiming = {word: string; start: number; end: number};
+
 // Windows epoch offset: seconds between 1601-01-01 and 1970-01-01
 const WIN_EPOCH = 11644473600;
 
@@ -40,6 +42,37 @@ function escapeXml(text: string): string {
         c
       ]!,
   );
+}
+
+export function parseEdgeWordBoundaryMessage(message: string): EdgeWordTiming[] {
+  if (!message.includes('Path:audio.metadata')) return [];
+  const body = message.split('\r\n\r\n', 2)[1];
+  if (!body) return [];
+  try {
+    const payload = JSON.parse(body) as {
+      Metadata?: Array<{
+        Type?: string;
+        Data?: {Offset?: number; Duration?: number; text?: {Text?: string}};
+      }>;
+    };
+    return (payload.Metadata ?? []).flatMap((entry) => {
+      const word = String(entry.Data?.text?.Text ?? '').trim();
+      const offset = Number(entry.Data?.Offset);
+      const duration = Number(entry.Data?.Duration);
+      if (entry.Type !== 'WordBoundary' || !word || !Number.isFinite(offset) || !Number.isFinite(duration)) {
+        return [];
+      }
+      const start = Math.max(0, offset / 10_000_000);
+      const end = start + Math.max(0, duration / 10_000_000);
+      return [{
+        word,
+        start: Math.round(start * 1_000_000) / 1_000_000,
+        end: Math.round(end * 1_000_000) / 1_000_000,
+      }];
+    });
+  } catch {
+    return [];
+  }
 }
 
 /**
@@ -80,15 +113,16 @@ function deriveVoiceLocale(voiceName: string): string {
 export async function synthesizeEdge(
   text: string,
   voice?: string,
+  includeWordBoundaries = false,
 ): Promise<
-  { ok: true; buf: Buffer } | { ok: false; message: string; status: number }
+  { ok: true; buf: Buffer; words: EdgeWordTiming[] } | { ok: false; message: string; status: number }
 > {
   // Voice resolution: explicit param > language-aware config > tts-config.json > DEFAULT_VOICE
   const resolved = resolveEdgeTTSVoice();
   const effectiveVoice = voice || resolved.voice || getTTSConfig().edge.voice || DEFAULT_VOICE;
   console.log(`[edge-tts] Starting synthesis, voice=${effectiveVoice}`);
   try {
-    const buf = await new Promise<Buffer>((resolve, reject) => {
+    const synthesis = await new Promise<{buf: Buffer; words: EdgeWordTiming[]}>((resolve, reject) => {
       const muid = crypto.randomBytes(16).toString('hex').toUpperCase();
       const ws = new WebSocket(buildWsUrl(), {
         host: 'speech.platform.bing.com',
@@ -102,6 +136,7 @@ export async function synthesizeEdge(
       });
 
       const audioData: Buffer[] = [];
+      const words: EdgeWordTiming[] = [];
       const timeout = setTimeout(() => {
         ws.close();
         reject(new Error('Edge TTS timeout after 30s'));
@@ -110,9 +145,10 @@ export async function synthesizeEdge(
       ws.on('message', (rawData: Buffer, isBinary: boolean) => {
         if (!isBinary) {
           const data = rawData.toString('utf8');
+          if (includeWordBoundaries) words.push(...parseEdgeWordBoundaryMessage(data));
           if (data.includes('turn.end')) {
             clearTimeout(timeout);
-            resolve(Buffer.concat(audioData));
+            resolve({buf: Buffer.concat(audioData), words});
             ws.close();
           }
           return;
@@ -136,7 +172,7 @@ export async function synthesizeEdge(
             audio: {
               metadataoptions: {
                 sentenceBoundaryEnabled: false,
-                wordBoundaryEnabled: false,
+                wordBoundaryEnabled: includeWordBoundaries,
               },
               outputFormat: 'audio-24khz-48kbitrate-mono-mp3',
             },
@@ -175,10 +211,10 @@ export async function synthesizeEdge(
       });
     });
 
-    if (buf.length === 0) {
+    if (synthesis.buf.length === 0) {
       return { ok: false, message: 'Edge TTS returned empty audio', status: 500 };
     }
-    return { ok: true, buf };
+    return { ok: true, ...synthesis };
   } catch (err) {
     console.error('[edge-tts] error:', (err as Error).message);
     return {


### PR DESCRIPTION
## Outcome
Adds a constant-time service-token path scoped only to exact `POST /api/tts`, preserves Hono request context, and optionally returns Edge TTS audio with native word boundaries for frame-accurate downstream video captions. Legacy binary audio responses and other API authentication remain unchanged.

## Owned files
- `server/lib/config.ts`
- `server/middleware/auth.ts`
- `server/middleware/auth.test.ts`
- `server/app.ts`
- `server/services/edge-tts.ts`
- `server/services/edge-tts.test.ts`
- `server/routes/tts.ts`
- `server/routes/tts.test.ts`

## Impact
- Server only: authenticated TTS requests may opt into JSON `{audio_base64, words}`.
- Web/mobile/desktop: no UI changes.

## Checks
- Auth middleware: 18 passed
- Edge service + TTS route: 17 passed
- Server TypeScript: passed
- Full production build: passed
- Live direct Edge synthesis returned 5 ordered native word boundaries.

## Deployment
Back up the scoped source and built server files, apply the exact PR delta to the local Nerve runtime, rebuild, restart only Nerve, then verify unauthenticated 401, service-authenticated timed TTS 200, and denial on non-TTS APIs.

## Rollback
Restore the scoped backup, rebuild server output, and restart only Nerve.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Bearer-token authentication for text-to-speech requests.
  * Added word-timestamp support for Edge text-to-speech, returning audio with word timing data in JSON format.
  * Valid service tokens can access TTS without a session cookie.

* **Bug Fixes**
  * Invalid tokens cannot access TTS or other API routes.
  * Standard TTS requests retain their existing cached audio response behavior.
  * Improved request handling to apply environment settings correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->