### PR TITLE
feat(audio): add independent UI sound volume

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,7 +115,7 @@ export default function App({ onLogout }: AppProps) {
 
   // Settings state
   const {
-    soundEnabled, toggleSound,
+    soundEnabled, toggleSound, uiSoundVolume, setUiSoundVolume,
     ttsProvider, ttsModel, setTtsProvider, setTtsModel,
     sttProvider, setSttProvider, sttInputMode, setSttInputMode, sttModel, setSttModel,
     wakeWordEnabled, handleToggleWakeWord, handleWakeWordState,
@@ -1002,6 +1002,8 @@ export default function App({ onLogout }: AppProps) {
             connectionState={connectionState}
             soundEnabled={soundEnabled}
             onToggleSound={toggleSound}
+            uiSoundVolume={uiSoundVolume}
+            onUiSoundVolumeChange={setUiSoundVolume}
             ttsProvider={ttsProvider}
             ttsModel={ttsModel}
             onTtsProviderChange={handleTtsProviderChange}

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -102,7 +102,7 @@ const ChatContext = createContext<ChatContextValue | null>(null);
 export function ChatProvider({ children }: { children: ReactNode }) {
   const { connectionState, rpc, subscribe } = useGateway();
   const { currentSession, sessions } = useSessionContext();
-  const { soundEnabled, speak } = useSettings();
+  const { soundEnabled: ttsEnabled, speak } = useSettings();
 
   // ─── Shared state ─────────────────────────────────────────────────────────
   const [isGenerating, setIsGenerating] = useState(false);
@@ -111,15 +111,15 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   // ─── Refs for stable callback references ──────────────────────────────────
   const currentSessionRef = useRef(currentSession);
   const isGeneratingRef = useRef(isGenerating);
-  const soundEnabledRef = useRef(soundEnabled);
+  const ttsEnabledRef = useRef(ttsEnabled);
   const speakRef = useRef(speak);
 
   useEffect(() => {
     currentSessionRef.current = currentSession;
     isGeneratingRef.current = isGenerating;
-    soundEnabledRef.current = soundEnabled;
+    ttsEnabledRef.current = ttsEnabled;
     speakRef.current = speak;
-  }, [currentSession, isGenerating, soundEnabled, speak]);
+  }, [currentSession, isGenerating, ttsEnabled, speak]);
 
   // ─── Run state management ─────────────────────────────────────────────────
   const runsRef = useRef<Map<string, RunState>>(new Map());
@@ -131,7 +131,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   // ─── Compose hooks ────────────────────────────────────────────────────────
   const msgHook = useChatMessages({ rpc, currentSessionRef });
   const streamHook = useChatStreaming();
-  const ttsHook = useChatTTS({ soundEnabled: soundEnabledRef, speak: speakRef });
+  const ttsHook = useChatTTS({ ttsEnabled: ttsEnabledRef, speak: speakRef });
 
   const recoveryHook = useChatRecovery({
     rpc,

--- a/src/contexts/SessionContext.test.tsx
+++ b/src/contexts/SessionContext.test.tsx
@@ -5,20 +5,14 @@ import { getSessionKey, type GatewayEvent } from '@/types';
 import { getSessionDisplayLabel } from '@/features/sessions/sessionKeys';
 
 const mockUseGateway = vi.fn();
-const mockUseSettings = vi.fn();
 const playPingMock = vi.fn();
 let rpcMock: ReturnType<typeof vi.fn>;
 let subscribeMock: ReturnType<typeof vi.fn>;
 let connectionStateValue: 'disconnected' | 'connecting' | 'connected' | 'reconnecting' = 'connected';
 let subscribedHandler: ((msg: GatewayEvent) => void) | null = null;
-let soundEnabledValue = true;
 
 vi.mock('./GatewayContext', () => ({
   useGateway: () => mockUseGateway(),
-}));
-
-vi.mock('./SettingsContext', () => ({
-  useSettings: () => mockUseSettings(),
 }));
 
 vi.mock('@/features/voice/audio-feedback', () => ({
@@ -94,7 +88,6 @@ describe('SessionContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     subscribedHandler = null;
-    soundEnabledValue = true;
     connectionStateValue = 'connected';
 
     rpcMock = vi.fn(async (method: string, params?: Record<string, unknown>) => {
@@ -125,10 +118,6 @@ describe('SessionContext', () => {
       connectionState: connectionStateValue,
       rpc: rpcMock,
       subscribe: subscribeMock,
-    }));
-
-    mockUseSettings.mockImplementation(() => ({
-      soundEnabled: soundEnabledValue,
     }));
 
     globalThis.fetch = vi.fn((input: string | URL | Request) => {
@@ -822,7 +811,7 @@ describe('SessionContext', () => {
     expect(playPingMock).not.toHaveBeenCalled();
   });
 
-  it('keeps the DONE-to-IDLE timer alive when sound is toggled mid-response', async () => {
+  it('keeps the DONE-to-IDLE timer alive across provider rerenders', async () => {
     rpcMock.mockImplementation(async (method: string) => {
       if (method === 'sessions.list') {
         return {
@@ -862,7 +851,6 @@ describe('SessionContext', () => {
     expect(screen.getByTestId('reviewer-status').textContent).toBe('DONE');
 
     await act(async () => {
-      soundEnabledValue = false;
       view.rerender(
         <SessionProvider>
           <SessionStatusProbe />

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable react-refresh/only-export-components -- hook intentionally co-located with provider */
 import { createContext, useContext, useCallback, useRef, useEffect, useState, useMemo, type ReactNode } from 'react';
 import { useGateway } from './GatewayContext';
-import { useSettings } from './SettingsContext';
 import { getSessionKey, type Session, type AgentLogEntry, type EventEntry, type GatewayEvent, type EventPayload, type AgentEventPayload, type ChatEventPayload, type ContentBlock, type SessionsListResponse, type ChatHistoryResponse, type ChatMessage, type GranularAgentState } from '@/types';
 import { playPing } from '@/features/voice/audio-feedback';
 import { describeToolUse } from '@/utils/helpers';
@@ -64,7 +63,6 @@ const SessionContext = createContext<SessionContextValue | null>(null);
 
 export function SessionProvider({ children }: { children: ReactNode }) {
   const { connectionState, rpc, subscribe } = useGateway();
-  const { soundEnabled } = useSettings();
   const [sessions, setSessions] = useState<Session[]>([]);
   const [sessionsLoading, setSessionsLoading] = useState(true);
   const [currentSession, setCurrentSessionRaw] = useState('');
@@ -77,7 +75,6 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const [rootIdentityMisses, setRootIdentityMisses] = useState<Record<string, true>>({});
   const [unreadSessionKeys, setUnreadSessionKeys] = useState<Set<string>>(new Set());
   const unreadSessionKeysRef = useRef(unreadSessionKeys);
-  const soundEnabledRef = useRef(soundEnabled);
   const logStateRef = useRef<Record<string, boolean>>({});
   const toolSeenRef = useRef<Map<string, number>>(new Map());
   const doneTimeoutsRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
@@ -104,10 +101,6 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     unreadSessionKeysRef.current = unreadSessionKeys;
   }, [unreadSessionKeys]);
-
-  useEffect(() => {
-    soundEnabledRef.current = soundEnabled;
-  }, [soundEnabled]);
 
   const markSessionRead = useCallback((key: string) => {
     if (!unreadSessionKeysRef.current.has(key)) return;
@@ -278,7 +271,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const pingSession = useCallback((sessionKey: string) => {
-    if (!sessionKey || currentSessionRef.current === sessionKey || !soundEnabledRef.current) return;
+    if (!sessionKey || currentSessionRef.current === sessionKey) return;
     playPing();
   }, []);
 

--- a/src/contexts/SettingsContext.test.tsx
+++ b/src/contexts/SettingsContext.test.tsx
@@ -42,6 +42,7 @@ describe('SettingsContext UI sound volume', () => {
   });
 
   it('restores and applies the saved UI sound volume', async () => {
+    localStorage.setItem('oc-sound', 'false');
     localStorage.setItem('nerve:uiSoundVolume', '0.35');
 
     render(
@@ -52,6 +53,32 @@ describe('SettingsContext UI sound volume', () => {
 
     expect(screen.getByRole('button')).toHaveTextContent('0.35');
     await waitFor(() => expect(applyUiSoundVolumeMock).toHaveBeenCalledWith(0.35));
+  });
+
+  it('migrates an explicitly disabled legacy sound preference to muted UI sounds', async () => {
+    localStorage.setItem('oc-sound', 'false');
+
+    render(
+      <SettingsProvider>
+        <VolumeProbe />
+      </SettingsProvider>,
+    );
+
+    expect(screen.getByRole('button')).toHaveTextContent('0');
+    expect(localStorage.getItem('nerve:uiSoundVolume')).toBe('0');
+    await waitFor(() => expect(applyUiSoundVolumeMock).toHaveBeenCalledWith(0));
+  });
+
+  it('defaults fresh installs to full UI sound volume', async () => {
+    render(
+      <SettingsProvider>
+        <VolumeProbe />
+      </SettingsProvider>,
+    );
+
+    expect(screen.getByRole('button')).toHaveTextContent('1');
+    expect(localStorage.getItem('nerve:uiSoundVolume')).toBe('1');
+    await waitFor(() => expect(applyUiSoundVolumeMock).toHaveBeenCalledWith(1));
   });
 
   it('persists UI sound volume changes independently', async () => {

--- a/src/contexts/SettingsContext.test.tsx
+++ b/src/contexts/SettingsContext.test.tsx
@@ -1,0 +1,70 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SettingsProvider, useSettings } from './SettingsContext';
+
+const { applyUiSoundVolumeMock } = vi.hoisted(() => ({
+  applyUiSoundVolumeMock: vi.fn(),
+}));
+
+vi.mock('@/features/tts/useTTS', () => ({
+  migrateTTSProvider: (provider: string) => provider,
+  useTTS: () => ({ speak: vi.fn() }),
+}));
+
+vi.mock('@/features/voice/audio-feedback', () => ({
+  normalizeUiSoundVolume: (volume: number) => (
+    Number.isFinite(volume) ? Math.min(1, Math.max(0, volume)) : 1
+  ),
+  setUiSoundVolume: applyUiSoundVolumeMock,
+}));
+
+const originalFetch = globalThis.fetch;
+
+function VolumeProbe() {
+  const { uiSoundVolume, setUiSoundVolume } = useSettings();
+
+  return (
+    <button type="button" onClick={() => setUiSoundVolume(0.25)}>
+      {uiSoundVolume}
+    </button>
+  );
+}
+
+describe('SettingsContext UI sound volume', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('restores and applies the saved UI sound volume', async () => {
+    localStorage.setItem('nerve:uiSoundVolume', '0.35');
+
+    render(
+      <SettingsProvider>
+        <VolumeProbe />
+      </SettingsProvider>,
+    );
+
+    expect(screen.getByRole('button')).toHaveTextContent('0.35');
+    await waitFor(() => expect(applyUiSoundVolumeMock).toHaveBeenCalledWith(0.35));
+  });
+
+  it('persists UI sound volume changes independently', async () => {
+    render(
+      <SettingsProvider>
+        <VolumeProbe />
+      </SettingsProvider>,
+    );
+
+    await act(async () => screen.getByRole('button').click());
+
+    expect(screen.getByRole('button')).toHaveTextContent('0.25');
+    expect(localStorage.getItem('nerve:uiSoundVolume')).toBe('0.25');
+    await waitFor(() => expect(applyUiSoundVolumeMock).toHaveBeenLastCalledWith(0.25));
+  });
+});

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -62,6 +62,7 @@ const COMMAND_PALETTE_BUTTON_STORAGE_KEY = 'nerve:showChatboxCommandPaletteButto
 const LEGACY_TOPBAR_COMMAND_PALETTE_BUTTON_STORAGE_KEY = 'nerve:showTopBarCommandPaletteButton';
 const LEGACY_COMPACT_COMMAND_PALETTE_BUTTON_STORAGE_KEY = 'nerve:showFloatingCommandPaletteButton';
 const UI_SOUND_VOLUME_STORAGE_KEY = 'nerve:uiSoundVolume';
+const SPOKEN_REPLIES_STORAGE_KEY = 'oc-sound';
 
 const ALLOWED_FONT_SIZES = new Set([10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 22, 24]);
 const ALLOWED_EDITOR_FONT_SIZES = new Set([10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 22, 24]);
@@ -76,7 +77,14 @@ function normalizeEditorFontSize(size: number): number {
 
 function resolveInitialUiSoundVolume(): number {
   const saved = localStorage.getItem(UI_SOUND_VOLUME_STORAGE_KEY);
-  return saved === null || saved.trim() === '' ? 1 : normalizeUiSoundVolume(Number(saved));
+  if (saved !== null && saved.trim() !== '') {
+    return normalizeUiSoundVolume(Number(saved));
+  }
+
+  const legacySoundPreference = localStorage.getItem(SPOKEN_REPLIES_STORAGE_KEY);
+  const volume = legacySoundPreference === null || legacySoundPreference === 'true' ? 1 : 0;
+  localStorage.setItem(UI_SOUND_VOLUME_STORAGE_KEY, String(volume));
+  return volume;
 }
 
 function resolveInitialCommandPaletteButtonVisible(): boolean {
@@ -119,7 +127,7 @@ function resolveInitialFont(): FontName {
 }
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
-  const [soundEnabled, setSoundEnabled] = useState(localStorage.getItem('oc-sound') === 'true');
+  const [soundEnabled, setSoundEnabled] = useState(localStorage.getItem(SPOKEN_REPLIES_STORAGE_KEY) === 'true');
   const [uiSoundVolume, setUiSoundVolumeState] = useState(resolveInitialUiSoundVolume);
   const [ttsProvider, setTtsProvider] = useState<TTSProvider>(() => migrateTTSProvider(localStorage.getItem('oc-tts-provider') || 'edge'));
   const [ttsModel, setTtsModelState] = useState(() => localStorage.getItem('oc-tts-model') || '');
@@ -204,7 +212,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const toggleSound = useCallback(() => {
     setSoundEnabled(prev => {
       const next = !prev;
-      localStorage.setItem('oc-sound', String(next));
+      localStorage.setItem(SPOKEN_REPLIES_STORAGE_KEY, String(next));
       return next;
     });
   }, []);

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react-refresh/only-export-components -- hook intentionally co-located with provider */
 import { createContext, useContext, useCallback, useRef, useState, useEffect, useMemo, type ReactNode } from 'react';
 import { useTTS, migrateTTSProvider, type TTSProvider } from '@/features/tts/useTTS';
+import { normalizeUiSoundVolume, setUiSoundVolume as applyUiSoundVolume } from '@/features/voice/audio-feedback';
 import { type ThemeName, applyTheme, themeNames } from '@/lib/themes';
 import { type FontName, applyFont, fontNames } from '@/lib/fonts';
 
@@ -10,6 +11,8 @@ export type STTInputMode = 'browser' | 'local' | 'hybrid';
 interface SettingsContextValue {
   soundEnabled: boolean;
   toggleSound: () => void;
+  uiSoundVolume: number;
+  setUiSoundVolume: (volume: number) => void;
   ttsProvider: TTSProvider;
   ttsModel: string;
   setTtsProvider: (provider: TTSProvider) => void;
@@ -58,6 +61,7 @@ const KANBAN_VISIBILITY_STORAGE_KEY = 'nerve:workspace:kanban-visible';
 const COMMAND_PALETTE_BUTTON_STORAGE_KEY = 'nerve:showChatboxCommandPaletteButton';
 const LEGACY_TOPBAR_COMMAND_PALETTE_BUTTON_STORAGE_KEY = 'nerve:showTopBarCommandPaletteButton';
 const LEGACY_COMPACT_COMMAND_PALETTE_BUTTON_STORAGE_KEY = 'nerve:showFloatingCommandPaletteButton';
+const UI_SOUND_VOLUME_STORAGE_KEY = 'nerve:uiSoundVolume';
 
 const ALLOWED_FONT_SIZES = new Set([10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 22, 24]);
 const ALLOWED_EDITOR_FONT_SIZES = new Set([10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 22, 24]);
@@ -68,6 +72,11 @@ function normalizeFontSize(size: number): number {
 
 function normalizeEditorFontSize(size: number): number {
   return Number.isFinite(size) && ALLOWED_EDITOR_FONT_SIZES.has(size) ? size : 13;
+}
+
+function resolveInitialUiSoundVolume(): number {
+  const saved = localStorage.getItem(UI_SOUND_VOLUME_STORAGE_KEY);
+  return saved === null || saved.trim() === '' ? 1 : normalizeUiSoundVolume(Number(saved));
 }
 
 function resolveInitialCommandPaletteButtonVisible(): boolean {
@@ -111,6 +120,7 @@ function resolveInitialFont(): FontName {
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const [soundEnabled, setSoundEnabled] = useState(localStorage.getItem('oc-sound') === 'true');
+  const [uiSoundVolume, setUiSoundVolumeState] = useState(resolveInitialUiSoundVolume);
   const [ttsProvider, setTtsProvider] = useState<TTSProvider>(() => migrateTTSProvider(localStorage.getItem('oc-tts-provider') || 'edge'));
   const [ttsModel, setTtsModelState] = useState(() => localStorage.getItem('oc-tts-model') || '');
   const [sttProvider, setSttProviderState] = useState<STTProvider>(() => {
@@ -177,6 +187,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     applyFont(font);
   }, [font]);
 
+  useEffect(() => {
+    applyUiSoundVolume(uiSoundVolume);
+  }, [uiSoundVolume]);
+
   // Apply font size on mount and when it changes
   useEffect(() => {
     document.documentElement.style.setProperty('--font-size-base', `${fontSize}px`);
@@ -193,6 +207,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       localStorage.setItem('oc-sound', String(next));
       return next;
     });
+  }, []);
+
+  const setUiSoundVolume = useCallback((volume: number) => {
+    const normalized = normalizeUiSoundVolume(volume);
+    setUiSoundVolumeState(normalized);
+    localStorage.setItem(UI_SOUND_VOLUME_STORAGE_KEY, String(normalized));
   }, []);
 
   const toggleLiveTranscriptionPreview = useCallback(() => {
@@ -368,6 +388,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const value = useMemo<SettingsContextValue>(() => ({
     soundEnabled,
     toggleSound,
+    uiSoundVolume,
+    setUiSoundVolume,
     ttsProvider,
     ttsModel,
     setTtsProvider: changeTtsProvider,
@@ -409,7 +431,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     kanbanVisible,
     toggleKanbanVisible,
   }), [
-    soundEnabled, toggleSound, ttsProvider, ttsModel, changeTtsProvider, changeTtsModel, toggleTtsProvider,
+    soundEnabled, toggleSound, uiSoundVolume, setUiSoundVolume,
+    ttsProvider, ttsModel, changeTtsProvider, changeTtsModel, toggleTtsProvider,
     sttProvider, changeSttProvider, sttInputMode, changeSttInputMode, sttModel, changeSttModel,
     wakeWordEnabled, handleToggleWakeWord, handleWakeWordState,
     liveTranscriptionPreview, toggleLiveTranscriptionPreview,

--- a/src/features/command-palette/commands.ts
+++ b/src/features/command-palette/commands.ts
@@ -142,10 +142,10 @@ export function createCommands(actions: CommandActions): Command[] {
     },
     {
       id: 'sound',
-      label: 'Toggle sound effects',
+      label: 'Toggle spoken replies',
       action: actions.onToggleSound,
       category: 'settings',
-      keywords: ['audio', 'mute', 'sfx'],
+      keywords: ['audio', 'mute', 'tts', 'voice'],
     },
     {
       id: 'settings',

--- a/src/features/settings/AudioSettings.component.test.tsx
+++ b/src/features/settings/AudioSettings.component.test.tsx
@@ -49,6 +49,8 @@ vi.mock('@/components/ui/InlineSelect', () => ({
 const baseProps = {
   soundEnabled: true,
   onToggleSound: vi.fn(),
+  uiSoundVolume: 1,
+  onUiSoundVolumeChange: vi.fn(),
   ttsProvider: 'edge' as const,
   ttsModel: 'tts-1',
   onTtsProviderChange: vi.fn(),
@@ -210,6 +212,29 @@ describe('AudioSettings', () => {
       fireEvent.change(screen.getByPlaceholderText('Happy, whisper, calm, dramatic...'), { target: { value: 'Happy' } });
 
       expect(updateField).toHaveBeenCalledWith('xiaomi', 'style', 'Happy');
+    });
+  });
+
+  describe('UI sound volume', () => {
+    it('changes UI sound volume independently from the spoken replies toggle', async () => {
+      const onUiSoundVolumeChange = vi.fn();
+      const onToggleSound = vi.fn();
+      render(
+        <AudioSettings
+          {...baseProps}
+          section="output"
+          uiSoundVolume={0.4}
+          onUiSoundVolumeChange={onUiSoundVolumeChange}
+          onToggleSound={onToggleSound}
+        />,
+      );
+
+      const slider = await screen.findByRole('slider', { name: /ui sound volume/i });
+      expect(slider).toHaveValue('40');
+
+      fireEvent.change(slider, { target: { value: '25' } });
+      expect(onUiSoundVolumeChange).toHaveBeenCalledWith(0.25);
+      expect(onToggleSound).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/features/settings/AudioSettings.tsx
+++ b/src/features/settings/AudioSettings.tsx
@@ -205,6 +205,8 @@ type AudioSettingsSection = 'all' | 'input' | 'output';
 interface AudioSettingsProps {
   soundEnabled: boolean;
   onToggleSound: () => void;
+  uiSoundVolume: number;
+  onUiSoundVolumeChange: (volume: number) => void;
   ttsProvider: TTSProvider;
   ttsModel: string;
   onTtsProviderChange: (provider: TTSProvider) => void;
@@ -432,6 +434,8 @@ const PROVIDER_MODELS: Record<TTSProvider, { value: string; label: string }[]> =
 export function AudioSettings({
   soundEnabled,
   onToggleSound,
+  uiSoundVolume,
+  onUiSoundVolumeChange,
   ttsProvider,
   ttsModel,
   onTtsProviderChange,
@@ -697,7 +701,7 @@ export function AudioSettings({
         </div>
       )}
 
-      {/* Sound Effects */}
+      {/* Spoken Replies */}
       {showOutput && (
         <div className="cockpit-row items-start justify-between">
           <div className="flex items-center gap-3">
@@ -707,15 +711,47 @@ export function AudioSettings({
               <VolumeX size={14} className="text-muted-foreground" aria-hidden="true" />
             )}
             <div className="flex flex-col">
-              <span className="text-sm font-medium text-foreground" id="sound-label">Sound effects</span>
-              <span className="text-xs text-muted-foreground">Keep subtle UI cues and audio confirmations enabled.</span>
+              <span className="text-sm font-medium text-foreground" id="sound-label">Spoken replies</span>
+              <span className="text-xs text-muted-foreground">Play assistant responses through the configured TTS provider.</span>
             </div>
           </div>
           <Switch
             checked={soundEnabled}
             onCheckedChange={onToggleSound}
-            aria-label="Toggle sound effects"
+            aria-label="Toggle spoken replies"
           />
+        </div>
+      )}
+
+      {/* UI Sound Volume */}
+      {showOutput && (
+        <div className="cockpit-row items-start justify-between gap-4">
+          <div className="flex items-center gap-3">
+            {uiSoundVolume > 0 ? (
+              <Volume2 size={14} className="text-primary" aria-hidden="true" />
+            ) : (
+              <VolumeX size={14} className="text-muted-foreground" aria-hidden="true" />
+            )}
+            <div className="flex flex-col">
+              <label className="text-sm font-medium text-foreground" htmlFor="ui-sound-volume">UI sound volume</label>
+              <span className="text-xs text-muted-foreground">Adjust voice cues and notifications without changing TTS volume.</span>
+            </div>
+          </div>
+          <div className="flex min-w-32 items-center gap-2 pt-1">
+            <input
+              id="ui-sound-volume"
+              type="range"
+              min="0"
+              max="100"
+              step="5"
+              value={Math.round(uiSoundVolume * 100)}
+              onChange={(event) => onUiSoundVolumeChange(Number(event.target.value) / 100)}
+              className="h-2 w-24 cursor-pointer accent-primary"
+            />
+            <span className="w-9 text-right font-mono text-xs text-muted-foreground">
+              {Math.round(uiSoundVolume * 100)}%
+            </span>
+          </div>
         </div>
       )}
 

--- a/src/features/settings/SettingsDrawer.tsx
+++ b/src/features/settings/SettingsDrawer.tsx
@@ -19,6 +19,8 @@ interface SettingsDrawerProps {
   // Audio settings
   soundEnabled: boolean;
   onToggleSound: () => void;
+  uiSoundVolume: number;
+  onUiSoundVolumeChange: (volume: number) => void;
   ttsProvider: TTSProvider;
   ttsModel: string;
   onTtsProviderChange: (provider: TTSProvider) => void;
@@ -73,6 +75,8 @@ export function SettingsDrawer({
   connectionState,
   soundEnabled,
   onToggleSound,
+  uiSoundVolume,
+  onUiSoundVolumeChange,
   ttsProvider,
   ttsModel,
   onTtsProviderChange,
@@ -226,6 +230,8 @@ export function SettingsDrawer({
                 section="all"
                 soundEnabled={soundEnabled}
                 onToggleSound={onToggleSound}
+                uiSoundVolume={uiSoundVolume}
+                onUiSoundVolumeChange={onUiSoundVolumeChange}
                 ttsProvider={ttsProvider}
                 ttsModel={ttsModel}
                 onTtsProviderChange={onTtsProviderChange}

--- a/src/features/voice/audio-feedback.test.ts
+++ b/src/features/voice/audio-feedback.test.ts
@@ -3,6 +3,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 // Mock AudioContext and related Web Audio API
 const mockStart = vi.fn();
 const mockConnect = vi.fn();
+const mockGainConnect = vi.fn();
+const mockGain = { gain: { value: 1 }, connect: mockGainConnect };
+const mockDestination = {};
 
 const mockCreateBufferSource = vi.fn(() => ({
   buffer: null,
@@ -19,8 +22,9 @@ const mockResume = vi.fn(() => Promise.resolve());
 
 class MockAudioContext {
   state = 'running';
-  destination = {};
+  destination = mockDestination;
   createBufferSource = mockCreateBufferSource;
+  createGain = vi.fn(() => mockGain);
   decodeAudioData = mockDecodeAudioData;
   resume = mockResume;
 }
@@ -42,10 +46,14 @@ describe('audio-feedback', () => {
   let playSubmitPing: () => void;
   let playCancelPing: () => void;
   let playPing: () => void;
+  let setUiSoundVolume: (volume: number) => void;
+  let normalizeUiSoundVolume: (volume: number) => number;
 
   beforeEach(async () => {
     mockStart.mockClear();
     mockConnect.mockClear();
+    mockGainConnect.mockClear();
+    mockGain.gain.value = 1;
     mockCreateBufferSource.mockClear();
     mockDecodeAudioData.mockClear();
     mockResume.mockClear();
@@ -58,6 +66,8 @@ describe('audio-feedback', () => {
     playSubmitPing = mod.playSubmitPing;
     playCancelPing = mod.playCancelPing;
     playPing = mod.playPing;
+    setUiSoundVolume = mod.setUiSoundVolume;
+    normalizeUiSoundVolume = mod.normalizeUiSoundVolume;
 
     // Wait for preloads to complete
     await new Promise(r => setTimeout(r, 10));
@@ -96,6 +106,29 @@ describe('audio-feedback', () => {
       playWakePing();
       const source = mockCreateBufferSource.mock.results[0].value;
       expect(source.playbackRate.value).toBe(1);
+    });
+
+    it('routes UI audio through its independent volume control', () => {
+      setUiSoundVolume(0.25);
+      playWakePing();
+
+      expect(mockGain.gain.value).toBe(0.25);
+      expect(mockConnect).toHaveBeenCalledWith(mockGain);
+      expect(mockGainConnect).toHaveBeenCalledWith(mockDestination);
+    });
+
+    it('does not start an audio source when UI sounds are muted', () => {
+      setUiSoundVolume(0);
+      playWakePing();
+
+      expect(mockCreateBufferSource).not.toHaveBeenCalled();
+      expect(mockStart).not.toHaveBeenCalled();
+    });
+
+    it('clamps UI sound volume to the supported range', () => {
+      expect(normalizeUiSoundVolume(-1)).toBe(0);
+      expect(normalizeUiSoundVolume(2)).toBe(1);
+      expect(normalizeUiSoundVolume(Number.NaN)).toBe(1);
     });
   });
 

--- a/src/features/voice/audio-feedback.ts
+++ b/src/features/voice/audio-feedback.ts
@@ -2,8 +2,31 @@
 // Files are preloaded into AudioBuffers for instant, glitch-free playback.
 
 let audioCtx: AudioContext | null = null;
+let outputGain: GainNode | null = null;
+let uiSoundVolume = 1;
 const bufferCache = new Map<string, AudioBuffer>();
 const loadingCache = new Map<string, Promise<AudioBuffer | null>>();
+
+export function normalizeUiSoundVolume(volume: number): number {
+  if (!Number.isFinite(volume)) return 1;
+  return Math.min(1, Math.max(0, volume));
+}
+
+/** Set the volume used by UI sound effects without affecting TTS playback. */
+export function setUiSoundVolume(volume: number): void {
+  uiSoundVolume = normalizeUiSoundVolume(volume);
+  if (outputGain) outputGain.gain.value = uiSoundVolume;
+}
+
+function getOutputGain(): GainNode {
+  if (!audioCtx) audioCtx = new AudioContext();
+  if (!outputGain) {
+    outputGain = audioCtx.createGain();
+    outputGain.gain.value = uiSoundVolume;
+    outputGain.connect(audioCtx.destination);
+  }
+  return outputGain;
+}
 
 /** Preload an audio file into an AudioBuffer. */
 function preloadSound(path: string): Promise<AudioBuffer | null> {
@@ -36,6 +59,7 @@ if (typeof window !== 'undefined') {
 
 function playSound(path: string, playbackRate = 1): void {
   try {
+    if (uiSoundVolume === 0) return;
     if (!audioCtx) audioCtx = new AudioContext();
     if (audioCtx.state === 'suspended') audioCtx.resume();
 
@@ -49,7 +73,7 @@ function playSound(path: string, playbackRate = 1): void {
     const source = audioCtx.createBufferSource();
     source.buffer = buffer;
     source.playbackRate.value = playbackRate;
-    source.connect(audioCtx.destination);
+    source.connect(getOutputGain());
     source.start(0);
   } catch {
     // AudioContext not available, silently skip

--- a/src/hooks/useChatTTS.test.ts
+++ b/src/hooks/useChatTTS.test.ts
@@ -1,0 +1,54 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useChatTTS } from './useChatTTS';
+
+const { playPingMock } = vi.hoisted(() => ({
+  playPingMock: vi.fn(),
+}));
+
+vi.mock('@/features/voice/audio-feedback', () => ({
+  playPing: playPingMock,
+}));
+
+describe('useChatTTS', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the independent UI sound channel for a completed text response', () => {
+    const ttsEnabled = { current: true };
+    const speak = { current: vi.fn() };
+    const { result } = renderHook(() => useChatTTS({ ttsEnabled, speak }));
+
+    act(() => result.current.handleFinalTTS(null, true));
+
+    expect(playPingMock).toHaveBeenCalledOnce();
+    expect(speak.current).not.toHaveBeenCalled();
+  });
+
+  it('plays an explicitly requested completion ping through the UI sound channel', () => {
+    const ttsEnabled = { current: true };
+    const speak = { current: vi.fn() };
+    const { result } = renderHook(() => useChatTTS({ ttsEnabled, speak }));
+
+    act(() => result.current.playCompletionPing());
+
+    expect(playPingMock).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to a UI ping when a TTS response arrives with spoken replies disabled', () => {
+    const ttsEnabled = { current: false };
+    const speak = { current: vi.fn() };
+    const { result } = renderHook(() => useChatTTS({ ttsEnabled, speak }));
+
+    act(() => result.current.handleFinalTTS({
+      message: { role: 'assistant', content: 'Done' },
+      text: 'Done',
+      ttsText: 'Task complete',
+      charts: [],
+    }, true));
+
+    expect(speak.current).not.toHaveBeenCalled();
+    expect(playPingMock).toHaveBeenCalledOnce();
+  });
+});

--- a/src/hooks/useChatTTS.ts
+++ b/src/hooks/useChatTTS.ts
@@ -41,11 +41,11 @@ export function buildVoiceFallbackText(raw: string): string | null {
 // ─── Hook ───────────────────────────────────────────────────────────────────────
 
 interface UseChatTTSDeps {
-  soundEnabled: React.RefObject<boolean>;
+  ttsEnabled: React.RefObject<boolean>;
   speak: React.RefObject<(text: string) => void>;
 }
 
-export function useChatTTS({ soundEnabled, speak }: UseChatTTSDeps) {
+export function useChatTTS({ ttsEnabled, speak }: UseChatTTSDeps) {
   const lastMessageWasVoiceRef = useRef(false);
   const playedSoundsRef = useRef<Set<string>>(new Set());
 
@@ -69,20 +69,22 @@ export function useChatTTS({ soundEnabled, speak }: UseChatTTSDeps) {
 
     if (finalData?.ttsText && !playedSoundsRef.current.has(finalData.ttsText)) {
       playedSoundsRef.current.add(finalData.ttsText);
-      speak.current(finalData.ttsText);
+      if (ttsEnabled.current) speak.current(finalData.ttsText);
+      else playPing();
     } else if (!finalData?.ttsText && lastMessageWasVoiceRef.current && finalData?.text) {
       // Voice fallback: agent forgot [tts:...] marker — auto-speak cleaned response
       const fallback = buildVoiceFallbackText(finalData.text);
-      if (fallback) speak.current(fallback);
-    } else if (soundEnabled.current) {
+      if (fallback && ttsEnabled.current) speak.current(fallback);
+      else playPing();
+    } else {
       playPing();
     }
-  }, [soundEnabled, speak]);
+  }, [ttsEnabled, speak]);
 
-  /** Play the completion ping sound if sound is enabled. */
+  /** Play the completion ping through the independent UI sound channel. */
   const playCompletionPing = useCallback(() => {
-    if (soundEnabled.current) playPing();
-  }, [soundEnabled]);
+    playPing();
+  }, []);
 
   return useMemo(() => ({
     trackVoiceMessage,


### PR DESCRIPTION
## Summary

- add a persistent 0–100% volume slider dedicated to UI sound effects
- route wake, submit, cancel, and completion cues through one Web Audio GainNode
- keep TTS playback independent through its existing HTMLAudioElement path
- relabel the legacy sound toggle as Spoken replies and update the command palette wording
- preserve completion notifications when spoken replies are disabled

Fixes #204

## Implementation

- persist the normalized value under nerve:uiSoundVolume, defaulting invalid or missing values to full volume
- skip source creation entirely at volume zero
- remove TTS gating from SessionContext completion notifications
- make useChatTTS choose spoken output or a UI completion ping without coupling their volume controls
- add provider, hook, audio-routing, session, and settings component regression tests

## Testing

- 46 focused Vitest tests passed
- npm run lint
- npm run build
- git diff --check

A full Windows Vitest run reached 1,811 passing tests; the remaining 40 failures are existing platform/environment issues involving Node built-in module mocks, POSIX path expectations, and symlink privileges. The affected suites all pass.

## Notes

The existing oc-sound storage key and internal soundEnabled name are retained for compatibility, but the user-facing control now accurately describes its TTS behavior as Spoken replies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an independent UI sound volume control with a 0–100% slider.
  - Volume preferences are saved and restored automatically.
  - UI sound effects respect the selected volume, including mute.
  - Renamed “Sound effects” to “Spoken replies” for clearer audio controls.
  - Disabled spoken replies now provide an audible UI completion ping.

- **Bug Fixes**
  - UI sound volume remains separate from spoken reply settings.
  - Volume values are constrained to the supported range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->